### PR TITLE
Phase 20-01 PR-A: bottom-drawer infrastructure

### DIFF
--- a/packages/app/tests/bottom-drawer.spec.ts
+++ b/packages/app/tests/bottom-drawer.spec.ts
@@ -1,0 +1,224 @@
+/**
+ * Bottom drawer infrastructure — Phase 20-01 PR-A T-10.
+ *
+ * Asserts the BottomPanel surface mounted by WorkspaceShell:
+ *   1. Drawer renders with one Timeline tab.
+ *   2. Default state is closed; toggle opens; body shows the placeholder.
+ *   3. Open + height + activeTabId persist across reload (Trap 7 — assert
+ *      on `domcontentloaded`, not `load`, to catch first-paint flicker).
+ *   4. Drag handle clamps to [80, 600] (Trap 6).
+ *   5. Single-tab keyboard nav is a stable no-op.
+ *   6. Closed-state pixel cost is exactly 29px (Trap 2 proxy — combined
+ *      with the unit test that empty-registry returns null this covers
+ *      "no editor-grid theft for users who haven't interacted").
+ *   7. Vocabulary regression — drawer DOM contains none of the
+ *      forbidden IR-jargon nouns (Trap 1).
+ */
+
+import { test, expect, type Page } from '@playwright/test'
+
+const STORAGE_KEYS = {
+  height: 'stave:bottomPanel.height',
+  open: 'stave:bottomPanel.open',
+  activeTabId: 'stave:bottomPanel.activeTabId',
+} as const
+
+const FORBIDDEN_NOUN_SOURCES = [
+  'snapshot',
+  'publishirsnapshot',
+  'irevent',
+  'publishir',
+  'capturesnapshot',
+] as const
+const FORBIDDEN_NOUNS = new RegExp(FORBIDDEN_NOUN_SOURCES.join('|'), 'i')
+
+async function clearDrawerStorage(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try {
+      window.localStorage.removeItem('stave:bottomPanel.height')
+      window.localStorage.removeItem('stave:bottomPanel.open')
+      window.localStorage.removeItem('stave:bottomPanel.activeTabId')
+    } catch {
+      /* ignore */
+    }
+  })
+}
+
+async function bootShell(page: Page): Promise<void> {
+  await page.goto('/')
+  await page
+    .locator('[data-bottom-panel="root"]')
+    .waitFor({ timeout: 15_000 })
+}
+
+test.describe('Bottom drawer — infra (Phase 20-01 PR-A)', () => {
+  test('drawer renders with the seeded Timeline tab', async ({ page }) => {
+    await clearDrawerStorage(page)
+    await bootShell(page)
+    const drawer = page.locator('[data-bottom-panel="root"]')
+    await expect(drawer).toBeVisible()
+    const tab = drawer.locator('role=tab[name="Timeline"]')
+    await expect(tab).toHaveCount(1)
+  })
+
+  test('default state is closed; toggling opens and shows the placeholder', async ({
+    page,
+  }) => {
+    await clearDrawerStorage(page)
+    await bootShell(page)
+    const drawer = page.locator('[data-bottom-panel="root"]')
+    // closed: no body
+    await expect(drawer.locator('[data-bottom-panel="body"]')).toHaveCount(0)
+    // open
+    await drawer.locator('[data-bottom-panel="toggle"]').click()
+    await expect(drawer.locator('[data-bottom-panel="body"]')).toHaveCount(1)
+    // body contains the placeholder text
+    await expect(drawer.locator('[data-bottom-panel="body"]')).toContainText(
+      '(empty — wired in PR-B)',
+    )
+  })
+
+  test('persisted open + height survive reload at first paint (Trap 7)', async ({
+    page,
+  }) => {
+    // Pre-set localStorage BEFORE first navigation so the FIRST paint
+    // hydrates from these values. addInitScript runs before page scripts.
+    await page.addInitScript(
+      ([heightKey, openKey, activeKey]: readonly string[]) => {
+        try {
+          window.localStorage.setItem(heightKey, '320')
+          window.localStorage.setItem(openKey, 'true')
+          window.localStorage.setItem(activeKey, 'musical-timeline')
+        } catch {
+          /* ignore */
+        }
+      },
+      [STORAGE_KEYS.height, STORAGE_KEYS.open, STORAGE_KEYS.activeTabId],
+    )
+    // Navigate and wait for domcontentloaded — earlier than 'load' so a
+    // post-effect resize would be visible as a regression.
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    const drawer = page.locator('[data-bottom-panel="root"]')
+    await drawer.waitFor({ timeout: 15_000 })
+    // Body present immediately (open=true persisted).
+    await expect(drawer.locator('[data-bottom-panel="body"]')).toHaveCount(1)
+    // flexBasis is 320px from the persisted height.
+    const flexBasis = await drawer.evaluate(
+      (el) => (el as HTMLElement).style.flexBasis,
+    )
+    expect(flexBasis).toBe('320px')
+  })
+
+  test('closed-state height is exactly 29px (Trap 2 budget)', async ({
+    page,
+  }) => {
+    await clearDrawerStorage(page)
+    await bootShell(page)
+    const drawer = page.locator('[data-bottom-panel="root"]')
+    const flexBasis = await drawer.evaluate(
+      (el) => (el as HTMLElement).style.flexBasis,
+    )
+    expect(flexBasis).toBe('29px')
+  })
+
+  test('drag handle clamps below MIN to 80px (Trap 6)', async ({ page }) => {
+    await page.addInitScript(
+      ([heightKey, openKey]: readonly string[]) => {
+        window.localStorage.setItem(heightKey, '240')
+        window.localStorage.setItem(openKey, 'true')
+      },
+      [STORAGE_KEYS.height, STORAGE_KEYS.open],
+    )
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    const drawer = page.locator('[data-bottom-panel="root"]')
+    await drawer.waitFor({ timeout: 15_000 })
+    const handle = drawer.locator('[data-bottom-panel="resize-handle"]')
+    await expect(handle).toHaveCount(1)
+    const handleBox = await handle.boundingBox()
+    expect(handleBox).not.toBeNull()
+    if (!handleBox) throw new Error('handleBox null')
+    const startX = handleBox.x + handleBox.width / 2
+    const startY = handleBox.y + handleBox.height / 2
+    // Drag DOWN by 1000px — should clamp drawer height to MIN (80).
+    await page.mouse.move(startX, startY)
+    await page.mouse.down()
+    await page.mouse.move(startX, startY + 1000, { steps: 10 })
+    await page.mouse.up()
+    // height committed on pointerup -> read flexBasis or persisted value
+    await page.waitForTimeout(50)
+    const stored = await page.evaluate(
+      (k) => window.localStorage.getItem(k),
+      STORAGE_KEYS.height,
+    )
+    expect(Number(stored)).toBe(80)
+  })
+
+  test('drag handle clamps above MAX to 600px (Trap 6)', async ({ page }) => {
+    await page.addInitScript(
+      ([heightKey, openKey]: readonly string[]) => {
+        window.localStorage.setItem(heightKey, '500')
+        window.localStorage.setItem(openKey, 'true')
+      },
+      [STORAGE_KEYS.height, STORAGE_KEYS.open],
+    )
+    await page.goto('/', { waitUntil: 'domcontentloaded' })
+    const drawer = page.locator('[data-bottom-panel="root"]')
+    await drawer.waitFor({ timeout: 15_000 })
+    const handle = drawer.locator('[data-bottom-panel="resize-handle"]')
+    const handleBox = await handle.boundingBox()
+    if (!handleBox) throw new Error('handleBox null')
+    const startX = handleBox.x + handleBox.width / 2
+    const startY = handleBox.y + handleBox.height / 2
+    // Drag UP by 2000px — should clamp drawer height to MAX (600).
+    await page.mouse.move(startX, startY)
+    await page.mouse.down()
+    await page.mouse.move(startX, startY - 2000, { steps: 10 })
+    await page.mouse.up()
+    await page.waitForTimeout(50)
+    const stored = await page.evaluate(
+      (k) => window.localStorage.getItem(k),
+      STORAGE_KEYS.height,
+    )
+    expect(Number(stored)).toBe(600)
+  })
+
+  test('single-tab keyboard nav is a stable no-op', async ({ page }) => {
+    await clearDrawerStorage(page)
+    await bootShell(page)
+    const tablist = page.locator('[role="tablist"][aria-label="Bottom panel tabs"]')
+    await expect(tablist).toHaveCount(1)
+    const tab = tablist.locator('role=tab[name="Timeline"]')
+    await tab.focus()
+    // Press ArrowRight; with a single tab this is a no-op (still selected).
+    await page.keyboard.press('ArrowRight')
+    await expect(tab).toHaveAttribute('aria-selected', 'true')
+    await page.keyboard.press('ArrowLeft')
+    await expect(tab).toHaveAttribute('aria-selected', 'true')
+  })
+
+  test('vocabulary regression — drawer DOM contains no IR-jargon (Trap 1)', async ({
+    page,
+  }) => {
+    await clearDrawerStorage(page)
+    await bootShell(page)
+    const drawer = page.locator('[data-bottom-panel="root"]')
+    // Closed
+    {
+      const text = (await drawer.textContent()) ?? ''
+      expect(text.toLowerCase()).not.toMatch(FORBIDDEN_NOUNS)
+    }
+    // Open
+    await drawer.locator('[data-bottom-panel="toggle"]').click()
+    {
+      const text = (await drawer.textContent()) ?? ''
+      expect(text.toLowerCase()).not.toMatch(FORBIDDEN_NOUNS)
+    }
+    // Aria-labels too
+    const ariaLabels = await drawer.locator('[aria-label]').evaluateAll(
+      (els) => els.map((el) => el.getAttribute('aria-label') ?? ''),
+    )
+    for (const label of ariaLabels) {
+      expect(label.toLowerCase()).not.toMatch(FORBIDDEN_NOUNS)
+    }
+  })
+})

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -286,6 +286,30 @@ export {
   subscribeIRSnapshot,
 } from './engine/irInspector'
 
