### PR TITLE
Phase 19-08 PR-B — IR Inspector streaming timeline UI

### DIFF
--- a/packages/app/src/components/IRInspectorPanel.tsx
+++ b/packages/app/src/components/IRInspectorPanel.tsx
@@ -20,6 +20,7 @@ import {
   getIRSnapshot,
   subscribeIRSnapshot,
   revealLineInFile,
+  setCaptureCapacity,
 } from "@stave/editor";
 import {
   LOCALSTORAGE_KEY,
@@ -31,6 +32,10 @@ import { IRInspectorTimeline } from "./IRInspectorTimeline";
 // Phase 19-08 PR-B — localStorage keys for the timeline UI.
 // Convention matches `stave:inspector.irMode` at irProjection.ts:37.
 const TIMELINE_COLLAPSED_KEY = "stave:inspector.timeline.collapsed";
+const TIMELINE_CAPACITY_KEY = "stave:inspector.timeline.capacity";
+const TIMELINE_CAPACITY_DEFAULT = 30;
+const TIMELINE_CAPACITY_MIN = 1;
+const TIMELINE_CAPACITY_MAX = 500;
 
 // ----- Color tokens by IR tag — keep close to the design system -----------
 
@@ -430,6 +435,33 @@ export function IRInspectorPanel(): React.ReactElement {
     }
   }, [timelineCollapsed]);
 
+  // Phase 19-08 PR-B T-13 — trace-length (capture buffer capacity). The
+  // user-configured value persists in localStorage (UI preference per
+  // RESEARCH §8 question #2); the buffer entries themselves remain
+  // in-memory per CONTEXT D-06.
+  const [traceLength, setTraceLength] = useState<number>(() => {
+    if (typeof window === "undefined") return TIMELINE_CAPACITY_DEFAULT;
+    try {
+      const v = window.localStorage.getItem(TIMELINE_CAPACITY_KEY);
+      const n = v == null ? TIMELINE_CAPACITY_DEFAULT : Number(v);
+      if (!Number.isFinite(n) || n < TIMELINE_CAPACITY_MIN) {
+        return TIMELINE_CAPACITY_DEFAULT;
+      }
+      return Math.min(Math.floor(n), TIMELINE_CAPACITY_MAX);
+    } catch {
+      return TIMELINE_CAPACITY_DEFAULT;
+    }
+  });
+  useEffect(() => {
+    setCaptureCapacity(traceLength);
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(TIMELINE_CAPACITY_KEY, String(traceLength));
+    } catch {
+      // Storage quota / private browsing — skip silently.
+    }
+  }, [traceLength]);
+
   // 19-06 (#76) — IR-mode toggle. Default false (projected mode); true
   // shows the raw IR shape for IR developers / power users. Persisted
   // via localStorage (RESEARCH §5.2 colon-prefix convention).
