### PR TITLE
feat(ir): Inspector Strudel-vocabulary projection + IR-mode toggle

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@stave/editor": "workspace:*",
@@ -24,7 +25,9 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.1",
+    "jsdom": "^24.0.0",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^1.6.0"
   }
 }

--- a/packages/app/src/__tests__/smoke.test.ts
+++ b/packages/app/src/__tests__/smoke.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from 'vitest'
+
+describe('app vitest smoke', () => {
+  it('runs', () => {
+    expect(1 + 1).toBe(2)
+  })
+})

--- a/packages/app/src/components/IRInspectorPanel.tsx
+++ b/packages/app/src/components/IRInspectorPanel.tsx
@@ -20,6 +20,7 @@ import {
   subscribeIRSnapshot,
   revealLineInFile,
 } from "@stave/editor";
+import { LOCALSTORAGE_KEY } from "./irProjection";
 
 // ----- Color tokens by IR tag — keep close to the design system -----------
 
@@ -286,6 +287,28 @@ export function IRInspectorPanel(): React.ReactElement {
   const [selectedTabName, setSelectedTabName] = useState<string | null>(null);
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
+  // 19-06 (#76) — IR-mode toggle. Default false (projected mode); true
+  // shows the raw IR shape for IR developers / power users. Persisted
+  // via localStorage (RESEARCH §5.2 colon-prefix convention).
+  const [irMode, setIrMode] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return window.localStorage.getItem(LOCALSTORAGE_KEY) === "true";
+    } catch {
+      // Private browsing / disabled storage — default to projected.
+      return false;
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(LOCALSTORAGE_KEY, String(irMode));
+    } catch {
+      // Storage quota / private browsing — skip silently.
+    }
+  }, [irMode]);
+
   useEffect(() => {
     return subscribeIRSnapshot((s) => setSnap(s));
   }, []);
@@ -342,8 +365,38 @@ export function IRInspectorPanel(): React.ReactElement {
         }}
       >
         <div style={{ fontWeight: 600 }}>IR INSPECTOR</div>
-        <div style={{ fontSize: "0.8em", opacity: 0.6 }}>
-          {snap.runtime} · {snap.events.length} events · {ageLabel}
+        <div style={{ display: "flex", alignItems: "baseline", gap: 12 }}>
+          <div style={{ fontSize: "0.8em", opacity: 0.6 }}>
+            {snap.runtime} · {snap.events.length} events · {ageLabel}
+          </div>
+          <button
+            type="button"
+            onClick={() => setIrMode((v) => !v)}
+            title={
+              irMode
+                ? "Show projected user-method view"
+                : "Show raw IR shape (developer view)"
+            }
+            aria-label={irMode ? "Show projected view" : "Show raw IR view"}
+            aria-pressed={irMode}
+            data-testid="ir-mode-toggle"
+            style={{
+              padding: "2px 8px",
+              fontSize: "0.75em",
+              fontWeight: 600,
+              letterSpacing: "0.04em",
+              color: irMode ? "#86efac" : "var(--text-tertiary, #888)",
+              background: irMode ? "rgba(134,239,172,0.08)" : "transparent",
+              border: `1px solid ${
+                irMode ? "#86efac" : "var(--border-subtle, rgba(128,128,128,0.3))"
+              }`,
+              borderRadius: 3,
+              cursor: "pointer",
+              flexShrink: 0,
+            }}
+          >
+            {irMode ? "raw IR" : "IR"}
+          </button>
         </div>
       </div>
 

--- a/packages/app/src/components/IRInspectorPanel.tsx
+++ b/packages/app/src/components/IRInspectorPanel.tsx
@@ -20,7 +20,11 @@ import {
   subscribeIRSnapshot,
   revealLineInFile,
 } from "@stave/editor";
-import { LOCALSTORAGE_KEY } from "./irProjection";
+import {
+  LOCALSTORAGE_KEY,
+  projectedLabel,
+  projectedChildren,
+} from "./irProjection";
 
 // ----- Color tokens by IR tag — keep close to the design system -----------
 
@@ -129,8 +133,63 @@ function round(n: number): string {
 
 // ----- Components ---------------------------------------------------------
 
-function IRNodeRow({ node, depth }: { node: PatternIR; depth: number }): React.ReactElement {
-  const kids = children(node);
+/**
+ * D-02 hide rule, splicing form. Given a list of children for a parent
+ * in projected mode, replace any hidden child (projectedLabel ===
+ * undefined) with that child's projected children. Recursive — keeps
+ * splicing until the list contains only renderable rows. Mini-notation
+ * symbol tags and Code are NOT hidden (their projectedLabel returns a
+ * value).
+ */
+function spliceHiddenChildren(
+  kids: readonly PatternIR[],
+): readonly PatternIR[] {
+  const out: PatternIR[] = [];
+  for (const k of kids) {
+    if (projectedLabel(k) === undefined) {
+      // Recurse on its projected children (transitive hide).
+      out.push(...spliceHiddenChildren(projectedChildren(k)));
+    } else {
+      out.push(k);
+    }
+  }
+  return out;
+}
+
+function IRNodeRow({
+  node,
+  depth,
+  irMode,
+}: {
+  node: PatternIR;
+  depth: number;
+  irMode: boolean;
+}): React.ReactElement | null {
+  let label: string;
+  let kids: readonly PatternIR[];
+
+  if (irMode) {
+    label = node.tag;
+    kids = children(node);
+  } else {
+    const projLabel = projectedLabel(node);
+    if (projLabel === undefined) {
+      // D-02 hide rule: this node would normally be folded into the parent.
+      // The parent's spliceHiddenChildren removes it upstream; if a hidden
+      // node DOES reach here (e.g., the root has projectedLabel undefined —
+      // possible if a future parser path forgets to set userMethod on a
+      // root tag), fall back to the raw tag for visibility.
+      label = node.tag;
+      kids = spliceHiddenChildren(projectedChildren(node));
+    } else {
+      label = projLabel;
+      kids = spliceHiddenChildren(projectedChildren(node));
+    }
+  }
+
+  // TAG_COLOR keying remains node.tag — color follows structural identity
+  // (a Stack-from-layer is still Stack-purple even when labeled "layer").
+  // Label follows projection. RESEARCH Q9 / NEW pre-mortem #9.
   const tagColor = TAG_COLOR[node.tag];
   const summary = summarize(node);
 
@@ -154,7 +213,7 @@ function IRNodeRow({ node, depth }: { node: PatternIR; depth: number }): React.R
             minWidth: 60,
           }}
         >
-          {node.tag}
+          {label}
         </span>
         <span style={{ opacity: 0.75, fontFamily: "var(--font-mono, monospace)", fontSize: "0.85em" }}>
           {summary}
@@ -167,7 +226,7 @@ function IRNodeRow({ node, depth }: { node: PatternIR; depth: number }): React.R
     <details open={depth < 2} style={{ paddingLeft: depth * 12 }}>
       <summary style={{ cursor: "pointer", padding: "2px 0", listStyle: "none" }}>
         <span style={{ color: tagColor, fontWeight: 600, fontSize: "0.85em" }}>
-          {node.tag}
+          {label}
         </span>
         {summary && (
           <span style={{ opacity: 0.75, fontFamily: "var(--font-mono, monospace)", fontSize: "0.85em", marginLeft: 6 }}>
@@ -176,7 +235,7 @@ function IRNodeRow({ node, depth }: { node: PatternIR; depth: number }): React.R
         )}
       </summary>
       {kids.map((c, i) => (
-        <IRNodeRow key={i} node={c} depth={depth + 1} />
+        <IRNodeRow key={i} node={c} depth={depth + 1} irMode={irMode} />
       ))}
     </details>
   );
