### PR TITLE
feat(19-07): parser stage decomposition — deeper tests + perf check + docs (PR-B)

### DIFF
--- a/packages/app/src/components/__tests__/irProjection.test.ts
+++ b/packages/app/src/components/__tests__/irProjection.test.ts
@@ -13,6 +13,7 @@
 import { describe, it, expect } from 'vitest'
 import { parseStrudel } from '../../../../editor/src/ir/parseStrudel'
 import { IR, type PatternIR } from '../../../../editor/src/ir/PatternIR'
+import { runRawStage } from '../../../../editor/src/ir/parseStrudelStages'
 import {
   projectedLabel,
   projectedChildren,
@@ -468,5 +469,59 @@ describe('stripInnerLate', () => {
   it('stops at Code leaf', () => {
     const code: PatternIR = IR.code('foo')
     expect(stripInnerLate(code)).toBe(code)
+  })
+})
+
+// -----------------------------------------------------------------------------
+// T-12.5 (REV-3) — RAW tab projection probe
+//
+// CONTEXT D-04 mandates uniform projection across all 4 stages
+// (RAW, MINI-EXPANDED, CHAIN-APPLIED, Parsed). T-12 audits the FINAL
+// (rightmost-by-default) tab via Playwright; the RAW tab — which renders
+// a multi-track $: source as Stack(userMethod=undefined) > Code, Code,
+// Code (RESEARCH §2.1) — has no explicit projection probe. P46 (display-
+// layer projection whitelist) is the catalogue ref: a missing rule would
+// fail silently as a thrown render error or blank row, neither of which
+// the existing FINAL-tab tests catch.
+// -----------------------------------------------------------------------------
+
+describe('RAW tab projection (D-04 uniform projection — REV-3)', () => {
+  it('multi-track $: RAW IR projects without errors; outer Stack(undefined) → "{}" mini polymetric symbol', () => {
+    const code = '$: note("c d")\n$: s("bd hh")'
+    const raw = runRawStage(IR.code(code))
+    // Sanity: RAW returned the expected shape (multi-track outer Stack).
+    expect(raw.tag).toBe('Stack')
+    expect((raw as { userMethod?: string }).userMethod).toBeUndefined()
+    // Outer Stack with userMethod undefined projects to the polymetric
+    // mini symbol per RESEARCH §6 D-04 risk acceptance — no thrown error.
+    expect(() => projectedLabel(raw)).not.toThrow()
+    expect(projectedLabel(raw)).toBe('{}')
+    // projectedChildren returns the per-track Code lifts (D-04 uniform
+    // — Code is whitelisted out of D-02 hide rule).
+    const kids = projectedChildren(raw)
+    expect(kids.length).toBe(2)
+    for (const k of kids) {
+      expect(k.tag).toBe('Code')
+      expect(projectedLabel(k)).toBe('Code')
+    }
+    // Each track's expr text is recoverable from its Code node.
+    const codes = (kids as Array<{ tag: 'Code'; code: string }>)
+      .filter((k) => k.tag === 'Code')
+      .map((k) => k.code)
+    expect(codes[0]).toContain('note("c d")')
+    expect(codes[1]).toContain('s("bd hh")')
+  })
+
+  it('single-track RAW IR projects to one Code row with the expected text', () => {
+    const code = 'note("c d")'
+    const raw = runRawStage(IR.code(code))
+    expect(raw.tag).toBe('Code')
+    expect(() => projectedLabel(raw)).not.toThrow()
+    expect(projectedLabel(raw)).toBe('Code')
+    // Code is a leaf at projection — no children.
+    const kids = projectedChildren(raw)
+    expect(kids).toHaveLength(0)
+    // The Code's text contains the source.
+    expect((raw as { code: string }).code).toBe('note("c d")')
   })
 })

--- a/packages/app/src/components/__tests__/irProjection.test.ts
+++ b/packages/app/src/components/__tests__/irProjection.test.ts
@@ -505,8 +505,8 @@ describe('RAW tab projection (D-04 uniform projection — REV-3)', () => {
       expect(projectedLabel(k)).toBe('Code')
     }
     // Each track's expr text is recoverable from its Code node.
-    const codes = (kids as Array<{ tag: 'Code'; code: string }>)
-      .filter((k) => k.tag === 'Code')
+    const codes = kids
+      .filter((k): k is Extract<PatternIR, { tag: 'Code' }> => k.tag === 'Code')
       .map((k) => k.code)
     expect(codes[0]).toContain('note("c d")')
     expect(codes[1]).toContain('s("bd hh")')

--- a/packages/editor/src/ir/__tests__/parseStrudelStages.test.ts
+++ b/packages/editor/src/ir/__tests__/parseStrudelStages.test.ts
@@ -417,7 +417,7 @@ describe('parseStrudel stages — Tier-4 round-trip per method (T-09)', () => {
  */
 function collectLocEntries(
   node: PatternIR,
-  path = node.tag,
+  path: string = node.tag,
   acc: Array<{ path: string; tag: string; start: number; end: number }> = [],
 ): Array<{ path: string; tag: string; start: number; end: number }> {
   const rec = node as Record<string, unknown>

--- a/packages/editor/src/ir/__tests__/parseStrudelStages.test.ts
+++ b/packages/editor/src/ir/__tests__/parseStrudelStages.test.ts
@@ -355,3 +355,251 @@ describe('parseStrudel stages — CHAIN-APPLIED → FINAL identity (T-05.d)', ()
     expect(passes[3].ir).toBe(passes[2].ir)
   })
 })
+
+// ===========================================================================
+// PR-B SCOPE — T-09 Tier-4 round-trip + T-10 deeper per-stage tests.
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// T-09 — Tier-4 round-trip per applyMethod case (REV: PR-A shipped real
+//        runChainAppliedStage; T-09 verifies parity per Tier-4 method).
+// ---------------------------------------------------------------------------
+
+const TIER4_FIXTURES: ReadonlyArray<{ method: string; code: string }> = [
+  { method: 'fast',     code: 's("bd").fast(2)' },
+  { method: 'slow',     code: 's("bd").slow(2)' },
+  { method: 'jux',      code: 's("bd hh sd cp").jux(x => x.gain(0.5))' },
+  { method: 'off',      code: 's("bd hh sd cp").off(0.125, x => x.gain(0.5))' },
+  { method: 'layer',    code: 'note("c d e").layer(x => x.add("0,2"))' },
+  { method: 'struct',   code: 's("bd hh sd cp").struct("1 0 1 0")' },
+  { method: 'ply',      code: 's("bd hh").ply(2)' },
+  { method: 'late',     code: 's("bd hh").late(0.125)' },
+  { method: 'degrade',  code: 's("bd hh sd cp").degrade()' },
+  { method: 'degradeBy', code: 's("bd hh sd cp").degradeBy(0.3)' },
+  { method: 'chunk',    code: 's("bd hh sd cp").chunk(2, x => x.fast(2))' },
+  { method: 'swing',    code: 's("bd hh sd cp").swing(4)' },
+  { method: 'pick',     code: 's("bd hh").pick("0 1", [s("sd"), s("cp")])' },
+  { method: 'shuffle',  code: 's("bd hh sd cp").shuffle(4)' },
+  { method: 'scramble', code: 's("bd hh sd cp").scramble(4)' },
+  { method: 'chop',     code: 's("bd hh").chop(4)' },
+  { method: 'every',    code: 's("bd").every(2, x => x.late(0.125))' },
+  { method: 'sometimes', code: 's("bd hh").sometimes(x => x.fast(2))' },
+  { method: 'gain',     code: 's("bd hh").gain(0.5)' },
+]
+
+describe('parseStrudel stages — Tier-4 round-trip per method (T-09)', () => {
+  for (const { method, code } of TIER4_FIXTURES) {
+    it(`CHAIN-APPLIED FINAL parity for .${method}(...) — pipeline === parseStrudel`, () => {
+      const fromPipeline = pipeline(code)
+      const fromDirect = parseStrudel(code)
+      expect(stripStageMeta(fromPipeline)).toEqual(stripStageMeta(fromDirect))
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// T-10 PR-B SCOPE
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursive walker that collects every node carrying a `loc[0]` field,
+ * keyed by tag-path from the root, into a flat list. Used for the
+ * MINI-EXPANDED → CHAIN-APPLIED universal loc-equality probe (T-10.b1,
+ * REV-2). The path string is `<tag>` for root and `<tag>.<childKey>...`
+ * for descendants — ensures structurally-corresponding nodes line up
+ * across stages even when applyChain wraps the root in additional tags.
+ *
+ * We collect in PRE-ORDER so root appears first; CHAIN-APPLIED's wrapping
+ * tags (Fast/Late/etc.) appear at the START of its list. Comparison
+ * strategy: every entry from MINI-EXPANDED MUST appear in CHAIN-APPLIED's
+ * list with the same loc — order need not match (CHAIN-APPLIED has
+ * extra entries from wrapping tags).
+ */
+function collectLocEntries(
+  node: PatternIR,
+  path = node.tag,
+  acc: Array<{ path: string; tag: string; start: number; end: number }> = [],
+): Array<{ path: string; tag: string; start: number; end: number }> {
+  const rec = node as Record<string, unknown>
+  const loc = rec.loc as Array<{ start: number; end: number }> | undefined
+  if (loc && loc.length > 0) {
+    acc.push({ path, tag: node.tag, start: loc[0].start, end: loc[0].end })
+  }
+  switch (node.tag) {
+    case 'Seq':   node.children.forEach((c, i) => collectLocEntries(c, `${path}.children[${i}]`, acc)); break
+    case 'Stack': node.tracks.forEach((t, i) => collectLocEntries(t, `${path}.tracks[${i}]`, acc)); break
+    case 'Cycle': node.items.forEach((c, i) => collectLocEntries(c, `${path}.items[${i}]`, acc)); break
+    case 'Choice':
+      collectLocEntries(node.then, `${path}.then`, acc)
+      collectLocEntries(node.else_, `${path}.else_`, acc)
+      break
+    case 'Every':
+      collectLocEntries(node.body, `${path}.body`, acc)
+      if (node.default_) collectLocEntries(node.default_, `${path}.default_`, acc)
+      break
+    case 'When': case 'FX': case 'Ramp': case 'Fast': case 'Slow':
+    case 'Elongate': case 'Late': case 'Degrade': case 'Ply': case 'Struct':
+    case 'Swing': case 'Shuffle': case 'Scramble': case 'Chop': case 'Loop':
+      collectLocEntries(node.body, `${path}.body`, acc)
+      break
+    case 'Chunk':
+      collectLocEntries(node.transform, `${path}.transform`, acc)
+      collectLocEntries(node.body, `${path}.body`, acc)
+      break
+    case 'Pick':
+      collectLocEntries(node.selector, `${path}.selector`, acc)
+      node.lookup.forEach((l, i) => collectLocEntries(l, `${path}.lookup[${i}]`, acc))
+      break
+    default: break
+  }
+  return acc
+}
+
+describe('parseStrudel stages — MINI-EXPANDED → CHAIN-APPLIED: universal loc-equality (T-10.b1, REV-2, PV25, P39)', () => {
+  const fixtures = [
+    's("bd hh sd cp").jux(x => x.gain(0.5))',
+    's("bd hh sd cp").off(0.125, x => x.gain(0.5))',
+    'note("c d e").layer(x => x.add("0,2"))',
+    's("bd hh sd cp").struct("1 0 1 0")',
+    '$: note("c d")\n$: s("bd hh")',
+    '$: s("bd").fast(2)\n$: s("hh").late(0.125)',
+  ]
+  for (const code of fixtures) {
+    it(`every loc preserved MINI-EXPANDED → CHAIN-APPLIED — ${JSON.stringify(code).slice(0, 50)}`, () => {
+      const seed = IR.code(code)
+      const passes = runPasses(seed, PASSES)
+      // Skip the synthetic-from-RAW outer Stack (multi-track $: wrapper)
+      // — it carries a synthetic loc spanning the full source for the RAW
+      // tab visualization; CHAIN-APPLIED rebuilds via IR.stack() which
+      // drops the synthetic loc to match today's parseStrudel byte-shape
+      // (parseStrudelStages.ts:189). Drop the outermost entry when both
+      // stages have a Stack-with-undefined-userMethod at root.
+      const me = passes[1].ir
+      const isSyntheticOuter =
+        me.tag === 'Stack' &&
+        (me as { userMethod?: string }).userMethod === undefined
+      const meEntries = collectLocEntries(passes[1].ir).filter(
+        (e, i) => !(isSyntheticOuter && i === 0),
+      )
+      const caEntries = collectLocEntries(passes[2].ir)
+      // CHAIN-APPLIED may have MORE entries (newly-wrapped tags) but every
+      // (start, end, tag) tuple from MINI-EXPANDED must appear at least
+      // once at CHAIN-APPLIED.
+      const caKeys = new Set(caEntries.map((e) => `${e.tag}|${e.start}|${e.end}`))
+      for (const me of meEntries) {
+        const key = `${me.tag}|${me.start}|${me.end}`
+        expect(caKeys.has(key), `MINI-EXPANDED loc dropped at CHAIN-APPLIED: ${me.path} (tag=${me.tag} start=${me.start} end=${me.end})`).toBe(true)
+      }
+    })
+  }
+})
+
+describe('parseStrudel stages — PK12 dot-inclusive convention preserved (T-10.b)', () => {
+  it('s("bd").fast(2).late(0.125).gain(0.5) — each tag.loc.start lands on its leading dot', () => {
+    const code = 's("bd").fast(2).late(0.125).gain(0.5)'
+    const ir = pipeline(code)
+    // Outermost tag is FX (gain). Walk down: FX → Late → Fast → Play.
+    expect(ir.tag).toBe('FX')
+    if (ir.tag !== 'FX') throw new Error('unreachable')
+    expect(ir.loc?.[0]?.start).toBe(code.indexOf('.gain'))
+
+    expect(ir.body.tag).toBe('Late')
+    if (ir.body.tag !== 'Late') throw new Error('unreachable')
+    expect(ir.body.loc?.[0]?.start).toBe(code.indexOf('.late'))
+
+    expect(ir.body.body.tag).toBe('Fast')
+    if (ir.body.body.tag !== 'Fast') throw new Error('unreachable')
+    expect(ir.body.body.loc?.[0]?.start).toBe(code.indexOf('.fast'))
+  })
+})
+
+describe('parseStrudel stages — userMethod alias-distinguished pairs (T-10.a, PV31)', () => {
+  it('Stack-from-layer ≠ Stack-from-jux', () => {
+    const layerFinal = pipeline('note("c d e").layer(x => x.add("0,2"))')
+    const juxFinal   = pipeline('s("bd hh sd cp").jux(x => x.gain(0.5))')
+    expect(layerFinal.tag).toBe('Stack')
+    expect((layerFinal as { userMethod?: string }).userMethod).toBe('layer')
+    expect(juxFinal.tag).toBe('Stack')
+    expect((juxFinal as { userMethod?: string }).userMethod).toBe('jux')
+  })
+
+  it('Degrade-from-degrade ≠ Degrade-from-degradeBy', () => {
+    const d  = pipeline('s("bd hh sd cp").degrade()')
+    const db = pipeline('s("bd hh sd cp").degradeBy(0.3)')
+    expect(d.tag).toBe('Degrade')
+    expect((d as { userMethod?: string }).userMethod).toBe('degrade')
+    expect(db.tag).toBe('Degrade')
+    expect((db as { userMethod?: string }).userMethod).toBe('degradeBy')
+  })
+
+  it('Every-from-every ≠ Every-from-sometimes', () => {
+    const e  = pipeline('s("bd").every(2, x => x.fast(2))')
+    const s  = pipeline('s("bd hh").sometimes(x => x.fast(2))')
+    // every → Every tag with userMethod 'every'
+    expect(e.tag).toBe('Every')
+    expect((e as { userMethod?: string }).userMethod).toBe('every')
+    // sometimes → Choice tag with userMethod 'sometimes' (per applyMethod case)
+    expect(s.tag).toBe('Choice')
+    expect((s as { userMethod?: string }).userMethod).toBe('sometimes')
+  })
+
+  it('FX-from-gain has userMethod gain (not pan)', () => {
+    const g = pipeline('s("bd").gain(0.5)')
+    expect(g.tag).toBe('FX')
+    expect((g as { userMethod?: string }).userMethod).toBe('gain')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// T-10.c — Orphan-metadata recursive walk for every regression fixture.
+//          (assertNoStageMeta exported above for reuse.)
+// ---------------------------------------------------------------------------
+
+describe('parseStrudel stages — orphan stage-metadata walk over fixtures (T-10.c, D-06.c)', () => {
+  const fixtures = [
+    's("bd hh sd cp").jux(x => x.gain(0.5))',
+    's("bd hh sd cp").off(0.125, x => x.gain(0.5))',
+    'note("c d e").layer(x => x.add("0,2"))',
+    's("bd hh sd cp").struct("1 0 1 0")',
+    's("bd hh").ply(2)',
+    's("bd").fast(2).late(0.125).gain(0.5)',
+    '$: s("bd").fast(2)\n$: s("hh").late(0.125)',
+  ]
+  for (const code of fixtures) {
+    it(`no orphan metadata at CHAIN-APPLIED + FINAL — ${JSON.stringify(code).slice(0, 50)}`, () => {
+      const seed = IR.code(code)
+      const passes = runPasses(seed, PASSES)
+      assertNoStageMeta(passes[2].ir)
+      assertNoStageMeta(passes[3].ir)
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// T-10.d — parseTransform recursion within CHAIN-APPLIED preserves arrow-body
+//          offsets (PRE-01).
+// ---------------------------------------------------------------------------
+
+describe('parseStrudel stages — parseTransform recursion (T-10.d, PRE-01)', () => {
+  it('every(2, x => x.late(0.125)) preserves arrow-body Late.loc.start at absolute dot offset', () => {
+    const code = 's("bd").every(2, x => x.late(0.125))'
+    const ir = pipeline(code)
+    // Walk: outer Every → inner body → Late (from arrow `x.late(0.125)`).
+    expect(ir.tag).toBe('Every')
+    if (ir.tag !== 'Every') throw new Error('unreachable')
+    expect(ir.loc?.[0]?.start).toBe(code.indexOf('.every'))
+    // The transform-body Late lives at Every.body. Inside the arrow,
+    // `x.late(0.125)` — the `.late` dot is at the absolute offset of the
+    // dot inside the source.
+    expect(ir.body.tag).toBe('Late')
+    if (ir.body.tag !== 'Late') throw new Error('unreachable')
+    // The dot before `.late` inside the arrow body is at:
+    //   index of `x.late` in source - 0 (since it's `x.late(...)`)
+    // We just assert it's non-zero (PRE-01: arrow-body offsets preserved).
+    expect(ir.body.loc?.[0]?.start).toBeGreaterThan(0)
+    // Specifically: the dot before `.late` in `x => x.late(0.125)` is the
+    // character at `code.indexOf('x.late') + 1` (the `.` after `x`).
+    const dotPos = code.indexOf('x.late') + 1
+    expect(ir.body.loc?.[0]?.start).toBe(dotPos)
+  })
+})


### PR DESCRIPTION
## Summary

Phase 19-07 PR-B — continuation of [PR #80](https://github.com/MrityunjayBhardwaj/stave-code/pull/80) (PR-A, merged at `cb8c311`). PR-A shipped scaffolding + RAW + MINI-EXPANDED + REAL CHAIN-APPLIED logic + regression sentinel. PR-B layers on the deeper test gate per CONTEXT D-06 plus phase docs.

Closes #79 (continuation from PR-A).

- **T-09 + T-10:** 38 new editor tests covering Tier-4 round-trip per applyMethod case (19 fixtures, byte-equal pipeline FINAL ↔ `parseStrudel(code)`), MINI-EXPANDED → CHAIN-APPLIED universal loc-equality (PV25 + P39, REV-2 — 6 fixtures, synthetic-from-RAW outer Stack excluded per the new P47 catalogue entry), PK12 dot-inclusive convention probe (3-method chain), alias-distinguished pairs (PV31 — layer/jux, degrade/degradeBy, every/sometimes, gain), orphan-metadata recursive walk (D-06.c — 7 fixtures × CHAIN-APPLIED + FINAL), parseTransform recursion within CHAIN-APPLIED (PRE-01 — `every(2, x => x.late(0.125))`).
- **T-12.5 (REV-3):** 2 new app vitest probes for D-04 uniform projection — RAW tab Code-as-row + outer `{}` polymetric symbol — multi-track + single-track variants. P46-grounded.
- **T-13 perf observation:** Both direct `parseStrudel(code)` and 4-pass `runPasses(...)` measure sub-millisecond on a 3-track Tier-4 fixture (≈0.008ms vs ≈0.007ms over 1000 iterations). The 0.001ms delta is **inside measurement noise** (sub-ms timer resolution + GC/JIT variance), not a real "pipeline is faster" signal — both are bounded by the same underlying `extractTracks` / `parseRoot` / `applyChain` calls. Far under RESEARCH §3.6's 1.2-1.5× upper bound.
- **T-15 / T-16 / T-17:** SUMMARY, memory, ROADMAP — local files (gitignored per project convention).

## Test counts

| Suite | Before 19-07 | After PR-A | After PR-B | Net |
|---|---|---|---|---|
| Editor (vitest) | 1134 | 1155 | **1193** | +59 |
| App (vitest) | 54 | 54 | **56** | +2 |
| IR Inspector Playwright | 33 | 41 | **41** | +8 |

Pre-existing baseline failures unchanged: `tests/stave.spec.ts` × 3 + `tests/hydra-stave-bag.spec.ts` × 1 (verified by stash + re-run on `main`; same as 19-06 SUMMARY documented). Editor pre-existing tsc errors in unrelated files (`vizCompiler.hydra.test.ts`, `engineLogMarkers.test.ts`, `WorkspaceFile.test.ts`) — 53 errors here vs 65 on main — PR-B introduced ZERO new tsc errors and incidentally improved baseline by tightening one parameter type.

## Empirical findings

- **PR-A's T-03 shipped REAL `runChainAppliedStage` (not stub)** per RESEARCH §6 D-05 alternative path. T-09 in PR-B accordingly became deeper round-trip per Tier-4 method, not stub-replacement (per plan deviation §12 #1).
- **MINI-EXPANDED → CHAIN-APPLIED outer-Stack loc gap is INTENTIONAL.** Synthetic-from-RAW outer Stack carries `[0, code.length]` for RAW-tab visualization but CHAIN-APPLIED rebuilds via `IR.stack(...)` to match today's `parseStrudel` byte-shape. The universal loc-equality probe was adjusted to skip this synthetic outer wrapper. Documented as new hetvabhasa **P47** (P39 specialization).
- **Performance overhead within noise floor.** Both single-pass and 4-pass dispatch the same underlying calls — measured delta is timer noise, not signal. Real regressions would need a larger fixture (100+ event chain) or higher-resolution timing (N≥10000 iters).

## Critical self-review — follow-up issues filed

After review, three soft spots in this PR are filed as separate issues for follow-up (none block merge):

- **Synthetic-outer detection uses an implicit invariant** — `Stack && userMethod === undefined` heuristic at `parseStrudelStages.ts:115` and `:183`. Should become an explicit `synthetic: true` discriminant per P47's "generalization to future stages" guidance.
- **Exhaustiveness check missing in tag-switch helpers** — `assertNoStageMeta` and `collectLocEntries` have `default: break` so a new IR tag would be silently skipped during recursion. Should add `default: const _: never = node`.
- **No tab-content-divergence Playwright probe** — spec asserts 4 tabs render but doesn't assert that switching tabs shows different content. A future regression where the tab strip works but `passes[i].ir` wiring drifts would not be caught.

## Substrate axis advance — PV29

**First axis-2 (Stages) advance.** The 4-stage decomposition gives the Inspector tab-by-tab visibility into where transformations happen — bugs locate to the stage that introduced them, replacing today's "read parseStrudel.ts top-down" diagnostic posture. Axis 4 (Editing — Bidirectional DAW) is next, deferred to 19-08+.

## Test plan

- [x] `pnpm --filter @stave/editor test` — 1193 green
- [x] `pnpm --filter @stave/app test` — 56 green
- [x] `pnpm --filter @stave/app exec playwright test ir-inspector` — 41 green
- [x] `pnpm --filter @stave/app exec tsc --noEmit` — clean
- [x] `pnpm --filter @stave/editor exec tsc --noEmit` — pre-existing errors only (unrelated files); zero new errors introduced
- [x] T-13 perf observation captured (within measurement noise)

## Locked decisions honored

D-01 (axis-2 frontmatter), D-02 (stage boundaries), D-03 (narrow-union metadata), D-04 (uniform projection), D-05 (PR-A + PR-B sequencing), D-06 (both end-to-end parity + per-stage round-trip).

## Catalogue updates landing this PR (on-disk; .anvi/ gitignored)

- **NEW hetvabhasa P47** — Stage-transition synthetic metadata escape (P39 specialization).
- **PV25 update** — stage transitions are now PV25's primary enforcement surface; documented exemption for synthetic-from-stage anchors per P47.
- **PK9 update** — `STRUDEL_PASSES.length === 4` from 19-07 onward; `passes[3].ir` is the FINAL output that matches today's `parseStrudel(code)` byte-shape.

## Follow-up issues (filed during self-review)

- #82 — Replace implicit synthetic-outer heuristic with explicit `synthetic: true` discriminant
- #83 — Add exhaustiveness check to PatternIR tag-switch recursion in stage helpers
- #84 — Add tab-content-divergence Playwright probe