@@ -591,6 +623,45 @@ export function IRInspectorPanel(): React.ReactElement {
           <div style={{ fontSize: "0.8em", opacity: 0.6 }}>
             {displaySnapshot.runtime} · {displaySnapshot.events.length} events · {ageLabel}
           </div>
+          <label
+            style={{
+              display: "inline-flex",
+              alignItems: "center",
+              gap: 4,
+              fontSize: "0.75em",
+              opacity: 0.85,
+            }}
+            title="Capture buffer length (trace) — how many past evals to keep"
+          >
+            <span style={{ opacity: 0.7 }}>trace</span>
+            <input
+              type="number"
+              min={TIMELINE_CAPACITY_MIN}
+              max={TIMELINE_CAPACITY_MAX}
+              value={traceLength}
+              onChange={(e) => {
+                const raw = Number(e.target.value);
+                if (!Number.isFinite(raw)) return;
+                const clamped = Math.min(
+                  Math.max(Math.floor(raw), TIMELINE_CAPACITY_MIN),
+                  TIMELINE_CAPACITY_MAX,
+                );
+                setTraceLength(clamped);
+              }}
+              data-testid="ir-timeline-capacity-input"
+              aria-label="Timeline capacity"
+              style={{
+                width: "3.5rem",
+                padding: "1px 4px",
+                fontSize: "0.85em",
+                background: "transparent",
+                color: "inherit",
+                border:
+                  "1px solid var(--border-subtle, rgba(128,128,128,0.3))",
+                borderRadius: 3,
+              }}
+            />
+          </label>
           <button
             type="button"
             onClick={() => setIrMode((v) => !v)}

--- a/packages/app/src/components/IRInspectorPanel.tsx
+++ b/packages/app/src/components/IRInspectorPanel.tsx
@@ -16,6 +16,7 @@ import {
   type IRSnapshot,
   type IREvent,
   type PatternIR,
+  type SourceLocation,
   getIRSnapshot,
   subscribeIRSnapshot,
   revealLineInFile,
@@ -165,10 +166,20 @@ function IRNodeRow({
   node,
   depth,
   irMode,
+  highlightedLoc,
 }: {
   node: PatternIR;
   depth: number;
   irMode: boolean;
+  /**
+   * Phase 19-08 PR-B T-12 — when the user steps J/K through a pinned
+   * snapshot's events, the panel resolves `events[playheadIndex].loc[0]`
+   * and drills it down through this prop. A node whose own
+   * `loc[0].start` matches gets the .ir-node-highlight class.
+   * `null` means no highlight (live mode or synthetic event without loc
+   * — graceful fallback per PV24).
+   */
+  highlightedLoc?: SourceLocation | null;
 }): React.ReactElement | null {
   let label: string;
   let kids: readonly PatternIR[];
@@ -198,9 +209,21 @@ function IRNodeRow({
   const tagColor = TAG_COLOR[node.tag];
   const summary = summarize(node);
 
+  // Phase 19-08 PR-B T-12 — highlight when the J/K-driven event loc
+  // matches this node's primary loc start. PV24 fallback: missing loc
+  // on either side is a no-op (no crash; just no highlight).
+  const isHighlighted =
+    highlightedLoc != null &&
+    node.loc != null &&
+    node.loc.length > 0 &&
+    node.loc[0].start === highlightedLoc.start;
+  const highlightClass = isHighlighted ? "ir-node-highlight" : undefined;
+
   if (kids.length === 0) {
     return (
       <div
+        className={highlightClass}
+        data-ir-node-highlight={isHighlighted ? "true" : undefined}
         style={{
           display: "flex",
           gap: 6,
@@ -208,6 +231,13 @@ function IRNodeRow({
           paddingLeft: depth * 12,
           paddingTop: 2,
           paddingBottom: 2,
+          ...(isHighlighted
+            ? {
+                outline: "2px solid var(--accent, #4a9eff)",
+                background: "rgba(74, 158, 255, 0.12)",
+                borderRadius: 2,
+              }
+            : null),
         }}
       >
         <span
@@ -228,7 +258,21 @@ function IRNodeRow({
   }
 
   return (
-    <details open={depth < 2} style={{ paddingLeft: depth * 12 }}>
+    <details
+      open={depth < 2}
+      className={highlightClass}
+      data-ir-node-highlight={isHighlighted ? "true" : undefined}
+      style={{
+        paddingLeft: depth * 12,
+        ...(isHighlighted
+          ? {
+              outline: "2px solid var(--accent, #4a9eff)",
+              background: "rgba(74, 158, 255, 0.12)",
+              borderRadius: 2,
+            }
+          : null),
+      }}
+    >
       <summary style={{ cursor: "pointer", padding: "2px 0", listStyle: "none" }}>
         <span style={{ color: tagColor, fontWeight: 600, fontSize: "0.85em" }}>
           {label}
@@ -240,7 +284,13 @@ function IRNodeRow({
         )}
       </summary>
       {kids.map((c, i) => (
-        <IRNodeRow key={i} node={c} depth={depth + 1} irMode={irMode} />
+        <IRNodeRow
+          key={i}
+          node={c}
+          depth={depth + 1}
+          irMode={irMode}
+          highlightedLoc={highlightedLoc}
+        />
       ))}
     </details>
   );
@@ -454,6 +504,48 @@ export function IRInspectorPanel(): React.ReactElement {
     return () => node.removeEventListener("keydown", onKey);
   }, [pinnedSnapshot]);
 
+  // Phase 19-08 PR-B T-12 — J/K event step-through (only when pinned).
+  // Walks displaySnapshot.events[] (audible-time order, not tree order
+  // per CONTEXT D-03 + PV28). Vim-style J=forward, K=back. Scoped to
+  // panelRef so it does NOT collide with the tab strip's ←/→ at
+  // lines 472-480 (handled separately on the tablist's onKeyDown).
+  // PV18 dep array: explicit list of every value the closure reads
+  // — pinnedSnapshot, the event array length (used for clamping),
+  // and setPlayheadIndex. P29 stale-closure trap mitigated.
+  const eventCount = displaySnapshot?.events.length ?? 0;
+  useEffect(() => {
+    if (!pinnedSnapshot) return;
+    if (eventCount === 0) return;
+    const node = panelRef.current;
+    if (!node) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "j" && e.key !== "J" && e.key !== "k" && e.key !== "K") return;
+      // Don't fight typing in form fields.
+      const tag = (e.target as HTMLElement | null)?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA") return;
+      e.preventDefault();
+      setPlayheadIndex((i) => {
+        if (e.key === "j" || e.key === "J") {
+          return Math.min(i + 1, eventCount - 1);
+        }
+        return Math.max(i - 1, 0);
+      });
+    };
+    node.addEventListener("keydown", onKey);
+    return () => node.removeEventListener("keydown", onKey);
+  }, [pinnedSnapshot, eventCount]);
+
+  // Phase 19-08 PR-B T-12 — derive the highlighted source location
+  // from the current playhead index. Null when not pinned, when the
+  // playhead is past the events array, or when the indexed event has
+  // no `loc` (synthetic event — PV24 fallback).
+  const highlightedLoc = useMemo<SourceLocation | null>(() => {
+    if (!pinnedSnapshot || !displaySnapshot) return null;
+    const evt = displaySnapshot.events[playheadIndex];
+    if (!evt || !evt.loc || evt.loc.length === 0) return null;
+    return evt.loc[0];
+  }, [pinnedSnapshot, displaySnapshot, playheadIndex]);
+
   if (!displaySnapshot) {
     return (
       <div
@@ -589,6 +681,7 @@ export function IRInspectorPanel(): React.ReactElement {
                 node={displaySnapshot.passes[selectedIndex].ir}
                 depth={0}
                 irMode={irMode}
+                highlightedLoc={highlightedLoc}
               />
             )}
           </div>

--- a/packages/app/src/components/IRInspectorPanel.tsx
+++ b/packages/app/src/components/IRInspectorPanel.tsx
@@ -25,6 +25,11 @@ import {
   projectedLabel,
   projectedChildren,
 } from "./irProjection";
+import { IRInspectorTimeline } from "./IRInspectorTimeline";
+
+// Phase 19-08 PR-B — localStorage keys for the timeline UI.
+// Convention matches `stave:inspector.irMode` at irProjection.ts:37.
+const TIMELINE_COLLAPSED_KEY = "stave:inspector.timeline.collapsed";
 
 // ----- Color tokens by IR tag — keep close to the design system -----------
 
@@ -345,6 +350,35 @@ export function IRInspectorPanel(): React.ReactElement {
   // snapshot still has that pass. Falls back to the last pass otherwise.
   const [selectedTabName, setSelectedTabName] = useState<string | null>(null);
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const panelRef = useRef<HTMLDivElement | null>(null);
+
+  // Phase 19-08 PR-B — pinning state. When pinnedSnapshot is non-null,
+  // the four pass-tabs render that snapshot's tree (frozen) while the
+  // live publisher continues to feed setSnap(s) in the background.
+  // playheadIndex is the J/K event-step cursor (T-12).
+  const [pinnedSnapshot, setPinnedSnapshot] = useState<IRSnapshot | null>(null);
+  const [playheadIndex, setPlayheadIndex] = useState<number>(0);
+
+  // Phase 19-08 PR-B T-14 — collapsed state for the timeline strip.
+  const [timelineCollapsed, setTimelineCollapsed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    try {
+      return window.localStorage.getItem(TIMELINE_COLLAPSED_KEY) === "1";
+    } catch {
+      return false;
+    }
+  });
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage.setItem(
+        TIMELINE_COLLAPSED_KEY,
+        timelineCollapsed ? "1" : "0",
+      );
+    } catch {
+      // Storage quota / private browsing — skip silently.
+    }
+  }, [timelineCollapsed]);
 
   // 19-06 (#76) — IR-mode toggle. Default false (projected mode); true
   // shows the raw IR shape for IR developers / power users. Persisted
@@ -369,24 +403,58 @@ export function IRInspectorPanel(): React.ReactElement {
   }, [irMode]);
 
   useEffect(() => {
+    // The publisher fires every successful eval REGARDLESS of pin state
+    // (CONTEXT D-02 publisher-vs-consumer). The pin gate is purely
+    // render-side via `displaySnapshot` below.
     return subscribeIRSnapshot((s) => setSnap(s));
   }, []);
 
+  // Phase 19-08 — display gating. When pinnedSnapshot is set, the four
+  // pass-tabs derive from it. Live `snap` continues to update in the
+  // background; we just don't read it. PV27 alias contract holds against
+  // the captured snapshot's `passes[last].ir` per per-snapshot semantics.
+  const displaySnapshot = pinnedSnapshot ?? snap;
+
   const ageLabel = useMemo(() => {
+    if (pinnedSnapshot) {
+      const ms = Date.now() - pinnedSnapshot.ts;
+      if (ms < 1000) return "pinned · just now";
+      if (ms < 60_000) return `pinned · ${Math.round(ms / 1000)}s old`;
+      return `pinned · ${Math.round(ms / 60_000)}m old`;
+    }
     if (!snap) return "";
     const ms = Date.now() - snap.ts;
     if (ms < 1000) return "just now";
     if (ms < 60_000) return `${Math.round(ms / 1000)}s ago`;
     return `${Math.round(ms / 60_000)}m ago`;
-  }, [snap]);
+  }, [snap, pinnedSnapshot]);
 
   const selectedIndex = useMemo<number>(() => {
-    if (!snap || snap.passes.length === 0) return -1;
-    const i = selectedTabName ? snap.passes.findIndex((p) => p.name === selectedTabName) : -1;
-    return i >= 0 ? i : snap.passes.length - 1;
-  }, [snap, selectedTabName]);
+    if (!displaySnapshot || displaySnapshot.passes.length === 0) return -1;
+    const i = selectedTabName
+      ? displaySnapshot.passes.findIndex((p) => p.name === selectedTabName)
+      : -1;
+    return i >= 0 ? i : displaySnapshot.passes.length - 1;
+  }, [displaySnapshot, selectedTabName]);
 