+// Phase 20-01 PR-A — bottom-drawer infrastructure.
+// PK10 propagation: the registry + component + types must be exported
+// from the top-level barrel so @stave/app and PR-B can import them.
+// `__resetBottomPanelRegistryForTest` is intentionally NOT exported —
+// test-internal; tests import from the module path directly. Verified
+// by grep on packages/editor/dist/index.cjs.
+export { BottomPanel } from './workspace/bottomPanel/BottomPanel'
+export type { BottomPanelTab } from './workspace/bottomPanel/bottomPanelRegistry'
+export {
+  registerBottomPanelTab,
+  unregisterBottomPanelTab,
+  listBottomPanelTabs,
+  getBottomPanelTab,
+  subscribeToBottomPanelTabs,
+} from './workspace/bottomPanel/bottomPanelRegistry'
+export {
+  BOTTOM_PANEL_HEIGHT_KEY,
+  BOTTOM_PANEL_OPEN_KEY,
+  BOTTOM_PANEL_ACTIVE_TAB_KEY,
+  BOTTOM_PANEL_HEIGHT_MIN,
+  BOTTOM_PANEL_HEIGHT_MAX,
+  BOTTOM_PANEL_HEIGHT_DEFAULT,
+} from './workspace/bottomPanel/persistence'
+
 // Phase 19-08 — IR Inspector streaming timeline capture buffer.
 // Fed by every publishIRSnapshot fan-out (PK9 step 8); consumed by the
 // app-side IRInspectorTimeline strip (PR-B). __resetCaptureForTest is

--- a/packages/editor/src/workspace/WorkspaceShell.tsx
+++ b/packages/editor/src/workspace/WorkspaceShell.tsx
@@ -147,6 +147,7 @@ import {
   removeGroup as layoutRemoveGroup,
 } from './groupLayout'
 import { findBuiltinExampleSource } from './builtinExampleSources'
+import { BottomPanel } from './bottomPanel/BottomPanel'
 
 /**
  * Exhaustiveness helper used inside the tab dispatch switch. If TypeScript
@@ -2313,54 +2314,88 @@ export const WorkspaceShell = forwardRef<WorkspaceShellHandle, WorkspaceShellPro
        * column only unmounts that column's subtree, not the whole
        * shell.
        */}