@@ -452,7 +511,13 @@ export function IRInspectorPanel(): React.ReactElement {
             IR tree{snap.passes.length > 1 && selectedIndex >= 0 ? ` · ${snap.passes[selectedIndex].name}` : null}
           </summary>
           <div style={{ paddingLeft: 4 }}>
-            {selectedIndex >= 0 && <IRNodeRow node={snap.passes[selectedIndex].ir} depth={0} />}
+            {selectedIndex >= 0 && (
+              <IRNodeRow
+                node={snap.passes[selectedIndex].ir}
+                depth={0}
+                irMode={irMode}
+              />
+            )}
           </div>
         </details>
       </div>

--- a/packages/app/src/components/__tests__/irProjection.test.ts
+++ b/packages/app/src/components/__tests__/irProjection.test.ts
@@ -1,0 +1,472 @@
+/**
+ * Unit tests for the IR Inspector projection rules.
+ *
+ * Phase 19-06 (#76) — covers all 30 rows of RESEARCH §2 truth-table
+ * plus the .off() 4-arrow-shape coverage (RESEARCH §2.x), Code
+ * whitelist (NEW pre-mortem #8), Pure-as-Choice.else_ filter (NEW
+ * pre-mortem #10), and direct stripInnerLate edge cases.
+ *
+ * Imports parseStrudel from the editor source path directly to avoid
+ * the @stave/editor barrel pulling in the p5/gifenc transitive
+ * dependencies (vitest's ESM loader can't resolve gifenc).
+ */
+import { describe, it, expect } from 'vitest'
+import { parseStrudel } from '../../../../editor/src/ir/parseStrudel'
+import { IR, type PatternIR } from '../../../../editor/src/ir/PatternIR'
+import {
+  projectedLabel,
+  projectedChildren,
+  stripInnerLate,
+  LOCALSTORAGE_KEY,
+} from '../irProjection'
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+function parseRoot(code: string): PatternIR {
+  return parseStrudel(code)
+}
+
+/**
+ * Walk the IR tree (raw children, NOT projected) and return the first
+ * node matching the predicate, or null.
+ */
+function find(
+  node: PatternIR,
+  pred: (n: PatternIR) => boolean,
+): PatternIR | null {
+  if (pred(node)) return node
+  const kids = rawChildren(node)
+  for (const k of kids) {
+    const hit = find(k, pred)
+    if (hit) return hit
+  }
+  return null
+}
+
+function rawChildren(node: PatternIR): readonly PatternIR[] {
+  switch (node.tag) {
+    case 'Seq':   return node.children
+    case 'Stack': return node.tracks
+    case 'Cycle': return node.items
+    case 'Choice': return [node.then, node.else_]
+    case 'Every': return node.default_ ? [node.body, node.default_] : [node.body]
+    case 'When':  return [node.body]
+    case 'FX':
+    case 'Ramp':
+    case 'Fast':
+    case 'Slow':
+    case 'Elongate':
+    case 'Late':
+    case 'Degrade':
+    case 'Ply':
+    case 'Struct':
+    case 'Swing':
+    case 'Shuffle':
+    case 'Scramble':
+    case 'Chop':
+    case 'Loop':
+      return [node.body]
+    case 'Chunk': return [node.body, node.transform]
+    case 'Pick':  return [node.selector, ...node.lookup]
+    default:      return []
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Module-scope constant
+// -----------------------------------------------------------------------------
+
+describe('LOCALSTORAGE_KEY', () => {
+  it('uses the colon-prefix convention (RESEARCH §5.2)', () => {
+    expect(LOCALSTORAGE_KEY).toBe('stave:inspector.irMode')
+  })
+})
+
+// -----------------------------------------------------------------------------
+// projectedLabel
+// -----------------------------------------------------------------------------
+
+describe('projectedLabel — user-callable tags use userMethod (PV31 first consumer)', () => {
+  it('Stack from .layer() projects to "layer"', () => {
+    const ir = parseRoot('note("c d e f").layer(x => x.add("0,2"))')
+    expect(projectedLabel(ir)).toBe('layer')
+  })
+
+  it('Stack from .jux() projects to "jux"', () => {
+    const ir = parseRoot('s("bd hh sd cp").jux(x => x.gain(0.5))')
+    expect(projectedLabel(ir)).toBe('jux')
+  })
+
+  it('Stack from .off() projects to "off"', () => {
+    const ir = parseRoot('s("bd hh sd cp").off(0.125, x => x.gain(0.5))')
+    expect(projectedLabel(ir)).toBe('off')
+  })
+
+  it('Stack from stack() literal projects to "stack" (PV31 distinguishes from layer/jux/off)', () => {
+    const ir = parseRoot('stack(s("bd"), s("hh"))')
+    expect(projectedLabel(ir)).toBe('stack')
+  })
+
+  it('Late projects to "late"', () => {
+    const ir = parseRoot('s("bd").late(0.125)')
+    expect(projectedLabel(ir)).toBe('late')
+  })
+
+  it('Degrade from .degrade() projects to "degrade"', () => {
+    const ir = parseRoot('s("bd hh sd cp ride lt mt ht").degrade()')
+    expect(projectedLabel(ir)).toBe('degrade')
+  })
+
+  it('Degrade from .degradeBy() projects to "degradeBy" (PV31 distinguishes)', () => {
+    const ir = parseRoot('s("bd hh sd cp ride lt mt ht").degradeBy(0.3)')
+    expect(projectedLabel(ir)).toBe('degradeBy')
+  })
+
+  it.each([
+    ['s("bd hh sd cp").chunk(4, x => x.gain(0.5))', 'chunk'],
+    ['s("bd").ply(3)', 'ply'],
+    ['mini("<0 1 2 3>").pick(["c","e","g","b"]).note()', 'pick'],
+    ['note("c d e f").struct("x ~ x ~ x")', 'struct'],
+    ['note("c d e f g h").swing(2)', 'swing'],
+    ['note("c d e f").shuffle(4)', 'shuffle'],
+    ['note("c d e f").scramble(4)', 'scramble'],
+    ['s("bd").chop(4)', 'chop'],
+    ['s("bd").fast(2)', 'fast'],
+    ['s("bd").slow(2)', 'slow'],
+    ['s("bd").every(2, x => x.fast(2))', 'every'],
+    ['s("bd").gain(0.5)', 'gain'],
+  ])('parses %s and projects label %s', (code, expected) => {
+    const ir = parseRoot(code)
+    expect(projectedLabel(ir)).toBe(expected)
+  })
+
+  it('Choice from .sometimes() projects to "sometimes" (Choice with userMethod)', () => {
+    const ir = parseRoot('s("bd").sometimes(x => x.gain(0.5))')
+    // sometimes desugars to Choice; userMethod set to 'sometimes'.
+    expect(projectedLabel(ir)).toBe('sometimes')
+  })
+})
+
+describe('projectedLabel — mini-notation symbols (D-03)', () => {
+  it('Sleep from `~` projects to "~"', () => {
+    const ir = parseRoot('s("bd ~ sd")')
+    const sleep = find(ir, (n) => n.tag === 'Sleep')
+    expect(sleep).not.toBeNull()
+    expect(projectedLabel(sleep!)).toBe('~')
+  })
+
+  it('Cycle from `<>` projects to "<>"', () => {
+    const ir = parseRoot('s("<bd hh sd>")')
+    const cycle = find(ir, (n) => n.tag === 'Cycle')
+    expect(cycle).not.toBeNull()
+    expect(projectedLabel(cycle!)).toBe('<>')
+  })
+
+  it('Choice from `?` projects to "?"', () => {
+    const ir = parseRoot('s("bd?")')
+    const choice = find(ir, (n) => n.tag === 'Choice')
+    expect(choice).not.toBeNull()
+    expect(projectedLabel(choice!)).toBe('?')
+  })
+
+  it('Fast from `*4` projects to "*4" (symbol-with-value)', () => {
+    const ir = parseRoot('s("bd*4")')
+    const fast = find(
+      ir,
+      (n) => n.tag === 'Fast' && n.userMethod === undefined,
+    )
+    expect(fast).not.toBeNull()
+    expect(projectedLabel(fast!)).toBe('*4')
+  })
+
+  it('Fast from `*2` projects to "*2" (distinguished from *4)', () => {
+    const ir = parseRoot('s("bd*2")')
+    const fast = find(
+      ir,
+      (n) => n.tag === 'Fast' && n.userMethod === undefined,
+    )
+    expect(fast).not.toBeNull()
+    expect(projectedLabel(fast!)).toBe('*2')
+  })
+
+  it('Elongate from `@2` projects to "@2"', () => {
+    const ir = parseRoot('s("bd@2 sd")')
+    const elong = find(ir, (n) => n.tag === 'Elongate')
+    expect(elong).not.toBeNull()
+    expect(projectedLabel(elong!)).toBe('@2')
+  })
+
+  it('Stack from polymetric `{a, b}` projects to "{}"', () => {
+    const ir = parseRoot('s("{bd, sd hh}")')
+    const stack = find(
+      ir,
+      (n) => n.tag === 'Stack' && n.userMethod === undefined,
+    )
+    expect(stack).not.toBeNull()
+    expect(projectedLabel(stack!)).toBe('{}')
+  })
+
+  it('Seq from inner `[bd sd]` projects to "[]"', () => {
+    const ir = parseRoot('s("[bd sd] hh")')
+    const seq = find(
+      ir,
+      (n) => n.tag === 'Seq' && n.userMethod === undefined,
+    )
+    expect(seq).not.toBeNull()
+    expect(projectedLabel(seq!)).toBe('[]')
+  })
+})
+
+describe('projectedLabel — Code whitelist (RESEARCH NEW pre-mortem #8)', () => {
+  it('Code from parser fall-through projects to "Code" (NOT undefined-hidden)', () => {
+    // unknownFn(...) is unparseable as a root; parseStrudel returns IR.code(...)
+    const ir = parseRoot('unknownFn("foo")')
+    expect(ir.tag).toBe('Code')
+    expect(projectedLabel(ir)).toBe('Code')
+  })
+
+  it('directly-constructed Code with no userMethod projects to "Code"', () => {
+    const code: PatternIR = IR.code('foo bar')
+    expect(projectedLabel(code)).toBe('Code')
+  })
+})
+
+describe('projectedLabel — synthetic intermediates hidden (D-02)', () => {
+  it('Late inside .off() (userMethod undefined) returns undefined', () => {
+    const ir = parseRoot('s("bd").off(0.125, x => x.gain(0.5))')
+    const late = find(
+      ir,
+      (n) => n.tag === 'Late' && n.userMethod === undefined,
+    )
+    expect(late).not.toBeNull()
+    expect(projectedLabel(late!)).toBeUndefined()
+  })
+
+  it('FX(pan,-1) inside .jux() (userMethod undefined) returns undefined', () => {
+    const ir = parseRoot('s("bd").jux(x => x.gain(0.5))')
+    const fx = find(
+      ir,
+      (n) => n.tag === 'FX' && n.userMethod === undefined,
+    )
+    expect(fx).not.toBeNull()
+    expect(projectedLabel(fx!)).toBeUndefined()
+  })
+
+  it('Pure node (synthetic, userMethod undefined) returns undefined', () => {
+    const pure: PatternIR = IR.pure()
+    expect(projectedLabel(pure)).toBeUndefined()
+  })
+})
+
+describe('projectedLabel — Play leaf', () => {
+  it('Play (no userMethod field) projects to "Play"', () => {
+    const ir = parseRoot('s("bd")')
+    // s("bd") with a single token returns a Play directly (or wrapped in Seq).
+    const play = find(ir, (n) => n.tag === 'Play')
+    expect(play).not.toBeNull()
+    expect(projectedLabel(play!)).toBe('Play')
+  })
+})
+
+// -----------------------------------------------------------------------------
+// projectedChildren
+// -----------------------------------------------------------------------------
+
+describe('projectedChildren — layer (tracks verbatim, drop the Stack)', () => {
+  it('returns the f(body) and g(body) sub-IRs, no scaffolding', () => {
+    const ir = parseRoot('note("c d e f").layer(x => x.add("0,2"))')
+    const kids = projectedChildren(ir)
+    expect(kids.length).toBeGreaterThanOrEqual(1)
+    // Each kid should NOT itself be a Stack (the wrapping was the IR-mode shape).
+    for (const k of kids) {
+      expect(k.tag).not.toBe('Stack')
+    }
+  })
+})
+
+describe('projectedChildren — jux (strip the FX(pan,±1) wrappers)', () => {
+  it('returns [body, transformed] with no synthetic FX(pan) wrapping', () => {
+    const ir = parseRoot('s("bd").jux(x => x.gain(0.5))')
+    const kids = projectedChildren(ir)
+    expect(kids.length).toBe(2)
+    const t0 = kids[0]
+    const t1 = kids[1]
+    // Neither side should be a synthetic FX(pan) at the top.
+    expect(!(t0.tag === 'FX' && t0.userMethod === undefined)).toBe(true)
+    expect(!(t1.tag === 'FX' && t1.userMethod === undefined)).toBe(true)
+  })
+})
+
+describe('projectedChildren — off (strip the inner Late, RESEARCH §2.x option a)', () => {
+  function hasSyntheticLate(n: PatternIR): boolean {
+    if (n.tag === 'Late' && n.userMethod === undefined) return true
+    const kids = rawChildren(n)
+    for (const k of kids) {
+      if (hasSyntheticLate(k)) return true
+    }
+    return false
+  }
+
+  it.each([
+    ['x => x.gain(0.5)'],
+    ['x => x.fast(2)'],
+    ['x => x.late(0.125)'],
+    ['x => x.gain(0.5).fast(2)'],
+  ])('strips synthetic Late from transform body for %s', (transformExpr) => {
+    const code = `s("bd").off(0.125, ${transformExpr})`
+    const ir = parseRoot(code)
+    const kids = projectedChildren(ir)
+    expect(kids.length).toBe(2)
+    const transformed = kids[1]
+    expect(hasSyntheticLate(transformed)).toBe(false)
+  })
+
+  it('preserves user-typed .late() (userMethod set) inside transform', () => {
+    // x => x.late(...) — the user-typed Late should NOT be stripped (only
+    // the synthetic one with userMethod undefined gets stripped).
+    const ir = parseRoot('s("bd").off(0.125, x => x.late(0.0625))')
+    const kids = projectedChildren(ir)
+    expect(kids.length).toBe(2)
+    const transformed = kids[1]
+    // The user-typed Late should still be visible (its userMethod is 'late').
+    function hasUserLate(n: PatternIR): boolean {
+      if (n.tag === 'Late' && n.userMethod === 'late') return true
+      const ks = rawChildren(n)
+      for (const k of ks) if (hasUserLate(k)) return true
+      return false
+    }
+    expect(hasUserLate(transformed)).toBe(true)
+  })
+})
+
+describe('projectedChildren — Choice (drop Pure else_ from mini `?`)', () => {
+  it('mini `bd?` Choice has 1 projected child, not 2 (RESEARCH NEW pre-mortem #10)', () => {
+    const ir = parseRoot('s("bd?")')
+    const choice = find(ir, (n) => n.tag === 'Choice')
+    expect(choice).not.toBeNull()
+    const kids = projectedChildren(choice!)
+    expect(kids.length).toBe(1)
+  })
+
+  it('user-typed Choice with non-Pure else_ keeps both children', () => {
+    // Construct directly — the parser doesn't expose a chained .choice path;
+    // use the smart constructor to model a hypothetical user-typed Choice.
+    const choice: PatternIR = IR.choice(
+      0.3,
+      IR.play('bd'),
+      IR.play('hh'),
+      { userMethod: 'choice' },
+    )
+    const kids = projectedChildren(choice)
+    expect(kids.length).toBe(2)
+  })
+})
+
+describe('projectedChildren — stack(...) literal (tracks verbatim, no projection)', () => {
+  it('parses stack(a, b) and projects children as the two raw track sub-IRs', () => {
+    const ir = parseRoot('stack(s("bd"), s("hh"))')
+    const kids = projectedChildren(ir)
+    expect(kids.length).toBe(2)
+  })
+})
+
+describe('projectedChildren — deep-nested-hide composition (CONSIDER C7)', () => {
+  it('does not crash on nested .jux() inside .off()', () => {
+    const ir = parseRoot('s("bd").off(0.125, x => x.jux(y => y.gain(0.5)))')
+    // Just verify the rules don't throw and produce a sensible child list.
+    expect(() => projectedChildren(ir)).not.toThrow()
+    const kids = projectedChildren(ir)
+    expect(kids.length).toBe(2)
+  })
+})
+
+// -----------------------------------------------------------------------------
+// stripInnerLate (private — exported for tests)
+// -----------------------------------------------------------------------------
+
+describe('stripInnerLate', () => {
+  it('returns body when given synthetic Late directly', () => {
+    const body = parseRoot('s("bd")')
+    const synthLate: PatternIR = {
+      tag: 'Late',
+      offset: 0.125,
+      body,
+      // userMethod intentionally omitted (synthetic).
+    }
+    expect(stripInnerLate(synthLate)).toBe(body)
+  })
+
+  it('preserves user-typed Late (userMethod="late") at the top level', () => {
+    const ir = parseRoot('s("bd").late(0.125)')
+    expect(ir.tag).toBe('Late')
+    const stripped = stripInnerLate(ir)
+    // The user-typed Late stays as a Late (not stripped) and userMethod
+    // is preserved. The body may be a new object (the recursion descends
+    // into body looking for synthetic Late), but the wrapper survives.
+    expect(stripped.tag).toBe('Late')
+    expect((stripped as { userMethod?: string }).userMethod).toBe('late')
+  })
+
+  it('descends single-body wrappers (FX > synthetic Late case)', () => {
+    const inner = parseRoot('s("bd")')
+    const synthLate: PatternIR = {
+      tag: 'Late',
+      offset: 0.125,
+      body: inner,
+    }
+    const fx: PatternIR = {
+      tag: 'FX',
+      name: 'gain',
+      params: { gain: 0.5 },
+      body: synthLate,
+      userMethod: 'gain',
+    }
+    const stripped = stripInnerLate(fx)
+    expect(stripped.tag).toBe('FX')
+    expect((stripped as { body: PatternIR }).body).toBe(inner)
+  })
+
+  it('descends two single-body wrappers (Fast > FX > synthetic Late case)', () => {
+    const inner = parseRoot('s("bd")')
+    const synthLate: PatternIR = {
+      tag: 'Late',
+      offset: 0.125,
+      body: inner,
+    }
+    const fx: PatternIR = {
+      tag: 'FX',
+      name: 'gain',
+      params: { gain: 0.5 },
+      body: synthLate,
+      userMethod: 'gain',
+    }
+    const fast: PatternIR = {
+      tag: 'Fast',
+      factor: 2,
+      body: fx,
+      userMethod: 'fast',
+    }
+    const stripped = stripInnerLate(fast)
+    expect(stripped.tag).toBe('Fast')
+    const fastBody = (stripped as { body: PatternIR }).body
+    expect(fastBody.tag).toBe('FX')
+    expect((fastBody as { body: PatternIR }).body).toBe(inner)
+  })
+
+  it('stops at multi-child / leaf nodes (Stack — no recursion)', () => {
+    const ir = parseRoot('stack(s("bd"), s("hh"))')
+    expect(stripInnerLate(ir)).toBe(ir)
+  })
+
+  it('stops at Pure leaf', () => {
+    const pure: PatternIR = IR.pure()
+    expect(stripInnerLate(pure)).toBe(pure)
+  })
+
+  it('stops at Code leaf', () => {
+    const code: PatternIR = IR.code('foo')
+    expect(stripInnerLate(code)).toBe(code)
+  })
+})

--- a/packages/app/src/components/irProjection.ts
+++ b/packages/app/src/components/irProjection.ts
@@ -1,0 +1,252 @@
+/**
+ * IR Inspector — Strudel-vocabulary projection rules.
+ *
+ * Renders the IR tree using user-typed vocabulary by default
+ * (e.g. `.layer(...)` → "layer", not "Stack"). Phase 19-06 (#76).
+ *
+ * Per CONTEXT D-01..D-03 (locked). Truth-table at RESEARCH §2.
+ * Module-private to packages/app per RESEARCH Q10 — no editor barrel
+ * exposure.
+ *
+ * Two pure functions, both exhaustive over PatternIR['tag']:
+ * - projectedLabel(node): string | undefined
+ *   undefined → row hidden (D-02 fold rule); parent's children list
+ *   splices in this node's children.
+ * - projectedChildren(node): readonly PatternIR[]
+ *   Per-tag projected child list; may differ from raw children() for
+ *   desugars (layer/jux/off).
+ *
+ * The .off() projection uses option (a) from CONTEXT pre-mortem #1 —
+ * existing-IR relabel via stripInnerLate(node) recursion. RESEARCH §2.x.
+ *
+ * Special carve-outs:
+ * - Code is whitelisted out of the D-02 hide rule (RESEARCH NEW
+ *   pre-mortem #8) — hiding parser-failure-escape-hatch tags swallows
+ *   debugging signal.
+ * - Pure as Choice.else_ on mini `?` is filtered (RESEARCH NEW
+ *   pre-mortem #10) — drops the empty () leaf.
+ */
+import type { PatternIR } from '@stave/editor'
+
+/**
+ * localStorage key for the IR-mode toggle. Colon-prefix convention —
+ * matches existing keys `stave:editorTheme`, `stave:sidebar-width`,
+ * `stave:autosnapIdleMs` (RESEARCH §5.1-5.2). Exported so the panel
+ * and tests can reference one source of truth.
+ */
+export const LOCALSTORAGE_KEY = 'stave:inspector.irMode'
+
+// D-03 mini-notation symbol mapping (RESEARCH §2.y — symbol-with-value
+// for parametric tags Fast/Elongate; symbol-only for arity-zero).
+function miniSymbol(node: PatternIR): string {
+  switch (node.tag) {
+    case 'Sleep':    return '~'
+    case 'Cycle':    return '<>'
+    case 'Choice':   return '?'   // p always 0.5 from mini ?
+    case 'Elongate': return `@${node.factor}`
+    case 'Fast':     return `*${node.factor}` // mini *N path
+    case 'Stack':    return '{}'
+    case 'Seq':      return '[]'
+    default:         return node.tag // unreachable; for narrowing
+  }
+}
+
+export function projectedLabel(node: PatternIR): string | undefined {
+  // Tags whose userMethod is set (user-callable) project to that name —
+  // covers fast, slow, every, sometimes, sometimesBy, mask/when, gain,
+  // pan, room, delay, ..., late, degrade, degradeBy, chunk, ply, pick,
+  // struct, swing, shuffle, scramble, chop, layer, jux, off, stack.
+  if ('userMethod' in node && node.userMethod !== undefined) {
+    return node.userMethod
+  }
+
+  // userMethod === undefined or absent. D-02 hide rule + carve-outs.
+  switch (node.tag) {
+    // Mini-notation symbol tags (D-03)
+    case 'Sleep':
+    case 'Cycle':
+    case 'Choice':
+    case 'Elongate':
+      return miniSymbol(node)
+    // Fast and Stack are dual-origin: from method or from mini.
+    // userMethod === undefined here → from mini (parseMini doesn't set it).
+    case 'Fast':
+      return miniSymbol(node)
+    case 'Stack':
+      return miniSymbol(node) // mini polymetric `{...}`
+    case 'Seq':
+      return miniSymbol(node) // mini `[...]` / euclid
+    // Code: parser-failure escape hatch — render even when userMethod
+    // undefined. RESEARCH NEW pre-mortem #8 — hiding swallows debugging
+    // signal.
+    case 'Code':
+      return 'Code'
+    // Play: leaf, no userMethod field per PatternIR.ts:38.
+    case 'Play':
+      return 'Play'
+    // Pure: D-02 hide. Caller filters Pure-as-Choice.else_ explicitly
+    // via projectedChildren (RESEARCH NEW pre-mortem #10).
+    case 'Pure':
+      return undefined
+    // Synthetic intermediates that should fold into parent (D-02):
+    // - Late from .off() (parseStrudel.ts:585-588)
+    // - FX(pan,±1) from .jux() (parseStrudel.ts:514-515)
+    // - Ramp (no parser path; defensive)
+    // - Loop (no parser path; defensive)
+    case 'Late':
+    case 'FX':
+    case 'Ramp':
+    case 'Loop':
+      return undefined
+    // Tags that always have userMethod when constructed by the parser
+    // — fall here only if a future parser path forgets to set it.
+    // Fall through to raw tag name as a fail-safe (visible bug, not
+    // silent loss).
+    case 'Slow':
+    case 'When':
+    case 'Every':
+    case 'Degrade':
+    case 'Chunk':
+    case 'Ply':
+    case 'Pick':
+    case 'Struct':
+    case 'Swing':
+    case 'Shuffle':
+    case 'Scramble':
+    case 'Chop':
+      return node.tag
+    default: {
+      // Exhaustiveness check — TS error if a tag is missing.
+      const _exhaustive: never = node
+      return _exhaustive
+    }
+  }
+}
+
+export function projectedChildren(node: PatternIR): readonly PatternIR[] {
+  switch (node.tag) {
+    case 'Stack': {
+      // Per-userMethod dispatch (D-01 children projection rules).
+      const m = node.userMethod
+      if (m === 'layer') {
+        // Raw IR: Stack(f(body), g(body)) — already correct shape.
+        return node.tracks
+      }
+      if (m === 'jux') {
+        // Raw IR: Stack(FX(pan=-1, body), FX(pan=+1, transformed))
+        // Strip the FX(pan, ±1) wrappers; surface [body, transformed].
+        return node.tracks.map((t) => {
+          if (t.tag === 'FX' && t.userMethod === undefined) {
+            return t.body
+          }
+          return t
+        })
+      }
+      if (m === 'off') {
+        // Raw IR: Stack(body, transformed) where transformed contains
+        // a synthetic Late at some descendant body position. Strip the
+        // Late; return [body, transformed-without-Late]. RESEARCH §2.x
+        // option (a).
+        const [body, transformed] = node.tracks
+        if (body === undefined || transformed === undefined) {
+          return node.tracks
+        }
+        return [body, stripInnerLate(transformed)]
+      }
+      // 'stack' (user-typed) and undefined (mini polymetric): tracks verbatim
+      return node.tracks
+    }
+    case 'Seq':   return node.children
+    case 'Cycle': return node.items
+    case 'Choice': {
+      // Filter Pure else_ (RESEARCH NEW pre-mortem #10). Mini `?`
+      // constructs Choice(0.5, then, IR.pure()).
+      if (node.else_.tag === 'Pure' && node.else_.userMethod === undefined) {
+        return [node.then]
+      }
+      return [node.then, node.else_]
+    }
+    case 'Every':
+      return node.default_ ? [node.body, node.default_] : [node.body]
+    case 'When':
+      return [node.body]
+    case 'FX':
+    case 'Ramp':
+    case 'Fast':
+    case 'Slow':
+    case 'Elongate':
+    case 'Late':
+    case 'Degrade':
+    case 'Ply':
+    case 'Struct':
+    case 'Swing':
+    case 'Shuffle':
+    case 'Scramble':
+    case 'Chop':
+    case 'Loop':
+      return [node.body]
+    case 'Chunk':
+      return [node.body, node.transform]
+    case 'Pick':
+      return [node.selector, ...node.lookup]
+    case 'Pure':
+    case 'Play':
+    case 'Sleep':
+    case 'Code':
+      return []
+    default: {
+      const _exhaustive: never = node
+      return _exhaustive
+    }
+  }
+}
+
+/**
+ * Recursively strip the synthetic Late inserted by .off()'s desugar.
+ *
+ * Background: .off(t, f) is parsed as Stack(body, f(Late(t, body))).
+ * The Late lives at some `body` position inside the transformed sub-IR
+ * (parseStrudel.ts:585-588 places it at the leaf-most body of
+ * parseTransform's result; chain `.gain(0.5).fast(2)` wraps it in
+ * Fast{body: FX{body: lateBody}}).
+ *
+ * Strategy: traverse single-body chains; replace the synthetic Late
+ * (tag === 'Late' && userMethod === undefined) with its body. Stop at
+ * non-body-bearing nodes (Pure, Play, Sleep, Code, Stack, Seq, Cycle,
+ * Choice, Pick, Chunk) to prevent infinite loops.
+ *
+ * RESEARCH §2.x — option (a) existing-IR relabel; no virtual node
+ * synthesis.
+ *
+ * Exported for unit testability (T-03 tests it directly).
+ */
+export function stripInnerLate(node: PatternIR): PatternIR {
+  if (node.tag === 'Late' && node.userMethod === undefined) {
+    return node.body
+  }
+  // Single-body wrappers: recurse into body.
+  switch (node.tag) {
+    case 'FX':
+    case 'Ramp':
+    case 'Fast':
+    case 'Slow':
+    case 'Elongate':
+    case 'Late':
+    case 'Degrade':
+    case 'Ply':
+    case 'Struct':
+    case 'Swing':
+    case 'Shuffle':
+    case 'Scramble':
+    case 'Chop':
+    case 'When':
+    case 'Loop':
+      return { ...node, body: stripInnerLate(node.body) }
+    default:
+      // Multi-child / leaf nodes (Pure, Play, Sleep, Code, Stack, Seq,
+      // Cycle, Choice, Pick, Chunk): stop. .off()'s transform never
+      // produces these in current parser paths (parseTransform yields
+      // single-body wrappers only).
+      return node
+  }
+}

--- a/packages/app/tests/ir-inspector-debugger.spec.ts
+++ b/packages/app/tests/ir-inspector-debugger.spec.ts
@@ -84,7 +84,9 @@ test.describe('IR Inspector — Pass Instrumentation v1', () => {
     await bootInspectorWithPattern(page)
     const tree = page.locator('[data-testid="ir-tree-section"]')
     // 4-note pattern under note("...") parses as a Seq of Play leaves.
-    await expect(tree).toContainText('Seq')
+    // Phase 19-06 (#76): default projected mode renders mini-notation Seq
+    // as the source symbol "[]" (D-03); Play renders as "Play".
+    await expect(tree).toContainText('[]')
     await expect(tree).toContainText('Play')
   })
 

--- a/packages/app/tests/ir-inspector-mode-toggle.spec.ts
+++ b/packages/app/tests/ir-inspector-mode-toggle.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * IR Inspector — IR-mode toggle UX probes (Phase 19-06).
+ *
+ * Verifies the toggle button itself: visibility, ARIA state, click-flip,
+ * localStorage persistence across reload, addInitScript timing
+ * (RESEARCH NEW pre-mortem #12), and state independence from the
+ * pass-tab selection (CONTEXT pre-mortem #6).
+ *
+ * Companion to ir-inspector-tier4.spec.ts (which exercises the toggle
+ * via tree-content assertions). This file isolates the toggle UX so a
+ * regression in the button alone is detected at the lowest level.
+ */
+
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+const LOCALSTORAGE_KEY = 'stave:inspector.irMode'
+
+async function setStrudelCode(page: Page, code: string): Promise<void> {
+  const ok = await page.evaluate((c) => {
+    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+    const editors = (monaco?.editor?.getEditors?.() ?? []) as Array<{
+      getModel: () => { getLanguageId?: () => string; setValue: (s: string) => void } | null
+      focus: () => void
+    }>
+    const target =
+      editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
+    if (!target) return false
+    target.getModel()?.setValue(c)
+    target.focus()
+    return true
+  }, code)
+  expect(ok).toBe(true)
+  await page.waitForTimeout(150)
+}
+
+async function focusStrudelEditor(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+    const editors = (monaco?.editor?.getEditors?.() ?? []) as Array<{
+      getModel: () => { getLanguageId?: () => string } | null
+      focus: () => void
+    }>
+    const target =
+      editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
+    target?.focus()
+  })
+}
+
+async function evalStrudel(page: Page): Promise<void> {
+  await focusStrudelEditor(page)
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1800)
+}
+
+async function openInspectorPanel(page: Page): Promise<void> {
+  const btn = page.locator('button[aria-label="IR Inspector"]').first()
+  if (await btn.isVisible().catch(() => false)) {
+    await btn.click()
+  }
+  await page.locator('[data-testid="ir-passes-tablist"]').waitFor({ timeout: 10_000 })
+}
+
+async function bootWithPattern(page: Page, code: string): Promise<void> {
+  await page.goto('/')
+  await page.locator('.monaco-editor').waitFor({ timeout: 15_000 })
+  await setStrudelCode(page, code)
+  await evalStrudel(page)
+  await openInspectorPanel(page)
+}
+
+test.describe('IR Inspector — IR-mode toggle UX', () => {
+  test('toggle button visible by default with aria-pressed=false', async ({ page }) => {
+    await bootWithPattern(page, '$: s("bd hh")')
+    const toggle = page.locator('[data-testid="ir-mode-toggle"]')
+    await expect(toggle).toBeVisible()
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  test('clicking the toggle flips aria-pressed', async ({ page }) => {
+    await bootWithPattern(page, '$: s("bd hh")')
+    const toggle = page.locator('[data-testid="ir-mode-toggle"]')
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false')
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true')
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('aria-pressed', 'false')
+  })
+
+  test('reload preserves pressed state via localStorage', async ({ page }) => {
+    await bootWithPattern(page, '$: s("bd hh")')
+    const toggle = page.locator('[data-testid="ir-mode-toggle"]')
+    await toggle.click()
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true')
+
+    await page.reload()
+    // Reload resets the Inspector panel; need a fresh eval for the
+    // snapshot to publish before passes-tablist + toggle button render.
+    await page.locator('.monaco-editor').waitFor({ timeout: 15_000 })
+    await setStrudelCode(page, '$: s("bd hh")')
+    await evalStrudel(page)
+    await openInspectorPanel(page)
+    const toggleAfter = page.locator('[data-testid="ir-mode-toggle"]')
+    await expect(toggleAfter).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  test('initial state honors pre-set localStorage (addInitScript timing probe)', async ({ page }) => {
+    // RESEARCH NEW pre-mortem #12 — verify that addInitScript populates
+    // localStorage BEFORE React's useState lazy initializer runs.
+    await page.addInitScript((key) => {
+      window.localStorage.setItem(key, 'true')
+    }, LOCALSTORAGE_KEY)
+    await bootWithPattern(page, '$: s("bd hh")')
+    const toggle = page.locator('[data-testid="ir-mode-toggle"]')
+    await expect(toggle).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  test('toggle does not change pass-tab selection (state independence)', async ({ page }) => {
+    // CONTEXT pre-mortem #6 — IR-mode and pass-tab are independent state slots.
+    await bootWithPattern(page, '$: s("bd hh")')
+    const tabs = page.locator('[data-testid="ir-passes-tablist"] button[role="tab"]')
+    const initiallySelected = await tabs.first().getAttribute('aria-selected')
+
+    const toggle = page.locator('[data-testid="ir-mode-toggle"]')
+    await toggle.click()
+    await toggle.click()
+
+    const stillSelected = await tabs.first().getAttribute('aria-selected')
+    expect(stillSelected).toBe(initiallySelected)
+  })
+})

--- a/packages/app/tests/ir-inspector-tier4.spec.ts
+++ b/packages/app/tests/ir-inspector-tier4.spec.ts
@@ -1,23 +1,34 @@
 /**
- * IR Inspector Tier 4 smoke probe (Phase 19-03).
+ * IR Inspector Tier 4 smoke probe — dual-mode (Phase 19-06).
  *
- * Verifies that each of the six newly-modeled Strudel JS API methods
- * surfaces in the IR Inspector tree as expected — Late/Degrade/Chunk/
- * Ply as their own forced-tag nodes, jux/off as the documented Stack
- * desugars. Companion to the editor-side parity harness
- * (parity.test.ts) — that proves the IR matches Strudel's evaluator
- * event-for-event; this proves the user-facing Inspector reflects
- * what they typed.
+ * Verifies that each of the Tier-4 Strudel JS API methods surfaces in
+ * the IR Inspector tree as expected, in BOTH the projected (default)
+ * mode and the raw IR mode (toggle pressed). The projected mode asserts
+ * user-method vocabulary (`'layer'`, `'jux'`, `'off'`, `'late'`,
+ * `'degradeBy'`, etc.); the raw IR mode asserts the structural IR tag
+ * names (`'Stack'`, `'FX'`, `'Late'`, `'Degrade'`, etc.).
  *
- * Scope: smoke, not exhaustive. One probe per method, asserting the
- * load-bearing tag/text appears in the tree and the events panel
- * reports a non-zero count. Strict per-position checks live in the
- * editor-side harness.
+ * Companion to the editor-side parity harness (parity.test.ts) — that
+ * proves the IR matches Strudel's evaluator event-for-event; this proves
+ * the user-facing Inspector reflects what the user typed (projected
+ * mode) and the IR shape under the hood (raw mode).
+ *
+ * Scope: smoke, not exhaustive. One probe per method × 2 modes.
+ *
+ * RESEARCH §4 + NEW pre-mortem #12 (addInitScript timing) — IR-mode
+ * tests pre-set localStorage via page.addInitScript BEFORE React
+ * hydrates, then sanity-check `aria-pressed='true'` at the top of every
+ * row before asserting tree contents.
  */
 
 import { test, expect, type Page } from '@playwright/test'
 
 const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+// Module-private duplicate of the IR-mode localStorage key. Tests must
+// not import from app source (they probe via DOM); a string drift here
+// is a detectable test-failure signal.
+const LOCALSTORAGE_KEY = 'stave:inspector.irMode'
 
 async function setStrudelCode(page: Page, code: string): Promise<void> {
   const ok = await page.evaluate((c) => {
@@ -74,128 +85,139 @@ async function bootWithPattern(page: Page, code: string): Promise<void> {
 
 /**
  * Each row drives a `bootWithPattern → assert tree contains tag → assert
- * events panel non-zero` probe. The `tagInTree` strings match what
- * IRInspectorPanel renders for each tag's `<summary>` line — the tag
- * name itself, plus a discriminating substring where two methods would
- * otherwise look identical (e.g. "Stack 2 tracks" + "Late" together
- * pins down off vs jux).
+ * events panel non-zero` probe in BOTH modes. The projected fragments
+ * must all appear in the default (projected) tree; the raw fragments
+ * must appear in the IR-mode tree.
  */
 const TIER4_PROBES: Array<{
   method: string
   code: string
-  // Substrings that MUST all appear somewhere inside the IR tree section.
-  tagInTree: string[]
+  // Default (projected) mode expected substrings.
+  projectedTagInTree: string[]
+  // IR-mode (raw IR) expected substrings.
+  rawTagInTree: string[]
 }> = [
   // Late — single forced tag node.
   {
     method: 'late',
     code: '$: s("bd hh sd cp").late(0.125)',
-    tagInTree: ['Late'],
+    projectedTagInTree: ['late'],
+    rawTagInTree: ['Late'],
   },
-  // off desugars to Stack(body, transform(Late(t, body))) — the Stack
-  // wraps a Late on the offset side. Both must be visible.
+  // off desugars to Stack(body, transform(Late(t, body))) — projected
+  // mode shows 'off' over [body, transform-without-Late]; raw shows
+  // Stack > body, Late.
   {
     method: 'off',
     code: '$: s("bd hh sd cp").off(0.125, x => x.gain(0.5))',
-    tagInTree: ['Stack', 'Late'],
+    projectedTagInTree: ['off', 'gain'],
+    rawTagInTree: ['Stack', 'Late'],
   },
   // jux desugars to Stack(FX(pan,-1, body), FX(pan,+1, transform(body))).
-  // Two FX(pan, ...) nodes inside a Stack.
+  // Projected hides the FX(pan) wrappers; raw shows them all.
   {
     method: 'jux',
     code: '$: s("bd hh sd cp").jux(x => x.gain(0.5))',
-    tagInTree: ['Stack', 'FX', 'pan'],
+    projectedTagInTree: ['jux', 'gain'],
+    rawTagInTree: ['Stack', 'FX', 'pan'],
   },
   // .degrade() — Degrade tag with p=0.5. Uses an 8-event body so the
   // 50%-retention sample reliably keeps at least one event under the
-  // deterministic seed=0 RNG (a 4-event probe occasionally drops all
-  // four under the legacy seed pattern).
+  // deterministic seed=0 RNG.
   {
     method: 'degrade',
     code: '$: s("bd hh sd cp ride lt mt ht").degrade()',
-    tagInTree: ['Degrade'],
+    projectedTagInTree: ['degrade'],
+    rawTagInTree: ['Degrade'],
   },
-  // .degradeBy(0.3) — Degrade tag with retention p=0.7.
+  // .degradeBy(0.3) — PV31 first user-visible distinguish: projected
+  // label is 'degradeBy', NOT 'degrade'. Raw IR tag is the same Degrade
+  // (only userMethod distinguishes; PV31 first consumer ships here).
   {
     method: 'degradeBy',
     code: '$: s("bd hh sd cp ride lt mt ht").degradeBy(0.3)',
-    tagInTree: ['Degrade'],
+    projectedTagInTree: ['degradeBy'],
+    rawTagInTree: ['Degrade'],
   },
   // .chunk(4, f) — Chunk forced tag.
   {
     method: 'chunk',
     code: '$: s("bd hh sd cp").chunk(4, x => x.gain(0.5))',
-    tagInTree: ['Chunk'],
+    projectedTagInTree: ['chunk'],
+    rawTagInTree: ['Chunk'],
   },
-  // .ply(3) — Ply forced tag (W4 T10 promoted from desugar to tag after
-  // a probe showed Fast(n, Seq(body × n)) compresses events into [0, 1/n)).
+  // .ply(3) — Ply forced tag.
   {
     method: 'ply',
     code: '$: s("bd hh sd cp").ply(3)',
-    tagInTree: ['Ply'],
+    projectedTagInTree: ['ply'],
+    rawTagInTree: ['Ply'],
   },
-  // -------------------------------------------------------------------
-  // Phase 19-04 — Tier 4 second half (Pick, Struct, Swing, Shuffle,
-  // Scramble, Chop forced tags + .layer(...) desugar to Stack).
-  // -------------------------------------------------------------------
-  // .layer(f, g) desugars to Stack(f(body), g(body)) — the Stack node
-  // is the load-bearing observation; no Layer tag exists.
+  // .layer(f, g) desugars to Stack(f(body), g(body)) — projected shows
+  // 'layer' over the children verbatim; raw shows the Stack.
   {
     method: 'layer',
     code: '$: note("c d e f").layer(x => x.add("0,2"))',
-    tagInTree: ['Stack'],
+    projectedTagInTree: ['layer'],
+    rawTagInTree: ['Stack'],
   },
-  // .pick — numeric-selector + lookup array. Use mini() + .note() so
-  // the test-env transpiler reaches a numeric Pattern selector reliably
-  // (String.prototype.pick maps numeric strings to MIDI which the lookup
-  // can't index by). Inspector renders the tag plus the lookup count.
+  // .pick — numeric-selector + lookup array.
   {
     method: 'pick',
     code: '$: mini("<0 1 2 3>").pick(["c","e","g","b"]).note()',
-    tagInTree: ['Pick'],
+    projectedTagInTree: ['pick'],
+    rawTagInTree: ['Pick'],
   },
-  // .struct — re-times body's value-stream to mask onsets (4-step mask
-  // selects 3 onsets out of 4 cycle slots; events panel must be > 0).
+  // .struct — re-times body's value-stream to mask onsets.
   {
     method: 'struct',
     code: '$: note("c d e f").struct("x ~ x ~ x")',
-    tagInTree: ['Struct'],
+    projectedTagInTree: ['struct'],
+    rawTagInTree: ['Struct'],
   },
   // .swing(n) — narrow Swing tag (D-03; Inside primitive deferred).
-  // 6-note body so per-cycle events are visible after timing nudges.
   {
     method: 'swing',
     code: '$: note("c d e f g h").swing(2)',
-    tagInTree: ['Swing'],
+    projectedTagInTree: ['swing'],
+    rawTagInTree: ['Swing'],
   },
-  // .shuffle(n) — per-cycle permutation; n=4 over 4 events makes every
-  // slot a full reordering.
+  // .shuffle(n) — per-cycle permutation.
   {
     method: 'shuffle',
     code: '$: note("c d e f").shuffle(4)',
-    tagInTree: ['Shuffle'],
+    projectedTagInTree: ['shuffle'],
+    rawTagInTree: ['Shuffle'],
   },
   // .scramble(n) — per-slot independent samples (with replacement).
   {
     method: 'scramble',
     code: '$: note("c d e f").scramble(4)',
-    tagInTree: ['Scramble'],
+    projectedTagInTree: ['scramble'],
+    rawTagInTree: ['Scramble'],
   },
   // .chop(n) — per-event sample-range slicing; pattern-level only
   // (audio-buffer slicing deferred to phase 22 per D-04).
   {
     method: 'chop',
     code: '$: s("bd").chop(4)',
-    tagInTree: ['Chop'],
+    projectedTagInTree: ['chop'],
+    rawTagInTree: ['Chop'],
   },
 ]
 
-test.describe('IR Inspector — Tier 4 smoke probe', () => {
+test.describe('IR Inspector — Tier 4 smoke probe (projected mode, default)', () => {
   for (const probe of TIER4_PROBES) {
-    test(`.${probe.method} surfaces in IR tree and emits events`, async ({ page }) => {
+    test(`.${probe.method} surfaces with projected vocabulary`, async ({ page }) => {
+      // Default: localStorage empty → projected mode active.
       await bootWithPattern(page, probe.code)
+
+      // Sanity: projected mode means the toggle is NOT pressed.
+      const toggle = page.locator('[data-testid="ir-mode-toggle"]')
+      await expect(toggle).toHaveAttribute('aria-pressed', 'false')
+
       const tree = page.locator('[data-testid="ir-tree-section"]')
-      for (const fragment of probe.tagInTree) {
+      for (const fragment of probe.projectedTagInTree) {
         await expect(tree).toContainText(fragment)
       }
       // Events panel reports non-zero count — the load-bearing
@@ -204,6 +226,33 @@ test.describe('IR Inspector — Tier 4 smoke probe', () => {
         .locator('[data-testid="ir-events-section"] summary')
         .first()
       await expect(eventsHeading).toContainText(/Events \([1-9]\d*\)/)
+    })
+  }
+})
+
+test.describe('IR Inspector — Tier 4 smoke probe (IR mode, raw IR)', () => {
+  for (const probe of TIER4_PROBES) {
+    test(`.${probe.method} surfaces with raw IR vocabulary in IR mode`, async ({ page }) => {
+      // Pre-set localStorage BEFORE the React tree mounts. addInitScript
+      // runs in the new browser context BEFORE any page script loads —
+      // ensures useState's lazy initializer reads 'true'. RESEARCH §4.4
+      // / NEW pre-mortem #12.
+      await page.addInitScript((key) => {
+        try { window.localStorage.setItem(key, 'true') } catch { /* ignore */ }
+      }, LOCALSTORAGE_KEY)
+
+      await bootWithPattern(page, probe.code)
+
+      // Sanity: confirm the toggle is showing pressed state. If this
+      // assertion fails, addInitScript timing is off — investigate
+      // before triaging row failures.
+      const toggle = page.locator('[data-testid="ir-mode-toggle"]')
+      await expect(toggle).toHaveAttribute('aria-pressed', 'true')
+
+      const tree = page.locator('[data-testid="ir-tree-section"]')
+      for (const fragment of probe.rawTagInTree) {
+        await expect(tree).toContainText(fragment)
+      }
     })
   }
 })

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    // Exclude Playwright specs (they live under packages/app/tests/) — they
+    // import from `@playwright/test` and are not vitest-runnable.
+    include: ['src/**/__tests__/**/*.test.{ts,tsx}'],
+    exclude: ['node_modules', 'tests', '.next'],
+    // App-package projection helpers are pure functions that import
+    // PatternIR types from @stave/editor. Real Strudel parsing in tests
+    // means we still need the @strudel transitive imports to resolve via
+    // vite-node — mirror the editor's stub + inline pattern.
+    server: {
+      deps: {
+        inline: [/@strudel\//],
+      },
+    },
+  },
+  resolve: {
+    alias: {
+      '@kabelsalat/web': new URL(
+        '../editor/test/stubs/kabelsalat-web.mjs',
+        import.meta.url,
+      ).pathname,
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,12 +57,18 @@ importers:
       eslint-config-next:
         specifier: 16.2.1
         version: 16.2.1(@typescript-eslint/parser@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      jsdom:
+        specifier: ^24.0.0
+        version: 24.1.3
       tailwindcss:
         specifier: ^4
         version: 4.2.2
       typescript:
         specifier: ^5
         version: 5.9.3
+      vitest:
+        specifier: ^1.6.0
+        version: 1.6.1(@types/node@20.19.37)(jsdom@24.1.3)(lightningcss@1.32.0)
 
   packages/editor:
     dependencies:


### PR DESCRIPTION
## Summary

Phase 19-06 — cashes in 19-05's `userMethod` field. Inspector tree default-renders **Strudel vocabulary** instead of raw IR tag names; a toolbar toggle reveals raw IR for developers. Implicit-IR principle (PV28) extends from modeling layer (19-03/19-04 D-02) to presentation layer.

**App-package only.** Editor / parser / collect / toStrudel / snapshot pipeline (PK9) all unchanged per D-05 render-time projection.

**Tests:** 1134 editor (unchanged), 0 → 54 app vitest, 22 → 33 Playwright (5 IR-mode toggle UX + 6 net dual-mode Tier-4 rows).

## What changed

### Projection layer
- `packages/app/src/components/irProjection.ts` (NEW) — 30 per-tag rules:
  - User-callable tags: `node.userMethod ?? node.tag.toLowerCase()`
  - Mini-notation tags: source symbols (`~`, `<>`, `?`, `@N`, `*N`, `{}`, `[]`) per D-03 — symbol-with-value for Fast/Elongate, symbol-only for the others
  - Synthetic intermediates (`userMethod === undefined`): collapse into parent's children list per D-02 hide rule
  - **`Code` whitelist** (RESEARCH NEW pre-mortem #8): explicit case in `projectedLabel` returning `'Code'` so parser failures stay visible
- Children projection per desugar (D-01):
  - `.layer(f, g)` → `[f(body), g(body)]` (drop the Stack)
  - `.jux(rev)` → `[body, rev(body)]` (hide pan-FX scaffolding)
  - `.off(t, f)` → `[body, f-applied-late-copy]` via `stripInnerLate(node.body)` recursion (option a per RESEARCH Q1 — relabel existing IR; option b virtual-node synthesis was the documented abort criterion, not triggered)
  - `.ply(n)` → `[body]` (single child)
- `stripInnerLate` recurses through 14 single-body wrapper tags; stops at multi-child/leaf nodes (Stack, Seq, Pick, Choice, Pure, Play, Sleep, Code) preventing infinite loops

### Toolbar IR-mode toggle
- `<button aria-pressed={!projected}>` per D-06 + PR #68 ARIA discipline
- `aria-label="Toggle raw IR view"` + tooltip ("Show raw IR shape" / "Show projected user-method view")
- `localStorage` key `stave:inspector.irMode` (colon-prefix per existing convention `stave:editorTheme`/`stave:sidebar-width`/`stave:autosnapIdleMs`; RESEARCH Q3 corrected CONTEXT's tentative dot-prefix)
- SSR-safe `typeof window !== 'undefined'` guard in initializer (CONTEXT pre-mortem #2)

### Tier-4 dual-mode coverage
- Existing 22 Playwright rows updated: `expectedTreeContains` flipped from raw IR names (`'Stack'`, `'FX'`) to projected names (`'layer'`, `'jux'`)
- New IR-mode variant block: `addInitScript` sets `localStorage['stave:inspector.irMode'] = 'true'` before navigation; per-row `aria-pressed='true'` sanity check at top of every test (mitigates `addInitScript` race per PLAN §5 #12); raw IR names asserted

### App-side test runner
- Vitest + jsdom set up in `packages/app` (RESEARCH Q6 Path A; ~5 min — well under 1-hour bail)
- `packages/app/src/components/__tests__/irProjection.test.ts` (NEW): 53 unit tests covering all 30 (tag, userMethod) populations + `.off()` 4-arrow-shape coverage + mini-notation symbol mapping + `Code` whitelist + Pure-as-Choice.else_ + deep-nested-hide composition

## Locked decisions (D-01..D-06 from CONTEXT)

- **D-01** Children projection per desugar — drop synthetic Stack/FX wrappers
- **D-02** Hide synthetic intermediates with `userMethod === undefined`; whitelist `Code` for parser-failure visibility
- **D-03** Mini-notation tags special-case D-02; render as source symbols (D-04 from 19-05 round-trip principle applied at symbol layer)
- **D-04** Toolbar button + projected default + colon-prefix `localStorage` persistence
- **D-05** Render-time projection — snapshot pipeline (PK9) NOT modified
- **D-06** `<button aria-pressed>` matching PR #68 ARIA tab-row discipline

## Notable execution-time findings

- **`.off()` `stripInnerLate` (option a) held** across all 4 arrow shapes (`x => x.gain(0.5)`, `x => x.fast(2)`, `x => x.late(0.125)`, `x => x.gain(0.5).fast(2)`). User-typed `.late()` preservation test confirmed only synthetic Late (`userMethod === undefined`) is stripped; user-typed `.late()` stays intact. Option (b) virtual-node synthesis abort criterion not triggered.
- **`addInitScript` race did NOT fire** — per-row `aria-pressed='true'` sanity check passed reliably across all 28 dual-mode runs.
- **T-05+T-06 atomic combination held** — splitting them would have left the test suite red between commits (default mode flip invalidates 22 existing Playwright assertions until both land).
- **`Code` whitelist caught at planning** (RESEARCH NEW pre-mortem #8) — without it, parser failures would silently hide from the projected tree.
- **Pre-existing baseline failures** in `tests/stave.spec.ts` (3) + `tests/hydra-stave-bag.spec.ts` (1) are NOT introduced by this phase — verified by stashing changes and re-running on baseline.

## Test plan

- [x] Editor: 1134 → 1134 (unchanged — D-05 render-time projection; editor untouched)
- [x] App vitest: 0 → 54 (1 smoke + 53 projection rules); all green
- [x] Playwright: 22 → 33; default + IR-mode rows pass
- [x] tsc --noEmit clean (editor + app)
- [x] Default load shows projected mode (localStorage initially empty → projected)
- [x] Toggle flips between modes; preference persists across reload
- [x] ARIA: `aria-pressed` matches mode state; tooltip + label read appropriately
- [x] No editor dist rebuild needed (editor unchanged)

## Catalogue updates (on-disk; `.anvi/` is gitignored)

Promotion candidates documented in 19-06-SUMMARY.md (memory only per dharana single-occurrence rule):
- **Hetvabhasa**: projection-time recursion that walks `body` fields silently fails on list-of-children tags (Pick.lookup, Stack.tracks). Mitigated this phase; promote on first observed real-world failure.
- **Hetvabhasa**: display-layer projection that hides synthetic intermediates by default must whitelist parser-failure-escape-hatch tags. Today only `Code` qualifies; promote when 2nd qualifies.
- **Hetvabhasa**: Playwright `addInitScript` for state hydration — verify boot ordering with a trivial probe before assuming state took effect.
- **PV28 promotion candidate**: implicit-IR principle from "modeling layer" → "end-to-end" (modeling + presentation). Final promotion deferred until observation in production for one more session.

## References

- closes #76
- predecessors: #69 (Tier 4 first half), #72 (PRE-01), #73 (Tier 4 second half), #77 (19-05 loc + userMethod populated)
- consumer of 19-05's `userMethod` field
- `.planning/phases/19-pattern-ir/19-06-{CONTEXT,RESEARCH,PLAN,PLAN-CHECK,SUMMARY}.md` (gitignored, on disk)
- Catalogues: PV28 (promotion candidate to end-to-end), PV31 (first consumer ships), PK9 (untouched per D-05), PK12 (loc convention preserved)