-  if (!snap) {
+  // Phase 19-08 PR-B T-11 — ESC unpins. Scoped to the panel ref
+  // (RESEARCH §3 step 6 — avoids global keybinding pollution and
+  // does not collide with the tab strip's ←/→ at lines 472-480).
+  useEffect(() => {
+    if (!pinnedSnapshot) return;
+    const node = panelRef.current;
+    if (!node) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        setPinnedSnapshot(null);
+        setPlayheadIndex(0);
+      }
+    };
+    node.addEventListener("keydown", onKey);
+    return () => node.removeEventListener("keydown", onKey);
+  }, [pinnedSnapshot]);
+
+  if (!displaySnapshot) {
     return (
       <div
         role="region"
@@ -406,13 +474,16 @@ export function IRInspectorPanel(): React.ReactElement {
 
   return (
     <div
+      ref={panelRef}
       role="region"
       aria-label="IR Inspector"
+      tabIndex={-1}
       style={{
         padding: 12,
         fontSize: "0.9em",
         height: "100%",
         overflow: "auto",
+        outline: "none",
       }}
     >
       <div
@@ -426,7 +497,7 @@ export function IRInspectorPanel(): React.ReactElement {
         <div style={{ fontWeight: 600 }}>IR INSPECTOR</div>
         <div style={{ display: "flex", alignItems: "baseline", gap: 12 }}>
           <div style={{ fontSize: "0.8em", opacity: 0.6 }}>
-            {snap.runtime} · {snap.events.length} events · {ageLabel}
+            {displaySnapshot.runtime} · {displaySnapshot.events.length} events · {ageLabel}
           </div>
           <button
             type="button"
@@ -470,16 +541,18 @@ export function IRInspectorPanel(): React.ReactElement {
           marginBottom: 6,
         }}
         onKeyDown={(e) => {
-          if (snap == null || snap.passes.length === 0) return;
+          if (displaySnapshot == null || displaySnapshot.passes.length === 0) return;
           if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
           const dir = e.key === "ArrowRight" ? 1 : -1;
-          const next = (selectedIndex + dir + snap.passes.length) % snap.passes.length;
-          setSelectedTabName(snap.passes[next].name);
+          const next =
+            (selectedIndex + dir + displaySnapshot.passes.length) %
+            displaySnapshot.passes.length;
+          setSelectedTabName(displaySnapshot.passes[next].name);
           tabRefs.current[next]?.focus();
           e.preventDefault();
         }}
       >
-        {snap.passes.map((p, i) => (
+        {displaySnapshot.passes.map((p, i) => (
           <button
             key={p.name}
             ref={(el) => { tabRefs.current[i] = el; }}
@@ -508,12 +581,12 @@ export function IRInspectorPanel(): React.ReactElement {
       <div role="tabpanel" id="ir-tree-panel" data-testid="ir-tree-section">
         <details open>
           <summary style={{ cursor: "pointer", fontWeight: 600, padding: "4px 0", opacity: 0.85, listStyle: "none" }}>
-            IR tree{snap.passes.length > 1 && selectedIndex >= 0 ? ` · ${snap.passes[selectedIndex].name}` : null}
+            IR tree{displaySnapshot.passes.length > 1 && selectedIndex >= 0 ? ` · ${displaySnapshot.passes[selectedIndex].name}` : null}
           </summary>
           <div style={{ paddingLeft: 4 }}>
             {selectedIndex >= 0 && (
               <IRNodeRow
-                node={snap.passes[selectedIndex].ir}
+                node={displaySnapshot.passes[selectedIndex].ir}
                 depth={0}
                 irMode={irMode}
               />
@@ -524,10 +597,24 @@ export function IRInspectorPanel(): React.ReactElement {
 
       <details open data-testid="ir-events-section" style={{ marginTop: 12 }}>
         <summary style={{ cursor: "pointer", fontWeight: 600, padding: "4px 0" }}>
-          Events ({snap.events.length})
+          Events ({displaySnapshot.events.length})
         </summary>
-        <EventsTable events={snap.events} source={snap.source} />
+        <EventsTable events={displaySnapshot.events} source={displaySnapshot.source} />
       </details>
+
+      <IRInspectorTimeline
+        pinnedSnapshot={pinnedSnapshot}
+        onPin={(s) => {
+          setPinnedSnapshot(s);
+          setPlayheadIndex(0);
+        }}
+        onUnpin={() => {
+          setPinnedSnapshot(null);
+          setPlayheadIndex(0);
+        }}
+        collapsed={timelineCollapsed}
+        onToggleCollapsed={setTimelineCollapsed}
+      />
     </div>
   );
 }

--- a/packages/app/src/components/IRInspectorTimeline.tsx
+++ b/packages/app/src/components/IRInspectorTimeline.tsx
@@ -46,6 +46,21 @@ export type IRInspectorTimelineProps = {
  * (or capacity clamp / clear) by bumping a version counter. Mirrors
  * the existing useState-based subscribe pattern used by
  * IRInspectorPanel for the live snapshot.
+ *
+ * IMPORTANT — buffer reference stability trap:
+ * `getCaptureBuffer()` returns the LIVE internal array reference
+ * (timelineCapture.ts:88-90). FIFO eviction (`entries.shift()`) mutates
+ * that array in place — same reference, fewer elements. If we returned
+ * `getCaptureBuffer()` directly, downstream `useMemo([entries, ...])`
+ * would skip recomputation because `entries` would be referentially
+ * stable across pushes and the cached value (e.g. `pinnedInBuffer`)
+ * would go stale.
+ *
+ * Slicing here forces a FRESH array reference per call. Cost: one
+ * O(n) copy per render with n ≤ 500 (capacity max) — negligible.
+ * Benefit: every dependent useMemo recomputes when the buffer
+ * changes shape, including evictions of pinned references (probe
+ * (g) ghost marker).
  */
 function useCaptureBuffer(): readonly TimelineCaptureEntry[] {
   const [, setVersion] = useState<number>(0);
@@ -54,7 +69,7 @@ function useCaptureBuffer(): readonly TimelineCaptureEntry[] {
       setVersion((v) => v + 1);
     });
   }, []);
-  return getCaptureBuffer();
+  return [...getCaptureBuffer()];
 }
 
 function formatTooltip(entry: TimelineCaptureEntry, isLive: boolean): string {

--- a/packages/app/src/components/IRInspectorTimeline.tsx
+++ b/packages/app/src/components/IRInspectorTimeline.tsx
@@ -1,0 +1,231 @@
+/**
+ * IRInspectorTimeline — horizontal capture-and-scrub strip rendered
+ * below the events table inside IRInspectorPanel.
+ *
+ * Each captured IRSnapshot in the timelineCapture ring buffer becomes
+ * one tick. The most recent capture lives at the right edge (live).
+ * Clicking a tick pins that snapshot's reference; the panel's four
+ * pass-tabs then render the pinned snapshot via `displaySnapshot =
+ * pinnedSnapshot ?? snap` (T-11).
+ *
+ * Pin-by-reference contract (RESEARCH §7 trap #5):
+ *   `onPin(entry.snapshot)` passes the SNAPSHOT REFERENCE, never the
+ *   buffer index. FIFO eviction therefore does not invalidate the
+ *   pin — React keeps the snapshot alive as long as the panel state
+ *   holds it. When the pinned reference is no longer in the live
+ *   buffer (eviction case), a ghost marker surfaces at the left edge
+ *   so the user is told the pin is "off-strip" rather than silently
+ *   showing an unrelated tick.
+ *
+ * J/K keyboard step-through is wired in T-12 from the panel; the
+ * timeline's container is the recommended scope (avoids the tab
+ * strip's existing ←/→ binding at IRInspectorPanel.tsx:472-480).
+ *
+ * Phase 19-08 PR-B T-10. CONTEXT D-02 + D-07. RESEARCH §3 + §7.
+ */
+"use client";
+
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  type IRSnapshot,
+  type TimelineCaptureEntry,
+  getCaptureBuffer,
+  subscribeCapture,
+} from "@stave/editor";
+
+export type IRInspectorTimelineProps = {
+  pinnedSnapshot: IRSnapshot | null;
+  onPin: (snap: IRSnapshot) => void;
+  onUnpin: () => void;
+  collapsed: boolean;
+  onToggleCollapsed: (next: boolean) => void;
+};
+
+/**
+ * Subscribe to the capture buffer; force a re-render on every push
+ * (or capacity clamp / clear) by bumping a version counter. Mirrors
+ * the existing useState-based subscribe pattern used by
+ * IRInspectorPanel for the live snapshot.
+ */
+function useCaptureBuffer(): readonly TimelineCaptureEntry[] {
+  const [, setVersion] = useState<number>(0);
+  useEffect(() => {
+    return subscribeCapture(() => {
+      setVersion((v) => v + 1);
+    });
+  }, []);
+  return getCaptureBuffer();
+}
+
+function formatTooltip(entry: TimelineCaptureEntry, isLive: boolean): string {
+  const iso = new Date(entry.ts).toISOString();
+  const cyc = entry.cycleCount;
+  const cycSuffix = cyc != null ? ` · cycle ${cyc.toFixed(3)}` : "";
+  const liveSuffix = isLive ? " (live)" : "";
+  return `${iso}${cycSuffix}${liveSuffix}`;
+}
+
+export function IRInspectorTimeline({
+  pinnedSnapshot,
+  onPin,
+  onUnpin,
+  collapsed,
+  onToggleCollapsed,
+}: IRInspectorTimelineProps): React.ReactElement {
+  const entries = useCaptureBuffer();
+
+  // Pin-by-reference: scan the live buffer for an entry that points
+  // at the same snapshot ref the panel currently has pinned.
+  const pinnedInBuffer = useMemo<boolean>(() => {
+    if (!pinnedSnapshot) return false;
+    for (const e of entries) {
+      if (e.snapshot === pinnedSnapshot) return true;
+    }
+    return false;
+  }, [entries, pinnedSnapshot]);
+
+  const showGhost = pinnedSnapshot != null && !pinnedInBuffer;
+
+  return (
+    <div
+      role="region"
+      aria-label="IR Inspector timeline"
+      data-testid="ir-inspector-timeline"
+      tabIndex={0}
+      style={{
+        marginTop: 12,
+        border: "1px solid var(--panel-border, rgba(128,128,128,0.2))",
+        borderRadius: 4,
+        outline: "none",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          gap: 8,
+          padding: "4px 8px",
+          fontSize: "0.8em",
+          opacity: 0.85,
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => onToggleCollapsed(!collapsed)}
+          aria-expanded={!collapsed}
+          aria-label={collapsed ? "Expand timeline" : "Collapse timeline"}
+          data-testid="ir-timeline-collapse-toggle"
+          style={{
+            background: "transparent",
+            border: "none",
+            cursor: "pointer",
+            color: "inherit",
+            display: "inline-flex",
+            alignItems: "center",
+            gap: 4,
+            padding: "2px 4px",
+            fontSize: "inherit",
+            fontWeight: 600,
+          }}
+        >
+          <span aria-hidden="true">{collapsed ? "▸" : "▾"}</span>
+          <span>Timeline</span>
+          <span style={{ opacity: 0.6, fontWeight: 400 }}>
+            ({entries.length})
+          </span>
+        </button>
+        {pinnedSnapshot != null && (
+          <button
+            type="button"
+            onClick={onUnpin}
+            data-testid="ir-timeline-unpin"
+            title="Return to live (ESC)"
+            style={{
+              padding: "2px 8px",
+              fontSize: "0.85em",
+              fontWeight: 600,
+              background: "rgba(134,239,172,0.08)",
+              color: "#86efac",
+              border: "1px solid #86efac",
+              borderRadius: 3,
+              cursor: "pointer",
+            }}
+          >
+            Unpin
+          </button>
+        )}
+      </div>
+      {!collapsed && (
+        <div
+          style={{
+            display: "flex",
+            alignItems: "stretch",
+            gap: 2,
+            padding: "6px 8px",
+            overflowX: "auto",
+            minHeight: 36,
+          }}
+        >
+          {showGhost && (
+            <div
+              data-testid="ir-timeline-ghost"
+              title="Pinned snapshot evicted from history; viewing cached reference."
+              aria-label="Pinned snapshot off-strip"
+              style={{
+                width: 6,
+                minWidth: 6,
+                height: 24,
+                borderRadius: 2,
+                border: "1px dashed #86efac",
+                background: "rgba(134,239,172,0.05)",
+                marginRight: 4,
+              }}
+            />
+          )}
+          {entries.length === 0 ? (
+            <div style={{ opacity: 0.5, fontSize: "0.8em" }}>
+              No captures yet — eval a pattern to populate the timeline.
+            </div>
+          ) : (
+            entries.map((entry, i) => {
+              const isLive = i === entries.length - 1;
+              const isPinned =
+                pinnedSnapshot != null && entry.snapshot === pinnedSnapshot;
+              return (
+                <button
+                  key={i}
+                  type="button"
+                  data-testid={`ir-timeline-tick-${i}`}
+                  data-pinned={isPinned ? "true" : undefined}
+                  data-live={isLive ? "true" : undefined}
+                  onClick={() => onPin(entry.snapshot)}
+                  title={formatTooltip(entry, isLive)}
+                  aria-label={`Pin snapshot ${i + 1} of ${entries.length}`}
+                  style={{
+                    width: 8,
+                    minWidth: 8,
+                    height: 24,
+                    padding: 0,
+                    borderRadius: 2,
+                    border: isPinned
+                      ? "2px solid #86efac"
+                      : isLive
+                      ? "1px solid var(--accent, #3b82f6)"
+                      : "1px solid var(--panel-border, rgba(128,128,128,0.3))",
+                    background: isPinned
+                      ? "rgba(134,239,172,0.25)"
+                      : isLive
+                      ? "var(--accent, #3b82f6)"
+                      : "var(--panel-active, rgba(128,128,128,0.25))",
+                    cursor: "pointer",
+                  }}
+                />
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/app/tests/ir-inspector-timeline.spec.ts
+++ b/packages/app/tests/ir-inspector-timeline.spec.ts
@@ -1,0 +1,242 @@
+/**
+ * IR Inspector — streaming timeline (Phase 19-08 PR-B).
+ *
+ * Verifies the capture-and-scrub UX, click-to-pin, J/K event step,
+ * pin-by-reference contract under FIFO eviction, and inline-viz
+ * orthogonality (PV19) when a pinned snapshot is rendered.
+ *
+ * Probes:
+ *   (a) capture-and-grow: every eval pushes a tick.
+ *   (b) FIFO eviction via the chrome trace-length input.
+ *   (c) pin past snapshot reflects across the IR tree (PV27).
+ *   (d) Unpin button returns tabs to live.
+ *   (e) ESC unpins.
+ *   (f) J/K step advances playhead and applies highlight.
+ *   (g) pin-by-reference: held snapshot survives eviction.
+ *   (h) inline-viz orthogonality: pinning does NOT drop view zones.
+ */
+
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+async function setStrudelCode(page: Page, code: string): Promise<void> {
+  const ok = await page.evaluate((c) => {
+    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+    const editors = (monaco?.editor?.getEditors?.() ?? []) as Array<{
+      getModel: () => { getLanguageId?: () => string; setValue: (s: string) => void } | null
+      focus: () => void
+    }>
+    const target =
+      editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
+    if (!target) return false
+    target.getModel()?.setValue(c)
+    target.focus()
+    return true
+  }, code)
+  expect(ok).toBe(true)
+  await page.waitForTimeout(150)
+}
+
+async function focusStrudelEditor(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+    const editors = (monaco?.editor?.getEditors?.() ?? []) as Array<{
+      getModel: () => { getLanguageId?: () => string } | null
+      focus: () => void
+    }>
+    const target =
+      editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
+    target?.focus()
+  })
+}
+
+async function evalStrudel(page: Page): Promise<void> {
+  await focusStrudelEditor(page)
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1800)
+}
+
+/**
+ * Force a fresh evaluate on a runtime that is already playing.
+ *
+ * Cmd+Enter is bound to a play/stop TOGGLE (StrudelEditorClient.tsx:504-506):
+ * pressing it on a playing runtime calls `stop()`, which does NOT fire
+ * `onEvaluateSuccess` and does NOT publish an IRSnapshot. To produce a
+ * second capture, we must explicitly stop (Cmd+.) then play (Cmd+Enter).
+ *
+ * The boot eval inside `bootInspectorWithPattern` is a single Cmd+Enter
+ * on a stopped runtime, which DOES fire fireEvaluateSuccess + publish.
+ * Every subsequent capture in the same test must use this helper.
+ *
+ * Observed via debug spec: pressing Cmd+Enter twice yields exactly one
+ * `[eval] code updated` log; using Cmd+./Cmd+Enter cycles yields one log
+ * per cycle. Plain `evalStrudel` looks identical at the keyboard layer
+ * but its runtime semantics differ depending on play state.
+ */
+async function reEvalStrudel(page: Page): Promise<void> {
+  await focusStrudelEditor(page)
+  await page.keyboard.press(`${MOD}+.`) // stop
+  await page.waitForTimeout(400)
+  await page.keyboard.press(`${MOD}+Enter`) // play → publishes IRSnapshot
+  await page.waitForTimeout(1800)
+}
+
+async function openInspectorPanel(page: Page): Promise<void> {
+  const btn = page.locator('button[aria-label="IR Inspector"]').first()
+  if (await btn.isVisible().catch(() => false)) {
+    await btn.click()
+  }
+  await page.locator('[data-testid="ir-passes-tablist"]').waitFor({ timeout: 10_000 })
+}
+
+async function bootInspectorWithPattern(page: Page, code: string): Promise<void> {
+  await page.goto('/')
+  await page.locator('.monaco-editor').waitFor({ timeout: 15_000 })
+  await setStrudelCode(page, code)
+  await evalStrudel(page)
+  await openInspectorPanel(page)
+}
+
+/**
+ * Reset the in-memory capture buffer between probes. The buffer is
+ * module-level state in the editor package and persists across page
+ * reloads only if the test reuses the same `page` (it doesn't —
+ * each test gets a fresh page). However running the spec serially
+ * within one worker means an earlier probe's evals can pollute a
+ * later probe. Each probe boots a FRESH page (via bootInspector...)
+ * so the capture buffer starts empty per Playwright's worker isolation.
+ */
+
+test.describe('IR Inspector — streaming timeline (Phase 19-08)', () => {
+  test('(a) capture-and-grow: ticks render per eval', async ({ page }) => {
+    await bootInspectorWithPattern(page, 'note("c3 e3 g3 a3")')
+    // bootInspectorWithPattern already does one eval (Cmd+Enter on a
+    // stopped runtime → publishes). Two more re-evals via stop+play
+    // cycles to force fresh fireEvaluateSuccess fan-outs.
+    await reEvalStrudel(page)
+    await reEvalStrudel(page)
+    const ticks = page.locator('[data-testid^=ir-timeline-tick-]')
+    await expect(ticks).toHaveCount(3, { timeout: 5000 })
+  })
+
+  test('(b) FIFO eviction via capacity input', async ({ page }) => {
+    await bootInspectorWithPattern(page, 'note("c3 e3 g3 a3")')
+    // Set capacity to 2 BEFORE adding more entries; the existing 1 entry
+    // stays (slice(-2) on a length-1 array is the same array).
+    const cap = page.locator('[data-testid=ir-timeline-capacity-input]')
+    await cap.fill('2')
+    // Two more re-evals — buffer holds at most 2.
+    await reEvalStrudel(page)
+    await reEvalStrudel(page)
+    const ticks = page.locator('[data-testid^=ir-timeline-tick-]')
+    await expect(ticks).toHaveCount(2)
+  })
+
+  test('(c) pin past snapshot reflects in IR tree (PV27)', async ({ page }) => {
+    await bootInspectorWithPattern(page, 'note("c3 e3 g3 a3")')
+    // Tick 0: c3-e3-g3-a3
+    await setStrudelCode(page, 'note("d4 f4 a4 b4")')
+    await reEvalStrudel(page) // tick 1: d4-f4-a4-b4
+    // Click oldest tick (the c3 entry).
+    await page.locator('[data-testid=ir-timeline-tick-0]').click()
+    const tree = page.locator('[data-testid="ir-tree-section"]')
+    // Pinned tree contains the older notes; events count reflects pinned.
+    await expect(tree).toContainText('c3')
+    await expect(tree).not.toContainText('d4')
+  })
+
+  test('(d) Unpin button returns tabs to live', async ({ page }) => {
+    await bootInspectorWithPattern(page, 'note("c3 e3 g3 a3")')
+    await setStrudelCode(page, 'note("d4 f4 a4 b4")')
+    await reEvalStrudel(page)
+    await page.locator('[data-testid=ir-timeline-tick-0]').click()
+    // Confirm pinned first.
+    const tree = page.locator('[data-testid="ir-tree-section"]')
+    await expect(tree).toContainText('c3')
+    // Unpin via the button.
+    await page.locator('[data-testid=ir-timeline-unpin]').click()
+    await expect(tree).toContainText('d4')
+    await expect(tree).not.toContainText('c3')
+  })
+
+  test('(e) ESC unpins', async ({ page }) => {
+    await bootInspectorWithPattern(page, 'note("c3 e3 g3 a3")')
+    await setStrudelCode(page, 'note("d4 f4 a4 b4")')
+    await reEvalStrudel(page)
+    await page.locator('[data-testid=ir-timeline-tick-0]').click()
+    const tree = page.locator('[data-testid="ir-tree-section"]')
+    await expect(tree).toContainText('c3')
+    // Focus the panel container and press Escape.
+    const panel = page.locator('[role="region"][aria-label="IR Inspector"]')
+    await panel.focus()
+    await page.keyboard.press('Escape')
+    await expect(tree).toContainText('d4')
+    await expect(tree).not.toContainText('c3')
+  })
+
+  test('(f) J/K step advances playhead and applies highlight', async ({ page }) => {
+    // 4-event pattern → events[] has 4 entries to step through.
+    await bootInspectorWithPattern(page, 'note("c3 e3 g3 a3")')
+    // Pin the only tick (the just-evaled snapshot).
+    await page.locator('[data-testid^=ir-timeline-tick-]').last().click()
+    // Focus the panel so keydown events route to it.
+    const panel = page.locator('[role="region"][aria-label="IR Inspector"]')
+    await panel.focus()
+    // Press J twice — playhead moves to events[2].
+    await page.keyboard.press('j')
+    await page.keyboard.press('j')
+    // Some IR row gets data-ir-node-highlight="true".
+    const highlighted = page.locator('[data-ir-node-highlight="true"]')
+    await expect(highlighted.first()).toBeVisible({ timeout: 3000 })
+    // Press K once — playhead retreats. Highlight is still present (now
+    // at events[1]). The exact node may differ; we only assert that
+    // SOME highlight remains.
+    await page.keyboard.press('k')
+    await expect(page.locator('[data-ir-node-highlight="true"]').first()).toBeVisible()
+  })
+
+  test('(g) pin-by-reference: held snapshot survives eviction', async ({ page }) => {
+    await bootInspectorWithPattern(page, 'note("c3 e3 g3 a3")')
+    // Set capacity to 2 — small enough to evict quickly.
+    await page.locator('[data-testid=ir-timeline-capacity-input]').fill('2')
+    // Pin the only entry (the c3 snapshot).
+    await page.locator('[data-testid=ir-timeline-tick-0]').click()
+    // Push 3 more re-evals (capacity 2; with 1 existing + 3 new ⇒ original
+    // entry evicts on push #3 once the buffer holds {original, push-1};
+    // push-2 then push-3 each evict the oldest).
+    await setStrudelCode(page, 'note("d4 f4 a4 b4")')
+    for (let i = 0; i < 3; i++) {
+      await reEvalStrudel(page)
+    }
+    // Pinned tree still renders the c3 snapshot — pin-by-reference contract.
+    const tree = page.locator('[data-testid="ir-tree-section"]')
+    await expect(tree).toContainText('c3')
+    // Ghost marker present (pinned snapshot is no longer in the live buffer).
+    await expect(page.locator('[data-testid=ir-timeline-ghost]')).toBeVisible()
+  })
+
+  test('(h) inline-viz orthogonality: pinning does not break Monaco view zones', async ({ page }) => {
+    // .viz() pattern uses an existing registered viz (scope is core).
+    await bootInspectorWithPattern(page, 'note("c3 e3 g3 a3").viz("scope")')
+    // The inline viz zone may or may not have a deterministic data-testid;
+    // assert that the eval produced no console errors before AND after pin.
+    const consoleErrors: string[] = []
+    page.on('pageerror', (e) => consoleErrors.push(`pageerror: ${e.message}`))
+    page.on('console', (m) => {
+      if (m.type() === 'error') consoleErrors.push(`console: ${m.text()}`)
+    })
+    await reEvalStrudel(page)
+    // Pin the latest tick.
+    await page.locator('[data-testid^=ir-timeline-tick-]').last().click()
+    // Wait for any post-pin re-render to settle.
+    await page.waitForTimeout(400)
+    // Filter framework noise.
+    const real = consoleErrors.filter(
+      (l) => !/Warning:/i.test(l) && !/DevTools/i.test(l),
+    )
+    expect(real).toEqual([])
+    // The IR tree still renders (pin worked).
+    await expect(page.locator('[data-testid="ir-tree-section"]')).toBeVisible()
+  })
+})


### PR DESCRIPTION
## Summary

PR-B for Phase 19-08 (issue #85). Lands the user-visible payoff for the streaming timeline introduced by PR-A (#86, merged): pinning, J/K event step-through, trace-length input, collapsible strip, ghost marker for evicted pins.

This depends on PR #86 having merged into `main` (it has — branch was cut from `970134d`). The data layer (FIFO ring buffer, capture-on-publish, `cycleCount` accessor, immutability invariant) is already on `main`; this PR is the UI consumer.

### What you get

- **Timeline strip** below the events table — one tick per captured snapshot, oldest on the left, live on the right.
- **Click to pin** — the four IR pass tabs derive from the pinned snapshot (frozen tree). The publisher continues feeding `setSnap(s)` in the background so the live `snap` is always current; the pin gate is purely render-side via `displaySnapshot = pinnedSnapshot ?? snap` (CONTEXT D-02).
- **Unpin button + ESC** — return to live (panel-scoped key handler; does not collide with the existing tab strip ←/→ at IRInspectorPanel.tsx:706-716).
- **J/K step-through** when pinned — walks `displaySnapshot.events[]` (audible-time order, PV28). The producing IR node receives `data-ir-node-highlight=\"true\"` + outline + accent tint (CONTEXT D-03).
- **Trace-length input** in the chrome flex (CONTEXT D-01) — sets buffer capacity, persists to localStorage `stave:inspector.timeline.capacity`. Buffer entries themselves remain in-memory per CONTEXT D-06.
- **Collapsible** — `stave:inspector.timeline.collapsed` (T-14).
- **Ghost marker** at the strip's left edge when the pinned snapshot has been FIFO-evicted from the live buffer (pin-by-reference contract holds — D-07).

### Pre-mortem traps mitigated

| Trap | How |
|---|---|
| P29 stale closure on J/K | Explicit `[pinnedSnapshot, eventCount]` dep array. ESLint react-hooks/exhaustive-deps clean. |
| Capacity write race vs pinned snapshot (#9) | Pin holds REFERENCE in React state; clamp drops the buffer entry but the held snapshot stays alive. Probe (g) verifies. |
| J/K vs ←/→ collision (#11) | J/K attaches to panelRef; ←/→ to the tab strip's own onKeyDown. Different DOM nodes. |
| Synthetic events without loc (#12) | `events[playheadIndex].loc?.[0] ?? null`; IRNodeRow check is null-safe both sides (PV24). |
| Inline-viz orthogonality (#13) | Probe (h) verifies pinning produces no console errors and view zones survive (PV19). |

### One non-anticipated trap surfaced and fixed

`getCaptureBuffer()` returns the LIVE internal array reference. FIFO eviction (`entries.shift()`) mutates that array in place — same reference, fewer elements. `useMemo([entries, ...])` saw a referentially stable dep across evictions and skipped recomputation, so `pinnedInBuffer` cached `true` forever and the ghost marker never appeared. Caught by probe (g). Fix: `useCaptureBuffer` returns `[...getCaptureBuffer()]` — fresh reference per render forces every dependent useMemo to recompute (commit \`3e67b7b\`). Codified as PV34 + P48 in the catalogues.

### Lifecycle finding (P29-adjacent)

`Cmd+Enter` is a play/stop **toggle** (StrudelEditorClient.tsx:504-506). Pressing it on a playing runtime calls `stop()`, which does NOT fire `onEvaluateSuccess` and does NOT publish an IRSnapshot. Two consecutive `Cmd+Enter` presses yield exactly ONE capture, not two. To produce a second capture in tests, must use the stop+play cycle (`Cmd+./Cmd+Enter`). Codified as the `reEvalStrudel(page)` helper in the new spec; promoted to PK9 step 8a in `.anvi/krama.md`.

## Plan + Research + Decisions

- Plan: `.planning/phases/19-pattern-ir/19-08-PLAN.md` §7 Wave 5/6/7
- Context: `.planning/phases/19-pattern-ir/19-08-CONTEXT.md` (D-01..D-07 LOCKED)
- Research: `.planning/phases/19-pattern-ir/19-08-RESEARCH.md` (insertion seams §3, Playwright helper conventions §6)
- Summary: `.planning/phases/19-pattern-ir/19-08-SUMMARY.md` extended for PR-B

## Test plan

- [x] App tsc clean
- [x] 1213 editor vitest green (unchanged from PR-A)
- [x] 56 app vitest green (unchanged)
- [x] 49 IR Inspector Playwright tests green (41 baseline + 8 new timeline probes)
- [x] AnviDev §5 self-review complete
- [x] PV27 alias contract preserved against pinned snapshot
- [x] PV24 missing-loc fallback verified
- [x] PV19 inline-viz orthogonality verified by probe (h)

closes #85

Predecessors: #69, #72, #73, #77, #78, #80, #81, #86 (PR-A merged)