-      {totalGroupCount === 0 ? (
-        <div
-          data-testid="workspace-shell-empty"
-          style={{
-            flex: 1,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            color: 'var(--foreground-muted)',
-            fontSize: 12,
-          }}
-        >
-          Drop a tab here
-        </div>
-      ) : layout.length === 1 && layout[0].length === 1 ? (
-        (() => {
-          const g = groups.get(layout[0][0])
-          return g ? renderGroup(g) : null
-        })()
-      ) : (
-        <SplitPane direction="horizontal">
-          {layout.map((column, colIdx) => {
-            if (column.length === 1) {
-              const g = groups.get(column[0])
+      {/*
+       * Groups-area container — Phase 20-01 PR-A (DA-01).
+       *
+       * The shell's existing groups/SplitPane logic is unchanged inside
+       * this wrapper. The wrapper exists so the BottomPanel sibling
+       * (added below) can claim its own auto-height while the groups
+       * area still consumes `flex: 1` of the remaining shell space.
+       *
+       * `minHeight: 0` is load-bearing — without it the inner SplitPane
+       * doesn't shrink when the BottomPanel grows, defeating the resize.
+       */}
+      <div
+        data-workspace-groups="container"
+        style={{
+          flex: 1,
+          minHeight: 0,
+          display: 'flex',
+          flexDirection: 'column',
+        }}
+      >
+        {totalGroupCount === 0 ? (
+          <div
+            data-testid="workspace-shell-empty"
+            style={{
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: 'var(--foreground-muted)',
+              fontSize: 12,
+            }}
+          >
+            Drop a tab here
+          </div>
+        ) : layout.length === 1 && layout[0].length === 1 ? (
+          (() => {
+            const g = groups.get(layout[0][0])
+            return g ? renderGroup(g) : null
+          })()
+        ) : (
+          <SplitPane direction="horizontal">
+            {layout.map((column, colIdx) => {
+              if (column.length === 1) {
+                const g = groups.get(column[0])
+                return (
+                  <React.Fragment key={`col-${colIdx}-${column[0]}`}>
+                    {g ? renderGroup(g) : null}
+                  </React.Fragment>
+                )
+              }
               return (
-                <React.Fragment key={`col-${colIdx}-${column[0]}`}>
-                  {g ? renderGroup(g) : null}
-                </React.Fragment>
+                <SplitPane
+                  key={`col-${colIdx}-${column.join('+')}`}
+                  direction="vertical"
+                >
+                  {column.map((gid) => {
+                    const g = groups.get(gid)
+                    return (
+                      <React.Fragment key={gid}>
+                        {g ? renderGroup(g) : null}
+                      </React.Fragment>
+                    )
+                  })}
+                </SplitPane>
               )
-            }
-            return (
-              <SplitPane
-                key={`col-${colIdx}-${column.join('+')}`}
-                direction="vertical"
-              >
-                {column.map((gid) => {
-                  const g = groups.get(gid)
-                  return (
-                    <React.Fragment key={gid}>
-                      {g ? renderGroup(g) : null}
-                    </React.Fragment>
-                  )
-                })}
-              </SplitPane>
-            )
-          })}
-        </SplitPane>
-      )}
+            })}
+          </SplitPane>
+        )}
+      </div>
+
+      {/*
+       * Bottom drawer — Phase 20-01 PR-A (DA-01 / DA-04).
+       *
+       * Mounted as a sibling AFTER the groups container so the editor
+       * grid takes flex:1 and the drawer takes its auto-height
+       * contribution. Default closed -> ~29px header strip; user
+       * expands to expose the body. Tab content is contributed via the
+       * `bottomPanelRegistry` singleton; PR-A seeds a placeholder
+       * `Timeline` tab via `seedTabs.ts`. PR-B (MusicalTimeline) will
+       * replace by re-registering under the same id (idempotent).
+       */}
+      <BottomPanel />
 
       {/*
        * Guide line overlay — a shell-level element that previews where

--- a/packages/editor/src/workspace/bottomPanel/BottomPanel.tsx
+++ b/packages/editor/src/workspace/bottomPanel/BottomPanel.tsx
@@ -1,0 +1,469 @@
+/**
+ * BottomPanel — reusable bottom-drawer component for the editor surface.
+ *
+ * Mounted by `WorkspaceShell` below the groups area. Hosts a tab bar
+ * with one active tab + a body. Tab content is contributed externally
+ * via `bottomPanelRegistry` (DA-05); PR-A seeds a placeholder
+ * "Timeline" tab so the surface is reviewable before PR-B fills it.
+ *
+ * Closed-state pixel cost: ~29px (28px header + 1px top border). When
+ * zero tabs are registered the component returns `null` (true zero
+ * shift — Trap 2). Default open=false so existing users see only the
+ * 29px header strip until they expand the drawer.
+ *
+ * Persistence: height + open + activeTabId hydrate from localStorage in
+ * `useState` initializers (Trap 7 — no first-paint flicker). Writes
+ * happen in commit-time effects + a pagehide flush for the height.
+ *
+ * Audience: musician (PV35). Vocabulary lock (PV32 / D-06): the only
+ * strings PR-A introduces are "Hide panel" / "Show panel" /
+ * "Bottom panel" / "Bottom panel tabs" / "Resize bottom panel". Tab
+ * titles are sourced from the registry (PR-A's seed uses "Timeline").
+ *
+ * Phase 20-01 PR-A.
+ */
+
+import * as React from 'react'
+
+import {
+  type BottomPanelTab,
+  listBottomPanelTabs,
+  subscribeToBottomPanelTabs,
+} from './bottomPanelRegistry'
+import {
+  BOTTOM_PANEL_HEIGHT_MIN,
+  BOTTOM_PANEL_HEIGHT_MAX,
+  clampHeight,
+  readPersistedActiveTabId,
+  readPersistedHeight,
+  readPersistedOpen,
+  writePersistedActiveTabId,
+  writePersistedHeight,
+  writePersistedOpen,
+} from './persistence'
+// Module-side-effect import: registers the placeholder Timeline tab at
+// first bundle load (DA-09 / T-06). PR-B replaces by re-registering the
+// same id (idempotent).
+import './seedTabs'
+
+const HEADER_HEIGHT = 28
+const RESIZE_HANDLE_HEIGHT = 4
+const CLOSED_HEIGHT = HEADER_HEIGHT + 1 // +1 for the 1px top border
+
+// ---------------------------------------------------------------------------
+// useDragResize — pointer-event-based vertical resize hook (DA-03 / T-05).
+// ---------------------------------------------------------------------------
+
+interface UseDragResizeOptions {
+  readonly initial: number
+  readonly min: number
+  readonly max: number
+  readonly onCommit: (value: number) => void
+}
+
+interface DragHandleProps {
+  readonly onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void
+  readonly onPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void
+  readonly onPointerUp: (e: React.PointerEvent<HTMLDivElement>) => void
+  readonly onPointerCancel: (e: React.PointerEvent<HTMLDivElement>) => void
+}
+
+interface UseDragResizeResult {
+  readonly value: number
+  readonly setValue: (v: number) => void
+  readonly handleProps: DragHandleProps
+  readonly dragging: boolean
+}
+
+/**
+ * Pure inversion math — drag UP increases drawer height. Exported so
+ * the unit test can exercise the math without touching the DOM
+ * (Trap 10: jsdom doesn't fire PointerEvent like browsers).
+ */
+export function computeNewHeight(
+  startY: number,
+  currentY: number,
+  startHeight: number,
+): number {
+  return startHeight + (startY - currentY)
+}
+
+function useDragResize(opts: UseDragResizeOptions): UseDragResizeResult {
+  const [value, setValueState] = React.useState<number>(opts.initial)
+  const [dragging, setDragging] = React.useState(false)
+
+  // Refs hold drag transients so pointermove handler does NOT close over
+  // stale React state (P29 — stale useCallback closure).
+  const startYRef = React.useRef<number>(0)
+  const startValueRef = React.useRef<number>(opts.initial)
+  const pointerIdRef = React.useRef<number | null>(null)
+  const draggingRef = React.useRef<boolean>(false)
+  const minRef = React.useRef(opts.min)
+  const maxRef = React.useRef(opts.max)
+  React.useEffect(() => {
+    minRef.current = opts.min
+    maxRef.current = opts.max
+  }, [opts.min, opts.max])
+
+  // Public setter — also writes to ref so a programmatic set during a
+  // drag doesn't get clobbered on the next pointermove.
+  const setValue = React.useCallback((v: number) => {
+    const clamped = clampHeight(v)
+    startValueRef.current = clamped
+    setValueState(clamped)
+  }, [])
+
+  const onPointerDown = React.useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      e.preventDefault()
+      pointerIdRef.current = e.pointerId
+      startYRef.current = e.clientY
+      startValueRef.current = value
+      draggingRef.current = true
+      setDragging(true)
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId)
+      } catch {
+        /* setPointerCapture can throw if the pointer is not active */
+      }
+    },
+    [value],
+  )
+
+  const endDrag = React.useCallback(
+    (e: React.PointerEvent<HTMLDivElement>, commit: boolean) => {
+      if (!draggingRef.current) return
+      draggingRef.current = false
+      setDragging(false)
+      const id = pointerIdRef.current
+      pointerIdRef.current = null
+      try {
+        if (id != null) e.currentTarget.releasePointerCapture(id)
+      } catch {
+        /* may already be released */
+      }
+      if (commit) opts.onCommit(value)
+    },
+    [opts, value],
+  )
+
+  const onPointerMove = React.useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!draggingRef.current) return
+      const next = computeNewHeight(
+        startYRef.current,
+        e.clientY,
+        startValueRef.current,
+      )
+      const clamped = Math.max(
+        minRef.current,
+        Math.min(maxRef.current, Number.isFinite(next) ? next : startValueRef.current),
+      )
+      setValueState(clamped)
+    },
+    [],
+  )
+
+  const onPointerUp = React.useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      endDrag(e, true)
+    },
+    [endDrag],
+  )
+
+  const onPointerCancel = React.useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      endDrag(e, false)
+    },
+    [endDrag],
+  )
+
+  return {
+    value,
+    setValue,
+    handleProps: { onPointerDown, onPointerMove, onPointerUp, onPointerCancel },
+    dragging,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// BottomPanel component
+// ---------------------------------------------------------------------------
+
+function renderTabBody(tab: BottomPanelTab): React.ReactNode {
+  if (typeof tab.content === 'function') {
+    return (tab.content as () => React.ReactNode)()
+  }
+  return tab.content
+}
+
+function pickInitialActiveTabId(
+  tabs: readonly BottomPanelTab[],
+): string | null {
+  const stored = readPersistedActiveTabId()
+  if (stored && tabs.some((t) => t.id === stored)) return stored
+  return tabs[0]?.id ?? null
+}
+
+export function BottomPanel(): React.ReactElement | null {
+  // Hydrate everything in initializers — Trap 7. Reads are SSR-safe.
+  const [tabs, setTabs] = React.useState<readonly BottomPanelTab[]>(() =>
+    listBottomPanelTabs(),
+  )
+  const [open, setOpen] = React.useState<boolean>(readPersistedOpen)
+  const [height, setHeight] = React.useState<number>(readPersistedHeight)
+  const [activeTabId, setActiveTabId] = React.useState<string | null>(() =>
+    pickInitialActiveTabId(listBottomPanelTabs()),
+  )
+
+  // Subscribe to registry changes so a later registerBottomPanelTab
+  // (e.g., PR-B replacing the placeholder) rerenders the bar.
+  React.useEffect(() => {
+    return subscribeToBottomPanelTabs(() => {
+      const next = listBottomPanelTabs()
+      setTabs(next)
+      // If the active tab was removed, fall back to the first remaining.
+      setActiveTabId((curr) => {
+        if (curr && next.some((t) => t.id === curr)) return curr
+        return next[0]?.id ?? null
+      })
+    })
+  }, [])
+
+  // Persist open + activeTabId on change.
+  React.useEffect(() => {
+    writePersistedOpen(open)
+  }, [open])
+  React.useEffect(() => {
+    writePersistedActiveTabId(activeTabId)
+  }, [activeTabId])
+
+  // Drag-resize hook (T-05). Commits to React state + persistence on
+  // pointerup; live drag updates the hook's internal value only.
+  const drag = useDragResize({
+    initial: height,
+    min: BOTTOM_PANEL_HEIGHT_MIN,
+    max: BOTTOM_PANEL_HEIGHT_MAX,
+    onCommit: (v) => {
+      setHeight(v)
+      writePersistedHeight(v)
+    },
+  })
+
+  // pagehide flush — defense against unload race for a not-yet-committed
+  // drag (e.g., user grabs handle then closes tab without releasing).
+  React.useEffect(() => {
+    const flush = () => writePersistedHeight(height)
+    window.addEventListener('pagehide', flush)
+    return () => window.removeEventListener('pagehide', flush)
+  }, [height])
+
+  // Refs for tab buttons so keyboard navigation can move focus.
+  const tabButtonRefs = React.useRef<Map<string, HTMLButtonElement>>(new Map())
+  const setTabButtonRef = React.useCallback(
+    (id: string) => (el: HTMLButtonElement | null) => {
+      if (el) tabButtonRefs.current.set(id, el)
+      else tabButtonRefs.current.delete(id)
+    },
+    [],
+  )
+
+  const focusTab = React.useCallback((id: string) => {
+    const el = tabButtonRefs.current.get(id)
+    if (el) el.focus()
+  }, [])
+
+  const onTabsKeyDown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (tabs.length === 0) return
+      const idx = tabs.findIndex((t) => t.id === activeTabId)
+      const safeIdx = idx < 0 ? 0 : idx
+      let next = safeIdx
+      if (e.key === 'ArrowRight') {
+        next = (safeIdx + 1) % tabs.length
+      } else if (e.key === 'ArrowLeft') {
+        next = (safeIdx - 1 + tabs.length) % tabs.length
+      } else if (e.key === 'Home') {
+        next = 0
+      } else if (e.key === 'End') {
+        next = tabs.length - 1
+      } else {
+        return
+      }
+      e.preventDefault()
+      const target = tabs[next]
+      if (target) {
+        setActiveTabId(target.id)
+        // Move focus next tick so the rerender's tabIndex updates land.
+        queueMicrotask(() => focusTab(target.id))
+      }
+    },
+    [tabs, activeTabId, focusTab],
+  )
+
+  // True zero-pixel cost when no tabs are registered (Trap 2).
+  if (tabs.length === 0) return null
+
+  // While dragging, render with the live hook value so the drawer
+  // visibly resizes; otherwise use the committed height.
+  const renderHeight = drag.dragging ? drag.value : height
+
+  return (
+    <div
+      data-bottom-panel="root"
+      role="region"
+      aria-label="Bottom panel"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        flexBasis: open ? renderHeight : CLOSED_HEIGHT,
+        flexShrink: 0,
+        flexGrow: 0,
+        borderTop: '1px solid var(--border-subtle, rgba(255,255,255,0.08))',
+        background: 'var(--background, #0f0f12)',
+        color: 'var(--foreground, #e6e6ec)',
+        overflow: 'hidden',
+        position: 'relative',
+      }}
+    >
+      {open && (
+        <div
+          data-bottom-panel="resize-handle"
+          role="separator"
+          aria-orientation="horizontal"
+          aria-label="Resize bottom panel"
+          tabIndex={-1}
+          {...drag.handleProps}
+          style={{
+            height: RESIZE_HANDLE_HEIGHT,
+            cursor: 'ns-resize',
+            background: 'transparent',
+            // A subtle hover affordance via the user agent's outline isn't
+            // enough — give the handle a visible top hairline so the user
+            // sees something to grab. Stays inside the closed-state budget.
+            flex: '0 0 auto',
+            touchAction: 'none',
+          }}
+        />
+      )}
+      <div
+        data-bottom-panel="header"
+        style={{
+          height: HEADER_HEIGHT,
+          minHeight: HEADER_HEIGHT,
+          display: 'flex',
+          alignItems: 'stretch',
+          borderBottom: open
+            ? '1px solid var(--border-subtle, rgba(255,255,255,0.06))'
+            : 'none',
+          flex: '0 0 auto',
+        }}
+      >
+        <div
+          role="tablist"
+          aria-label="Bottom panel tabs"
+          onKeyDown={onTabsKeyDown}
+          style={{
+            display: 'flex',
+            alignItems: 'stretch',
+            flex: 1,
+            minWidth: 0,
+            overflow: 'hidden',
+          }}
+        >
+          {tabs.map((tab) => {
+            const selected = tab.id === activeTabId
+            return (
+              <button
+                key={tab.id}
+                ref={setTabButtonRef(tab.id)}
+                role="tab"
+                type="button"
+                aria-selected={selected}
+                tabIndex={selected ? 0 : -1}
+                data-tab-id={tab.id}
+                onClick={() => {
+                  // Clicking a closed-drawer tab opens the drawer in
+                  // addition to selecting; matches VSCode's terminal
+                  // header behavior.
+                  if (!open) setOpen(true)
+                  setActiveTabId(tab.id)
+                }}
+                style={{
+                  appearance: 'none',
+                  border: 'none',
+                  background: 'transparent',
+                  color: selected
+                    ? 'var(--foreground, #e6e6ec)'
+                    : 'var(--foreground-muted, #a0a0aa)',
+                  padding: '0 12px',
+                  fontSize: 12,
+                  fontFamily:
+                    'system-ui, -apple-system, "Segoe UI", sans-serif',
+                  cursor: 'pointer',
+                  borderTop: selected
+                    ? '1px solid var(--accent, #8b5cf6)'
+                    : '1px solid transparent',
+                  outline: 'none',
+                }}
+              >
+                {tab.title}
+              </button>
+            )
+          })}
+        </div>
+        <button
+          data-bottom-panel="toggle"
+          type="button"
+          aria-label={open ? 'Hide panel' : 'Show panel'}
+          aria-expanded={open}
+          onClick={() => setOpen((v) => !v)}
+          style={{
+            appearance: 'none',
+            border: 'none',
+            background: 'transparent',
+            color: 'var(--foreground-muted, #a0a0aa)',
+            padding: '0 10px',
+            cursor: 'pointer',
+            fontSize: 12,
+          }}
+        >
+          {open ? '▾' : '▴'}
+        </button>
+      </div>
+      {open && (
+        <div
+          data-bottom-panel="body"
+          style={{
+            flex: 1,
+            minHeight: 0,
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
+          }}
+        >
+          {tabs.map((tab) => {
+            const selected = tab.id === activeTabId
+            return (
+              <div
+                key={tab.id}
+                role="tabpanel"
+                aria-labelledby={tab.id}
+                hidden={!selected}
+                style={{
+                  display: selected ? 'flex' : 'none',
+                  flexDirection: 'column',
+                  flex: 1,
+                  minHeight: 0,
+                  overflow: 'auto',
+                }}
+              >
+                {renderTabBody(tab)}
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/editor/src/workspace/bottomPanel/__tests__/BottomPanel.test.tsx
+++ b/packages/editor/src/workspace/bottomPanel/__tests__/BottomPanel.test.tsx
@@ -1,0 +1,296 @@
+/**
+ * BottomPanel component tests — Phase 20-01 PR-A T-07.
+ *
+ * Covers: zero-tabs returns null (Trap 2 — true zero pixel cost), seeded
+ * render, default closed state, toggle to open, persisted state hydrates
+ * before first paint (Trap 7), keyboard tab nav, display:none preserves
+ * mount across tab switches (DA-02), vocabulary regression (Trap 1).
+ */
+
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
+import * as React from 'react'
+import { act } from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+// Install a Map-backed mock localStorage. jsdom's stub here lacks
+// setItem/getItem/clear; production code guards via safeLocalStorage,
+// but BottomPanel persistence reads/writes need a working store to
+// exercise the hydration path.
+function installMockLocalStorage(): void {
+  const store = new Map<string, string>()
+  const mock: Storage = {
+    get length() {
+      return store.size
+    },
+    clear: () => store.clear(),
+    getItem: (k: string) => (store.has(k) ? (store.get(k) as string) : null),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    removeItem: (k: string) => {
+      store.delete(k)
+    },
+    setItem: (k: string, v: string) => {
+      store.set(k, String(v))
+    },
+  }
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: mock,
+  })
+}
+
+beforeAll(installMockLocalStorage)
+
+import { BottomPanel } from '../BottomPanel'
+import {
+  __resetBottomPanelRegistryForTest,
+  registerBottomPanelTab,
+} from '../bottomPanelRegistry'
+import {
+  BOTTOM_PANEL_ACTIVE_TAB_KEY,
+  BOTTOM_PANEL_HEIGHT_KEY,
+  BOTTOM_PANEL_OPEN_KEY,
+} from '../persistence'
+
+const FORBIDDEN_NOUNS =
+  /snapshot|publishirsnapshot|loc\b|irevent|publishir/i
+
+beforeEach(() => {
+  // Reset BEFORE each test so the seedTabs side-effect import (which
+  // ran when BottomPanel.tsx loaded) doesn't leak the placeholder
+  // "Timeline" tab into "zero tabs registered" assertions.
+  __resetBottomPanelRegistryForTest()
+  window.localStorage.clear()
+})
+
+afterEach(() => {
+  __resetBottomPanelRegistryForTest()
+  window.localStorage.clear()
+})
+
+function registerStubTab(
+  id: string,
+  title: string,
+  body: React.ReactNode = null,
+): void {
+  registerBottomPanelTab({
+    id,
+    title,
+    content: body ?? <div data-testid={`stub-${id}`}>{title}-body</div>,
+  })
+}
+
+describe('BottomPanel — zero-cost when empty', () => {
+  it('renders nothing when no tabs are registered (Trap 2)', () => {
+    const { container } = render(<BottomPanel />)
+    expect(container.firstChild).toBeNull()
+  })
+})
+
+describe('BottomPanel — seeded render', () => {
+  beforeEach(() => {
+    registerStubTab('a', 'Alpha')
+  })
+
+  it('renders the bottom-panel root with the registered tab in the tab bar', () => {
+    render(<BottomPanel />)
+    const root = screen.getByRole('region', { name: /bottom panel/i })
+    expect(root).toBeTruthy()
+    const tab = screen.getByRole('tab', { name: 'Alpha' })
+    expect(tab.getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('default state is closed: no body in DOM', () => {
+    render(<BottomPanel />)
+    expect(screen.queryByRole('tabpanel')).toBeNull()
+  })
+
+  it('clicking the toggle opens the drawer; body is mounted', () => {
+    render(<BottomPanel />)
+    const toggle = screen.getByRole('button', { name: /show panel/i })
+    fireEvent.click(toggle)
+    expect(screen.getByRole('tabpanel')).toBeTruthy()
+    // ARIA label flips
+    expect(screen.getByRole('button', { name: /hide panel/i })).toBeTruthy()
+  })
+
+  it('closed-state height is exactly 29px (Trap 2 budget)', () => {
+    const { container } = render(<BottomPanel />)
+    const root = container.querySelector('[data-bottom-panel="root"]') as HTMLElement
+    expect(root.style.flexBasis).toBe('29px')
+  })
+
+  it('open-state flexBasis equals the persisted height; default 240', () => {
+    render(<BottomPanel />)
+    const toggle = screen.getByRole('button', { name: /show panel/i })
+    fireEvent.click(toggle)
+    const root = screen.getByRole('region', { name: /bottom panel/i })
+    expect((root as HTMLElement).style.flexBasis).toBe('240px')
+  })
+
+  it('clicking a tab when closed opens the drawer and selects the tab', () => {
+    registerStubTab('b', 'Beta')
+    render(<BottomPanel />)
+    // default: closed; activeTabId = first ('a')
+    const beta = screen.getByRole('tab', { name: 'Beta' })
+    fireEvent.click(beta)
+    // body should be present and Beta selected
+    expect(screen.getByRole('tabpanel')).toBeTruthy()
+    expect(beta.getAttribute('aria-selected')).toBe('true')
+  })
+})
+
+describe('BottomPanel — keyboard tab navigation', () => {
+  beforeEach(() => {
+    registerStubTab('a', 'Alpha')
+    registerStubTab('b', 'Beta')
+    registerStubTab('c', 'Gamma')
+  })
+
+  it('ArrowRight cycles forward and wraps; ArrowLeft cycles back and wraps', () => {
+    render(<BottomPanel />)
+    const tablist = screen.getByRole('tablist', { name: /bottom panel tabs/i })
+    // start: Alpha selected
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' })
+    expect(
+      screen.getByRole('tab', { name: 'Beta' }).getAttribute('aria-selected'),
+    ).toBe('true')
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' })
+    expect(
+      screen.getByRole('tab', { name: 'Gamma' }).getAttribute('aria-selected'),
+    ).toBe('true')
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' })
+    // wraps to Alpha
+    expect(
+      screen.getByRole('tab', { name: 'Alpha' }).getAttribute('aria-selected'),
+    ).toBe('true')
+    fireEvent.keyDown(tablist, { key: 'ArrowLeft' })
+    expect(
+      screen.getByRole('tab', { name: 'Gamma' }).getAttribute('aria-selected'),
+    ).toBe('true')
+  })
+
+  it('Home jumps to the first tab; End jumps to the last', () => {
+    render(<BottomPanel />)
+    const tablist = screen.getByRole('tablist', { name: /bottom panel tabs/i })
+    fireEvent.keyDown(tablist, { key: 'End' })
+    expect(
+      screen.getByRole('tab', { name: 'Gamma' }).getAttribute('aria-selected'),
+    ).toBe('true')
+    fireEvent.keyDown(tablist, { key: 'Home' })
+    expect(
+      screen.getByRole('tab', { name: 'Alpha' }).getAttribute('aria-selected'),
+    ).toBe('true')
+  })
+
+  it('single tab + ArrowRight is a stable no-op (no error)', () => {
+    __resetBottomPanelRegistryForTest()
+    registerStubTab('only', 'Only')
+    render(<BottomPanel />)
+    const tablist = screen.getByRole('tablist', { name: /bottom panel tabs/i })
+    fireEvent.keyDown(tablist, { key: 'ArrowRight' })
+    expect(
+      screen.getByRole('tab', { name: 'Only' }).getAttribute('aria-selected'),
+    ).toBe('true')
+  })
+})
+
+describe('BottomPanel — DA-02 display:none preserves child mount across tab switches', () => {
+  it('mount count for each tab body stays at 1 across switches', () => {
+    let alphaMounts = 0
+    let betaMounts = 0
+    function AlphaBody(): React.ReactElement {
+      React.useEffect(() => {
+        alphaMounts++
+      }, [])
+      return <div data-testid="alpha-body">Alpha</div>
+    }
+    function BetaBody(): React.ReactElement {
+      React.useEffect(() => {
+        betaMounts++
+      }, [])
+      return <div data-testid="beta-body">Beta</div>
+    }
+    registerBottomPanelTab({
+      id: 'a',
+      title: 'Alpha',
+      content: <AlphaBody />,
+    })
+    registerBottomPanelTab({ id: 'b', title: 'Beta', content: <BetaBody /> })
+    render(<BottomPanel />)
+    // open the drawer to mount bodies
+    fireEvent.click(screen.getByRole('button', { name: /show panel/i }))
+    expect(alphaMounts).toBe(1)
+    expect(betaMounts).toBe(1)
+    // switch to Beta
+    fireEvent.click(screen.getByRole('tab', { name: 'Beta' }))
+    // and back to Alpha
+    fireEvent.click(screen.getByRole('tab', { name: 'Alpha' }))
+    // mount counts must NOT increment — display:none keeps them mounted
+    expect(alphaMounts).toBe(1)
+    expect(betaMounts).toBe(1)
+  })
+})
+
+describe('BottomPanel — Trap 7 hydration before first paint', () => {
+  it('persisted activeTabId is applied on FIRST render (no setState rerender)', () => {
+    registerStubTab('first', 'First')
+    registerStubTab('second', 'Second')
+    window.localStorage.setItem(BOTTOM_PANEL_ACTIVE_TAB_KEY, 'second')
+    render(<BottomPanel />)
+    expect(
+      screen.getByRole('tab', { name: 'Second' }).getAttribute('aria-selected'),
+    ).toBe('true')
+  })
+
+  it('persisted open=true is applied on FIRST render (body present immediately)', () => {
+    registerStubTab('a', 'Alpha')
+    window.localStorage.setItem(BOTTOM_PANEL_OPEN_KEY, 'true')
+    render(<BottomPanel />)
+    expect(screen.queryByRole('tabpanel')).not.toBeNull()
+  })
+
+  it('persisted height applied on FIRST render', () => {
+    registerStubTab('a', 'Alpha')
+    window.localStorage.setItem(BOTTOM_PANEL_OPEN_KEY, 'true')
+    window.localStorage.setItem(BOTTOM_PANEL_HEIGHT_KEY, '320')
+    const { container } = render(<BottomPanel />)
+    const root = container.querySelector('[data-bottom-panel="root"]') as HTMLElement
+    expect(root.style.flexBasis).toBe('320px')
+  })
+})
+
+describe('BottomPanel — registry sync (registered after mount)', () => {
+  it('subscribes to registry; later registrations appear without remount', () => {
+    registerStubTab('a', 'Alpha')
+    render(<BottomPanel />)
+    expect(screen.getByRole('tab', { name: 'Alpha' })).toBeTruthy()
+    act(() => {
+      registerStubTab('b', 'Beta')
+    })
+    expect(screen.getByRole('tab', { name: 'Beta' })).toBeTruthy()
+  })
+})
+
+describe('BottomPanel — vocabulary regression (Trap 1)', () => {
+  it('rendered DOM contains none of the forbidden IR-vocabulary nouns', () => {
+    registerStubTab('a', 'Alpha')
+    const { container } = render(<BottomPanel />)
+    // closed
+    expect(container.textContent ?? '').not.toMatch(FORBIDDEN_NOUNS)
+    // open
+    fireEvent.click(screen.getByRole('button', { name: /show panel/i }))
+    expect(container.textContent ?? '').not.toMatch(FORBIDDEN_NOUNS)
+  })
+
+  it('aria labels do not contain forbidden nouns', () => {
+    registerStubTab('a', 'Alpha')
+    const { container } = render(<BottomPanel />)
+    fireEvent.click(screen.getByRole('button', { name: /show panel/i }))
+    const allAria = Array.from(
+      container.querySelectorAll('[aria-label]'),
+    ).map((el) => el.getAttribute('aria-label') ?? '')
+    for (const label of allAria) {
+      expect(label).not.toMatch(FORBIDDEN_NOUNS)
+    }
+  })
+})

--- a/packages/editor/src/workspace/bottomPanel/__tests__/bottomPanelRegistry.test.ts
+++ b/packages/editor/src/workspace/bottomPanel/__tests__/bottomPanelRegistry.test.ts
@@ -1,0 +1,113 @@
+/**
+ * bottomPanelRegistry tests — Phase 20-01 PR-A T-02.
+ *
+ * Covers register/unregister/list/get/subscribe + idempotent replace +
+ * fresh-array contract (PV34) + test-isolation reset (Trap 9).
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  registerBottomPanelTab,
+  unregisterBottomPanelTab,
+  listBottomPanelTabs,
+  getBottomPanelTab,
+  subscribeToBottomPanelTabs,
+  __resetBottomPanelRegistryForTest,
+  type BottomPanelTab,
+} from '../bottomPanelRegistry'
+
+const stub = (id: string, title = id): BottomPanelTab => ({
+  id,
+  title,
+  content: null,
+})
+
+describe('bottomPanelRegistry', () => {
+  beforeEach(() => {
+    __resetBottomPanelRegistryForTest()
+  })
+
+  it('register adds an entry visible to listBottomPanelTabs', () => {
+    registerBottomPanelTab(stub('a', 'Alpha'))
+    const all = listBottomPanelTabs()
+    expect(all).toHaveLength(1)
+    expect(all[0]).toMatchObject({ id: 'a', title: 'Alpha' })
+  })
+
+  it('register-replace overwrites by id; getBottomPanelTab returns new entry', () => {
+    registerBottomPanelTab(stub('a', 'Alpha'))
+    registerBottomPanelTab(stub('a', 'Alpha v2'))
+    expect(listBottomPanelTabs()).toHaveLength(1)
+    expect(getBottomPanelTab('a')?.title).toBe('Alpha v2')
+  })
+
+  it('unregister removes by id; subsequent get returns undefined', () => {
+    registerBottomPanelTab(stub('a'))
+    registerBottomPanelTab(stub('b'))
+    unregisterBottomPanelTab('a')
+    expect(getBottomPanelTab('a')).toBeUndefined()
+    expect(listBottomPanelTabs()).toHaveLength(1)
+  })
+
+  it('register returns an unsubscribe function that removes the entry', () => {
+    const unsub = registerBottomPanelTab(stub('a'))
+    expect(getBottomPanelTab('a')).toBeDefined()
+    unsub()
+    expect(getBottomPanelTab('a')).toBeUndefined()
+  })
+
+  it('unsubscribe is safe when the entry was already replaced', () => {
+    const unsub = registerBottomPanelTab(stub('a', 'first'))
+    registerBottomPanelTab(stub('a', 'second'))
+    // The unsubscribe from the first registration must NOT remove the
+    // replacement.
+    unsub()
+    expect(getBottomPanelTab('a')?.title).toBe('second')
+  })
+
+  it('subscribeToBottomPanelTabs fires on register, unregister, and replace', () => {
+    let n = 0
+    const unsub = subscribeToBottomPanelTabs(() => {
+      n++
+    })
+    registerBottomPanelTab(stub('a')) // +1
+    registerBottomPanelTab(stub('a')) // +1 (replace still notifies)
+    unregisterBottomPanelTab('a') // +1
+    unsub()
+    registerBottomPanelTab(stub('b')) // listener no longer registered
+    expect(n).toBe(3)
+  })
+
+  it('listBottomPanelTabs returns a fresh array reference on each call (PV34)', () => {
+    registerBottomPanelTab(stub('a'))
+    const a1 = listBottomPanelTabs()
+    const a2 = listBottomPanelTabs()
+    expect(a1).not.toBe(a2)
+    expect(a1).toEqual(a2)
+  })
+
+  it('__resetBottomPanelRegistryForTest clears tabs and listeners', () => {
+    let n = 0
+    subscribeToBottomPanelTabs(() => {
+      n++
+    })
+    registerBottomPanelTab(stub('a'))
+    __resetBottomPanelRegistryForTest()
+    expect(listBottomPanelTabs()).toHaveLength(0)
+    // Listener should also be cleared — register again, n must NOT change
+    // beyond what it was before reset (it was 1 after first register).
+    const before = n
+    registerBottomPanelTab(stub('b'))
+    expect(n).toBe(before)
+  })
+
+  it('two sequential register-then-list cycles with reset between prove no leakage', () => {
+    registerBottomPanelTab(stub('a'))
+    registerBottomPanelTab(stub('b'))
+    expect(listBottomPanelTabs().map((t) => t.id)).toEqual(['a', 'b'])
+    __resetBottomPanelRegistryForTest()
+    expect(listBottomPanelTabs()).toHaveLength(0)
+    registerBottomPanelTab(stub('c'))
+    expect(listBottomPanelTabs().map((t) => t.id)).toEqual(['c'])
+  })
+})

--- a/packages/editor/src/workspace/bottomPanel/__tests__/persistence.test.ts
+++ b/packages/editor/src/workspace/bottomPanel/__tests__/persistence.test.ts
@@ -1,0 +1,251 @@
+/**
+ * persistence tests — Phase 20-01 PR-A T-03.
+ *
+ * Covers clampHeight pure function (Trap 6 math fence), SSR-safe
+ * readers (Trap 7 — no flash, must be callable from useState init),
+ * and writer no-op behavior without window.
+ */
+
+import { describe, it, expect, beforeEach, beforeAll, afterEach, vi } from 'vitest'
+import {
+  clampHeight,
+  readPersistedHeight,
+  readPersistedOpen,
+  readPersistedActiveTabId,
+  writePersistedHeight,
+  writePersistedOpen,
+  writePersistedActiveTabId,
+  BOTTOM_PANEL_HEIGHT_KEY,
+  BOTTOM_PANEL_OPEN_KEY,
+  BOTTOM_PANEL_ACTIVE_TAB_KEY,
+  BOTTOM_PANEL_HEIGHT_MIN,
+  BOTTOM_PANEL_HEIGHT_MAX,
+  BOTTOM_PANEL_HEIGHT_DEFAULT,
+} from '../persistence'
+
+// jsdom in this repo's vitest config provides a non-functional localStorage
+// stub (no setItem / getItem / clear methods). Install a Map-backed mock on
+// window.localStorage for the duration of this test file so the
+// SSR-safe readers/writers can be exercised.
+function installMockLocalStorage(): void {
+  const store = new Map<string, string>()
+  const mock: Storage = {
+    get length() {
+      return store.size
+    },
+    clear: () => store.clear(),
+    getItem: (k: string) => (store.has(k) ? (store.get(k) as string) : null),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    removeItem: (k: string) => {
+      store.delete(k)
+    },
+    setItem: (k: string, v: string) => {
+      store.set(k, String(v))
+    },
+  }
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: mock,
+  })
+}
+
+describe('clampHeight', () => {
+  it('returns value when within bounds', () => {
+    expect(clampHeight(240)).toBe(240)
+    expect(clampHeight(80)).toBe(80)
+    expect(clampHeight(600)).toBe(600)
+  })
+
+  it('clamps below MIN to MIN', () => {
+    expect(clampHeight(0)).toBe(BOTTOM_PANEL_HEIGHT_MIN)
+    expect(clampHeight(-100)).toBe(BOTTOM_PANEL_HEIGHT_MIN)
+    expect(clampHeight(50)).toBe(BOTTOM_PANEL_HEIGHT_MIN)
+  })
+
+  it('clamps above MAX to MAX', () => {
+    expect(clampHeight(700)).toBe(BOTTOM_PANEL_HEIGHT_MAX)
+    expect(clampHeight(99999)).toBe(BOTTOM_PANEL_HEIGHT_MAX)
+  })
+
+  it('falls back to DEFAULT for non-finite values', () => {
+    expect(clampHeight(NaN)).toBe(BOTTOM_PANEL_HEIGHT_DEFAULT)
+    expect(clampHeight(Infinity)).toBe(BOTTOM_PANEL_HEIGHT_DEFAULT)
+    expect(clampHeight(-Infinity)).toBe(BOTTOM_PANEL_HEIGHT_DEFAULT)
+  })
+
+  it('falls back to DEFAULT for non-numbers (defensive)', () => {
+    // @ts-expect-error — testing defensive guard against bad input
+    expect(clampHeight('garbage')).toBe(BOTTOM_PANEL_HEIGHT_DEFAULT)
+    // @ts-expect-error — testing defensive guard against bad input
+    expect(clampHeight(null)).toBe(BOTTOM_PANEL_HEIGHT_DEFAULT)
+  })
+})
+
+describe('readPersistedHeight (SSR-safe)', () => {
+  beforeAll(installMockLocalStorage)
+  beforeEach(() => {
+    window.localStorage.clear()
+  })
+
+  it('returns DEFAULT when localStorage is empty', () => {
+    expect(readPersistedHeight()).toBe(BOTTOM_PANEL_HEIGHT_DEFAULT)
+  })
+
+  it('returns the stored value when present and valid', () => {
+    window.localStorage.setItem(BOTTOM_PANEL_HEIGHT_KEY, '320')
+    expect(readPersistedHeight()).toBe(320)
+  })
+
+  it('clamps stored value above MAX', () => {
+    window.localStorage.setItem(BOTTOM_PANEL_HEIGHT_KEY, '5000')
+    expect(readPersistedHeight()).toBe(BOTTOM_PANEL_HEIGHT_MAX)
+  })
+
+  it('clamps stored value below MIN', () => {
+    window.localStorage.setItem(BOTTOM_PANEL_HEIGHT_KEY, '10')
+    expect(readPersistedHeight()).toBe(BOTTOM_PANEL_HEIGHT_MIN)
+  })
+
+  it('falls back to DEFAULT on garbage', () => {
+    window.localStorage.setItem(BOTTOM_PANEL_HEIGHT_KEY, 'garbage')
+    expect(readPersistedHeight()).toBe(BOTTOM_PANEL_HEIGHT_DEFAULT)
+  })
+
+  it('falls back to DEFAULT when localStorage throws (Safari private mode)', () => {
+    const spy = vi
+      .spyOn(window.localStorage, 'getItem')
+      .mockImplementation(() => {
+        throw new Error('SecurityError')
+      })
+    expect(readPersistedHeight()).toBe(BOTTOM_PANEL_HEIGHT_DEFAULT)
+    spy.mockRestore()
+  })
+})
+
+describe('readPersistedOpen', () => {
+  beforeAll(installMockLocalStorage)
+  beforeEach(() => window.localStorage.clear())
+
+  it('defaults to false (drawer is closed for first-time users)', () => {
+    expect(readPersistedOpen()).toBe(false)
+  })
+
+  it('returns true when stored "true"', () => {
+    window.localStorage.setItem(BOTTOM_PANEL_OPEN_KEY, 'true')
+    expect(readPersistedOpen()).toBe(true)
+  })
+
+  it('returns false when stored "false"', () => {
+    window.localStorage.setItem(BOTTOM_PANEL_OPEN_KEY, 'false')
+    expect(readPersistedOpen()).toBe(false)
+  })
+
+  it('returns false on garbage (defensive)', () => {
+    window.localStorage.setItem(BOTTOM_PANEL_OPEN_KEY, 'maybe')
+    expect(readPersistedOpen()).toBe(false)
+  })
+})
+
+describe('readPersistedActiveTabId', () => {
+  beforeAll(installMockLocalStorage)
+  beforeEach(() => window.localStorage.clear())
+
+  it('returns null when missing', () => {
+    expect(readPersistedActiveTabId()).toBeNull()
+  })
+
+  it('returns the stored id', () => {
+    window.localStorage.setItem(BOTTOM_PANEL_ACTIVE_TAB_KEY, 'musical-timeline')
+    expect(readPersistedActiveTabId()).toBe('musical-timeline')
+  })
+
+  it('treats empty string as null', () => {
+    window.localStorage.setItem(BOTTOM_PANEL_ACTIVE_TAB_KEY, '')
+    expect(readPersistedActiveTabId()).toBeNull()
+  })
+})
+
+describe('writePersistedHeight', () => {
+  beforeAll(installMockLocalStorage)
+  beforeEach(() => window.localStorage.clear())
+
+  it('writes a clamped numeric value', () => {
+    writePersistedHeight(320)
+    expect(window.localStorage.getItem(BOTTOM_PANEL_HEIGHT_KEY)).toBe('320')
+  })
+
+  it('clamps before writing', () => {
+    writePersistedHeight(5000)
+    expect(window.localStorage.getItem(BOTTOM_PANEL_HEIGHT_KEY)).toBe(
+      String(BOTTOM_PANEL_HEIGHT_MAX),
+    )
+  })
+
+  it('does not throw when localStorage.setItem throws', () => {
+    const spy = vi
+      .spyOn(window.localStorage, 'setItem')
+      .mockImplementation(() => {
+        throw new Error('QuotaExceeded')
+      })
+    expect(() => writePersistedHeight(240)).not.toThrow()
+    spy.mockRestore()
+  })
+})
+
+describe('writePersistedOpen + writePersistedActiveTabId', () => {
+  beforeAll(installMockLocalStorage)
+  beforeEach(() => window.localStorage.clear())
+
+  it('writes boolean as "true"/"false"', () => {
+    writePersistedOpen(true)
+    expect(window.localStorage.getItem(BOTTOM_PANEL_OPEN_KEY)).toBe('true')
+    writePersistedOpen(false)
+    expect(window.localStorage.getItem(BOTTOM_PANEL_OPEN_KEY)).toBe('false')
+  })
+
+  it('writes a non-null string id', () => {
+    writePersistedActiveTabId('musical-timeline')
+    expect(window.localStorage.getItem(BOTTOM_PANEL_ACTIVE_TAB_KEY)).toBe(
+      'musical-timeline',
+    )
+  })
+
+  it('removes the key when writing null', () => {
+    window.localStorage.setItem(BOTTOM_PANEL_ACTIVE_TAB_KEY, 'foo')
+    writePersistedActiveTabId(null)
+    expect(window.localStorage.getItem(BOTTOM_PANEL_ACTIVE_TAB_KEY)).toBeNull()
+  })
+})
+
+describe('SSR safety (no window)', () => {
+  let originalWindow: typeof window | undefined
+  beforeEach(() => {
+    originalWindow = globalThis.window
+    // Simulate SSR: drop the window entirely.
+    delete (globalThis as { window?: unknown }).window
+  })
+  afterEach(() => {
+    if (originalWindow) {
+      ;(globalThis as { window?: typeof window }).window = originalWindow
+    }
+  })
+
+  it('readPersistedHeight returns DEFAULT', () => {
+    expect(readPersistedHeight()).toBe(BOTTOM_PANEL_HEIGHT_DEFAULT)
+  })
+
+  it('readPersistedOpen returns false', () => {
+    expect(readPersistedOpen()).toBe(false)
+  })
+
+  it('readPersistedActiveTabId returns null', () => {
+    expect(readPersistedActiveTabId()).toBeNull()
+  })
+
+  it('writers no-op without window', () => {
+    expect(() => writePersistedHeight(240)).not.toThrow()
+    expect(() => writePersistedOpen(true)).not.toThrow()
+    expect(() => writePersistedActiveTabId('foo')).not.toThrow()
+    expect(() => writePersistedActiveTabId(null)).not.toThrow()
+  })
+})

--- a/packages/editor/src/workspace/bottomPanel/__tests__/useDragResize.test.ts
+++ b/packages/editor/src/workspace/bottomPanel/__tests__/useDragResize.test.ts
@@ -1,0 +1,70 @@
+/**
+ * useDragResize math tests — Phase 20-01 PR-A T-05.
+ *
+ * jsdom does not propagate clientY through synthetic PointerEvents
+ * reliably (Trap 10), so the integration is asserted in Playwright
+ * (T-10). These tests cover the PURE math composition: computeNewHeight
+ * is the y-inversion math (drag UP increases height); clampHeight is
+ * the bounds fence shared with the persistence reader.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import {
+  clampHeight,
+  BOTTOM_PANEL_HEIGHT_MIN,
+  BOTTOM_PANEL_HEIGHT_MAX,
+} from '../persistence'
+import { computeNewHeight } from '../BottomPanel'
+
+describe('computeNewHeight (drag inversion math)', () => {
+  it('drag UP 20px increases height by 20', () => {
+    expect(computeNewHeight(100, 80, 240)).toBe(260)
+  })
+
+  it('drag DOWN 20px decreases height by 20', () => {
+    expect(computeNewHeight(100, 120, 240)).toBe(220)
+  })
+
+  it('zero delta returns startHeight unchanged', () => {
+    expect(computeNewHeight(100, 100, 240)).toBe(240)
+  })
+
+  it('large negative delta produces large positive height', () => {
+    // user dragged 500px UP from y=600 to y=100
+    expect(computeNewHeight(600, 100, 240)).toBe(740)
+  })
+})
+
+describe('computeNewHeight + clampHeight composition', () => {
+  it('drag down past MIN clamps to MIN', () => {
+    // start 240; drag DOWN by 500 -> raw -260; clamp -> 80
+    const raw = computeNewHeight(100, 600, 240)
+    expect(raw).toBe(-260)
+    expect(clampHeight(raw)).toBe(BOTTOM_PANEL_HEIGHT_MIN)
+  })
+
+  it('drag up past MAX clamps to MAX', () => {
+    // start 500; drag UP by 1000 -> raw 1500; clamp -> 600
+    const raw = computeNewHeight(1000, 0, 500)
+    expect(raw).toBe(1500)
+    expect(clampHeight(raw)).toBe(BOTTOM_PANEL_HEIGHT_MAX)
+  })
+
+  it('1px jitter near boundary stays clamped, no oscillation', () => {
+    // start at MIN; jitter +/-1 in raw space; clamp keeps at MIN.
+    expect(clampHeight(BOTTOM_PANEL_HEIGHT_MIN - 1)).toBe(
+      BOTTOM_PANEL_HEIGHT_MIN,
+    )
+    expect(clampHeight(BOTTOM_PANEL_HEIGHT_MIN + 1)).toBe(
+      BOTTOM_PANEL_HEIGHT_MIN + 1,
+    )
+    // start at MAX; jitter
+    expect(clampHeight(BOTTOM_PANEL_HEIGHT_MAX + 1)).toBe(
+      BOTTOM_PANEL_HEIGHT_MAX,
+    )
+    expect(clampHeight(BOTTOM_PANEL_HEIGHT_MAX - 1)).toBe(
+      BOTTOM_PANEL_HEIGHT_MAX - 1,
+    )
+  })
+})

--- a/packages/editor/src/workspace/bottomPanel/bottomPanelRegistry.ts
+++ b/packages/editor/src/workspace/bottomPanel/bottomPanelRegistry.ts
@@ -1,0 +1,114 @@
+/**
+ * bottomPanelRegistry — module-level singleton registry of tabs that the
+ * BottomPanel component renders.
+ *
+ * Mirrors the activity-bar panel registry shape at
+ * `packages/app/src/panels/registry.ts` (DA-05). Idempotent register
+ * (re-registering by id REPLACES the existing entry) so a re-mount /
+ * hot-reload doesn't double-up tabs.
+ *
+ * `listBottomPanelTabs()` returns a FRESH array on every call (PV34) so
+ * React subscribers using `useMemo([])` or shallow-prop comparison don't
+ * go stale on register/unregister.
+ *
+ * `__resetBottomPanelRegistryForTest` is intentionally NOT exported from
+ * the top-level barrel — it's test-internal. Tests import directly from
+ * this module path. (Trap 9 — vitest test isolation.)
+ *
+ * Phase 20-01 PR-A.
+ */
+
+import type * as React from 'react'
+
+export interface BottomPanelTab {
+  readonly id: string
+  /** User-facing tab title. Vocabulary discipline (PV32 / PV35) is the
+   *  responsibility of the registering caller — the registry stores
+   *  whatever string it's given. */
+  readonly title: string
+  /** Optional codicon name without the `codicon-` prefix. */
+  readonly icon?: string
+  /**
+   * Tab body. Either a ReactNode rendered directly, or a function that
+   * returns one (function form lets a future tab defer expensive mount
+   * until first activation). PR-A always uses the ReactNode form.
+   */
+  readonly content: React.ReactNode | (() => React.ReactNode)
+}
+
+type Listener = () => void
+
+const tabs = new Map<string, BottomPanelTab>()
+const listeners = new Set<Listener>()
+
+function notify(): void {
+  // Listener errors do NOT block other listeners — mirrors irInspector.ts.
+  for (const l of listeners) {
+    try {
+      l()
+    } catch {
+      /* swallow */
+    }
+  }
+}
+
+/**
+ * Register a tab. Idempotent — re-registering by `id` REPLACES the
+ * existing entry (matches activity-bar `registerPanel` semantics, lets
+ * PR-B re-register `'musical-timeline'` to swap the placeholder for the
+ * real component without an explicit unregister).
+ *
+ * Returns an unsubscribe function that removes the tab IF it's still the
+ * registered one (a later replace is the new owner).
+ */
+export function registerBottomPanelTab(tab: BottomPanelTab): () => void {
+  tabs.set(tab.id, tab)
+  notify()
+  return () => {
+    if (tabs.get(tab.id) === tab) {
+      tabs.delete(tab.id)
+      notify()
+    }
+  }
+}
+
+/** Remove a tab by id. No-op if the id isn't registered. */
+export function unregisterBottomPanelTab(id: string): void {
+  if (tabs.delete(id)) {
+    notify()
+  }
+}
+
+/**
+ * Fresh array of all registered tabs (insertion order). PV34 — never
+ * cache between renders without subscribing.
+ */
+export function listBottomPanelTabs(): readonly BottomPanelTab[] {
+  return Array.from(tabs.values())
+}
+
+/** Direct lookup by id. */
+export function getBottomPanelTab(id: string): BottomPanelTab | undefined {
+  return tabs.get(id)
+}
+
+/**
+ * Subscribe to register / unregister / replace events. Listener fires
+ * with no arguments — consumers re-read `listBottomPanelTabs()`.
+ */
+export function subscribeToBottomPanelTabs(cb: Listener): () => void {
+  listeners.add(cb)
+  return () => {
+    listeners.delete(cb)
+  }
+}
+
+/**
+ * Test-only: reset all module state. NOT exported via the top-level
+ * barrel; tests import directly from this module path. Mirrors
+ * `__resetCaptureForTest` in `engine/timelineCapture.ts`.
+ */
+export function __resetBottomPanelRegistryForTest(): void {
+  tabs.clear()
+  listeners.clear()
+}

--- a/packages/editor/src/workspace/bottomPanel/persistence.ts
+++ b/packages/editor/src/workspace/bottomPanel/persistence.ts
@@ -1,0 +1,133 @@
+/**
+ * persistence — SSR-safe localStorage helpers for BottomPanel state +
+ * the `clampHeight` pure function shared with `useDragResize`.
+ *
+ * All readers MUST be safe to call from a `useState` initializer
+ * (DA-06 + Trap 7). That means: no DOM access without the
+ * `typeof window !== 'undefined'` guard, no throws on Safari private
+ * mode (where `localStorage.getItem` raises), and a sensible default
+ * return on every error path.
+ *
+ * Constants are exported so Playwright assertions (T-10) and component
+ * tests (T-07) can reference the canonical key names.
+ *
+ * Phase 20-01 PR-A.
+ */
+
+export const BOTTOM_PANEL_HEIGHT_KEY = 'stave:bottomPanel.height'
+export const BOTTOM_PANEL_OPEN_KEY = 'stave:bottomPanel.open'
+export const BOTTOM_PANEL_ACTIVE_TAB_KEY = 'stave:bottomPanel.activeTabId'
+
+export const BOTTOM_PANEL_HEIGHT_MIN = 80
+export const BOTTOM_PANEL_HEIGHT_MAX = 600
+export const BOTTOM_PANEL_HEIGHT_DEFAULT = 240
+
+/**
+ * Clamp a numeric height to [MIN, MAX]. Non-finite (NaN, Infinity) and
+ * non-numbers fall back to BOTTOM_PANEL_HEIGHT_DEFAULT — the shared
+ * "math fence" for both drag math and persistence read.
+ */
+export function clampHeight(value: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return BOTTOM_PANEL_HEIGHT_DEFAULT
+  }
+  if (value < BOTTOM_PANEL_HEIGHT_MIN) return BOTTOM_PANEL_HEIGHT_MIN
+  if (value > BOTTOM_PANEL_HEIGHT_MAX) return BOTTOM_PANEL_HEIGHT_MAX
+  return value
+}
+
+/**
+ * Returns a real Storage interface or null. Mirrors the
+ * `safeLocalStorage` guard in editorRegistry.ts: jsdom in the editor
+ * package's vitest config provides a non-functional `localStorage`
+ * stub (no methods); the `typeof getItem !== 'function'` check filters
+ * those out alongside SSR (no window) and Safari private mode (throws).
+ */
+function safeLocalStorage(): Storage | null {
+  try {
+    if (typeof window === 'undefined') return null
+    if (typeof window.localStorage?.getItem !== 'function') return null
+    return window.localStorage
+  } catch {
+    return null
+  }
+}
+
+function safeGetItem(key: string): string | null {
+  const ls = safeLocalStorage()
+  if (!ls) return null
+  try {
+    return ls.getItem(key)
+  } catch {
+    return null
+  }
+}
+
+function safeSetItem(key: string, value: string): void {
+  const ls = safeLocalStorage()
+  if (!ls) return
+  try {
+    ls.setItem(key, value)
+  } catch {
+    /* quota / private mode — silently ignore */
+  }
+}
+
+function safeRemoveItem(key: string): void {
+  const ls = safeLocalStorage()
+  if (!ls) return
+  try {
+    ls.removeItem(key)
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Read the persisted drawer height. Returns the default if the window
+ * is unavailable, the entry is missing, parses to NaN, or fails the
+ * clamp. Safe to call from a useState initializer.
+ */
+export function readPersistedHeight(): number {
+  const raw = safeGetItem(BOTTOM_PANEL_HEIGHT_KEY)
+  if (raw == null) return BOTTOM_PANEL_HEIGHT_DEFAULT
+  const parsed = Number.parseFloat(raw)
+  return clampHeight(parsed)
+}
+
+/**
+ * Read the persisted open state. Default is `false` (closed) — the
+ * drawer is opt-in for existing users (Trap 2 — closed-state pixel
+ * cost is documented and bounded).
+ */
+export function readPersistedOpen(): boolean {
+  const raw = safeGetItem(BOTTOM_PANEL_OPEN_KEY)
+  return raw === 'true'
+}
+
+/**
+ * Read the persisted active tab id. Returns `null` when missing — the
+ * caller decides the fallback (typically the first registered tab).
+ * Empty string is treated as null.
+ */
+export function readPersistedActiveTabId(): string | null {
+  const raw = safeGetItem(BOTTOM_PANEL_ACTIVE_TAB_KEY)
+  if (raw == null || raw === '') return null
+  return raw
+}
+
+export function writePersistedHeight(value: number): void {
+  safeSetItem(BOTTOM_PANEL_HEIGHT_KEY, String(clampHeight(value)))
+}
+
+export function writePersistedOpen(value: boolean): void {
+  safeSetItem(BOTTOM_PANEL_OPEN_KEY, value ? 'true' : 'false')
+}
+
+export function writePersistedActiveTabId(value: string | null): void {
+  if (value == null) {
+    safeRemoveItem(BOTTOM_PANEL_ACTIVE_TAB_KEY)
+    return
+  }
+  safeSetItem(BOTTOM_PANEL_ACTIVE_TAB_KEY, value)
+}

--- a/packages/editor/src/workspace/bottomPanel/seedTabs.ts
+++ b/packages/editor/src/workspace/bottomPanel/seedTabs.ts
@@ -1,0 +1,43 @@
+/**
+ * seedTabs — module-init side-effect that registers the placeholder
+ * "Timeline" tab into the bottom-panel registry.
+ *
+ * Imported for side-effects from BottomPanel.tsx so the seed runs the
+ * first time the drawer's bundle loads (rather than at @stave/editor
+ * top-level barrel load — that would seed even in package consumers
+ * that don't render the drawer). PR-B replaces the entry by
+ * re-registering under the same id (`musical-timeline`); the registry's
+ * idempotent semantics (DA-05) make this a no-fanfare swap.
+ *
+ * Vocabulary discipline (PV32 / D-06): the only strings here are
+ * "Timeline" and "(empty — wired in PR-B)". No IR-jargon.
+ *
+ * Phase 20-01 PR-A.
+ */
+
+import * as React from 'react'
+
+import { registerBottomPanelTab } from './bottomPanelRegistry'
+
+function EmptyTimelineStub(): React.ReactElement {
+  return React.createElement(
+    'div',
+    {
+      'data-bottom-panel-tab': 'musical-timeline-empty',
+      style: {
+        padding: 24,
+        color: 'var(--foreground-muted, #a0a0aa)',
+        fontSize: 12,
+        fontFamily:
+          'system-ui, -apple-system, "Segoe UI", sans-serif',
+      },
+    },
+    '(empty — wired in PR-B)',
+  )
+}
+
+registerBottomPanelTab({
+  id: 'musical-timeline',
+  title: 'Timeline',
+  content: React.createElement(EmptyTimelineStub),
+})


### PR DESCRIPTION
## Summary

Ships the **BottomPanel** surface in `@stave/editor` — a reusable bottom-drawer mounted by `WorkspaceShell` below the editor grid (VSCode-terminal-style). Resizable, collapsible, multi-tab, persisted. PR-A only contains infra; **PR-B** (a separate plan) will fill the placeholder Timeline tab with the actual `MusicalTimeline` component.

This is the first phase to honor **PV35** (audience-classification gate) by construction: audience locked to `musician` in CONTEXT before any chrome was written. Vocabulary discipline (PV32 / D-06) is asserted by both vitest and Playwright probes.

## What's in this PR

- `packages/editor/src/workspace/bottomPanel/`:
  - `BottomPanel.tsx` — component + colocated `useDragResize` hook + `computeNewHeight` exported pure helper.
  - `bottomPanelRegistry.ts` — module-level singleton (mirrors activity-bar `registerPanel`); idempotent register-by-id; fresh-array `listBottomPanelTabs` per PV34; `__resetBottomPanelRegistryForTest` test-internal.
  - `persistence.ts` — SSR-safe localStorage helpers + `clampHeight` math fence shared with the drag hook.
  - `seedTabs.ts` — module-init registers the placeholder `id='musical-timeline', title='Timeline', body='(empty — wired in PR-B)'`.
  - `__tests__/` — 61 vitest cases.
- `packages/editor/src/workspace/WorkspaceShell.tsx` — surgical edit: groups area wrapped in `flex:1` container; `<BottomPanel/>` added as trailing sibling before `QuadrantGuideOverlay`. No refactor of existing code.
- `packages/editor/src/index.ts` — top-level barrel exports for the registry + component + types + constants (PK10 — verified with grep on `dist/index.cjs`: `registerBottomPanelTab`=5, `BottomPanel`=18, `__resetBottomPanelRegistryForTest`=0).
- `packages/app/tests/bottom-drawer.spec.ts` — 8 Playwright probes covering all 4 critical traps.

## Locked decisions

- **CONTEXT** (`.planning/phases/20-musician-timeline/20-01-CONTEXT.md`) D-01..D-10 (audience=musician; bottom-drawer surface, not activity-bar; LIVE data only; vocabulary lock; scope split into PR-A + PR-B).
- **PLAN** (`.planning/phases/20-musician-timeline/20-01-PLAN.md`) DA-01..DA-06 (insertion site inside `WorkspaceShell`; `display:none` for inactive tab content; pointer-event drag with `setPointerCapture`; in-shell ownership; module-singleton registry; SSR-safe `useState` initializer hydration).

## Pre-mortem mitigations called out

| Trap | Mitigation | Test catcher |
|---|---|---|
| 1 — IR vocabulary leaks into drawer chrome | Allow-listed strings; forbidden-noun regex | Vitest + Playwright vocabulary regression |
| 2 — Drawer-when-closed steals editor pixels | Returns null when zero tabs; closed flexBasis = exactly 29px | Vitest + Playwright |
| 6 — Drag jitters on trackpad | Pointer events + `setPointerCapture`; pure-math helper | Vitest pure-math + Playwright integration |
| 7 — localStorage hydration races React mount | All three values read in `useState` initializers, not `useEffect` | Vitest hydration probes + Playwright on `domcontentloaded` |
| 8 — Editor tsc baseline drifts | Each task verified ≤53 errors | T-final tsc check |
| 9 — Registry singleton leaks between vitest tests | `__resetBottomPanelRegistryForTest` in beforeEach | Sequential register-then-list test |
| 10 — jsdom doesn't fire PointerEvent like browsers | Drag math tested as pure function; integration in Playwright | Both |

## Test plan

- [x] Editor vitest: 1213 → **1274 (+61)** — registry (9) + persistence (28) + drag math (7) + BottomPanel component (17)
- [x] App vitest: **56 (unchanged)** — no app-side production code in PR-A
- [x] Playwright `bottom-drawer.spec.ts`: **8/8 new probes passing**
- [x] Pre-existing IR Inspector Playwright suite: **41/41 still passing** (timeline + mode-toggle + debugger + tier4)
- [x] Editor tsc: **53 errors (baseline, unchanged)**
- [x] PK10 grep on `dist/index.cjs` after `pnpm --filter @stave/editor build`:
  - `registerBottomPanelTab` → 5 (≥1 ✓)
  - `BottomPanel` → 18 (≥1 ✓)
  - `__resetBottomPanelRegistryForTest` → 0 (test-internal stays hidden ✓)
- [x] Vocabulary regression on production diff (excludes tests/specs): no `snapshot|publishIRSnapshot|IREvent|captureSnapshot` introduced in PR-A code

## Out of scope

- **MusicalTimeline component** — PR-B (separate plan + execution after PR-A merge).
- **Click-to-source / pan / zoom / breakpoints / bidirectional editing** — later phases.
- **Reframe of `IRInspectorTimeline`** (eval-tick strip → `IRInspectorEvalHistory`) — separate small follow-up; not a PR-A predecessor.
- **Mobile/touch tuning** — desktop-first.

closes #89