### PR TITLE
fix(backdrop): restore selection highlight when backdrop is active

### DIFF
--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -177,11 +177,10 @@ body {
    (`.monaco-editor`, `.monaco-editor-background`, `.margin`,
    `.minimap`, `.view-overlays`, `.monaco-scrollable-element`,
    etc.). Enumerating them all is fragile — we blanket every
-   descendant bg to transparent when backdrop is active. Token /
-   selection / diagnostic highlights remain (they paint via
-   borders + text colours, not backgrounds, inside spans). */
+   descendant bg to transparent when backdrop is active, EXCEPT
+   selection / highlight decorations which paint via background-color. */
 [data-stave-code-panel][data-stave-backdrop="on"] .monaco-editor,
-[data-stave-code-panel][data-stave-backdrop="on"] .monaco-editor * {
+[data-stave-code-panel][data-stave-backdrop="on"] .monaco-editor *:not(.selected-text):not(.selectionHighlight):not(.current-line-margin):not(.current-line) {
   background-color: transparent !important;
 }
 

--- a/packages/app/tests/selection-backdrop.spec.ts
+++ b/packages/app/tests/selection-backdrop.spec.ts
@@ -1,0 +1,49 @@
+/**
+ * Verifies that Monaco text selection highlight is visible when a
+ * backdrop is active. Regression test for the blanket
+ * `background-color: transparent !important` rule that was killing
+ * `.selected-text` backgrounds.
+ */
+import { test, expect } from '@playwright/test'
+
+test('selection highlight visible with backdrop active', async ({ page }) => {
+  await page.goto('/')
+  await page.locator('[data-workspace-shell="root"]').waitFor({ timeout: 15000 })
+  await page.locator('.monaco-editor').waitFor({ timeout: 15000 })
+
+  // Pin a hydra file as backdrop.
+  const tabs = page.locator('[data-workspace-tab]')
+  const count = await tabs.count()
+  for (let i = 0; i < count; i++) {
+    const t = await tabs.nth(i).textContent()
+    if (t && /\.hydra/.test(t)) {
+      await tabs.nth(i).click()
+      break
+    }
+  }
+  await page.waitForTimeout(200)
+  await page.locator('[data-testid="viz-chrome-bg-toggle"]').first().click()
+  await page.locator('[data-workspace-background]').first().waitFor({ timeout: 5000 })
+
+  // Switch to strudel tab and select all text.
+  await page
+    .locator('[data-workspace-tab]', { hasText: 'pattern.strudel' })
+    .click()
+  await page.waitForTimeout(300)
+  await page.locator('.monaco-editor').first().click()
+  const mod = process.platform === 'darwin' ? 'Meta' : 'Control'
+  await page.keyboard.press(`${mod}+A`)
+  await page.waitForTimeout(300)
+
+  // .selected-text elements should exist with a non-transparent bg.
+  const selBg = await page.evaluate(() => {
+    const els = document.querySelectorAll('.monaco-editor .selected-text')
+    if (!els.length) return { count: 0, bg: 'none' }
+    const cs = getComputedStyle(els[0])
+    return { count: els.length, bg: cs.backgroundColor }
+  })
+  expect(selBg.count).toBeGreaterThan(0)
+  // Must NOT be transparent — that was the bug.
+  expect(selBg.bg).not.toBe('rgba(0, 0, 0, 0)')
+  expect(selBg.bg).not.toBe('transparent')
+})


### PR DESCRIPTION
## Summary

- Exempt `.selected-text`, `.selectionHighlight`, `.current-line`, `.current-line-margin` from the blanket `background-color: transparent !important` rule via `:not()` selectors
- Add regression E2E test that pins a backdrop, selects text, and asserts the selection background is non-transparent

## Root cause

The blanket `.monaco-editor *` transparent rule was intended to strip opaque structural backgrounds so the backdrop viz shows through. But Monaco renders selection highlights via `background-color` on `.selected-text` divs — not via borders as the old comment claimed. The `:not()` exemptions preserve the backdrop transparency while restoring selection visibility.

## Test plan

- [x] New `selection-backdrop.spec.ts` — pins backdrop, Cmd+A, asserts `.selected-text` bg is non-transparent
- [x] 19 existing backdrop E2E tests still green
- [x] Manual verify: blue selection highlight visible in both normal and Cinema Mode

Closes #45