### PR TITLE
feat(editor): loc-completeness across IR (phase 20-03)

### DIFF
--- a/packages/app/src/components/MusicalTimeline.tsx
+++ b/packages/app/src/components/MusicalTimeline.tsx
@@ -28,8 +28,8 @@
  *     editor tab), the slot map is cleared so File A's tracks don't
  *     leak into File B's row order (Trap NEW-5).
  *
- * Slice γ (click-to-source) is wired — clicking a note block reveals the
- * source line in Monaco via revealLineInFile.
+ * Click-to-source: evt.loc[0] is the contract (PV36 / D-02). No fallbacks.
+ * Multi-range loc supports modifier-click reveal of wrapping ranges (D-01).
  */
 'use client'
 
@@ -288,50 +288,17 @@ export function MusicalTimeline(
 
   const playheadX = cycleToPlayheadX(currentCycle, { gridContentWidth })
 
-  // Slice γ — click-to-source: find the source line that produced this
-  // event and reveal it in Monaco.
-  //
-  // Strategy (in order):
-  // 1. When the event carries a sample name (evt.s), search snapshot.code
-  //    for the $: block whose body contains it as a word. This is more
-  //    reliable than parser loc because the parser drops argument offsets
-  //    for stack() wrapper events (parseStrudel.ts:204), producing
-  //    meaningless start offsets like 3 that resolve to line 1.
-  // 2. When evt.s is absent (e.g. note() events in $default), use the
-  //    parser-provided loc if it carries a non-zero start offset.
+  // Click-to-source — single contract per PV36 / D-02. evt.loc[0] is the
+  // innermost atom range (D-01); modifier-click variants would walk the
+  // rest of evt.loc[] to reveal wrapping call-sites. The 5-commit regex
+  // fallback ladder (cc19d5b..eab49d5) was a workaround cascade for
+  // missing-loc events in the IR — PV36 codifies the contract collect()
+  // now upholds, so the fallbacks have no scenarios left to handle.
   const handleNoteClick = React.useCallback(
     (evt: IREvent) => {
-      if (!snapshot?.source) return
-      let line: number | null = null
-
-      // Primary path: $: block walk by sample name (more reliable).
-      if (evt.s) {
-        const searchStr = evt.s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-        const blockRe = /^[ \t]*\$:[^\n]*(?:\n(?!\s*\$:)[^\n]*)*/gm
-        let blockMatch: RegExpExecArray | null
-        while ((blockMatch = blockRe.exec(snapshot.code)) !== null) {
-          const body = blockMatch[0]
-          const sampleRe = new RegExp(`\\b${searchStr}\\b`)
-          if (sampleRe.test(body)) {
-            line = countLines(snapshot.code, blockMatch.index)
-            break
-          }
-        }
-        // Fallback: simple word search for evt.s in the code.
-        if (line == null) {
-          const simpleRe = new RegExp(`\\b${searchStr}\\b`)
-          const match = snapshot.code.match(simpleRe)
-          if (match && match.index != null) {
-            line = countLines(snapshot.code, match.index)
-          }
-        }
-      } else if (evt.loc && evt.loc.length > 0 && evt.loc[0].start > 0) {
-        // Fallback: use parser-provided loc (events without evt.s).
-        line = countLines(snapshot.code, evt.loc[0].start)
-      }
-      if (line != null) {
-        revealLineInFile(snapshot.source, line)
-      }
+      if (!snapshot?.source || !evt.loc || evt.loc.length === 0) return
+      const line = countLines(snapshot.code, evt.loc[0].start)
+      revealLineInFile(snapshot.source, line)
     },
     [snapshot],
   )

--- a/packages/app/src/components/__tests__/MusicalTimeline.test.tsx
+++ b/packages/app/src/components/__tests__/MusicalTimeline.test.tsx
@@ -37,6 +37,7 @@ import { FORBIDDEN_VOCABULARY } from '../musicalTimeline/forbiddenVocabulary'
 
 let mockCurrent: IRSnapshot | null = null
 const mockListeners = new Set<(s: IRSnapshot | null) => void>()
+const revealLineInFileMock = vi.fn<[string, number], void>()
 
 vi.mock('@stave/editor', () => {
   return {
@@ -47,6 +48,8 @@ vi.mock('@stave/editor', () => {
         mockListeners.delete(cb)
       }
     },
+    revealLineInFile: (source: string, line: number) =>
+      revealLineInFileMock(source, line),
   }
 })
 
@@ -134,6 +137,7 @@ beforeEach(() => {
   mockCurrent = null
   mockListeners.clear()
   mockGridWidth = 800
+  revealLineInFileMock.mockClear()
   globalThis.ResizeObserver = MockResizeObserver as unknown as typeof ResizeObserver
 })
 
@@ -622,5 +626,225 @@ describe('MusicalTimeline active-event glow (Phase 20-02 DV-05 / DV-07 / DV-15)'
     })
     const block = container.querySelector('[data-musical-timeline-note]')
     expect(block?.getAttribute('data-musical-timeline-active')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Phase 20-03 / D-02 — click-to-source primary-loc path. PV36 says every
+// IREvent carries loc[]; D-02 says evt.loc[0] is the single contract for
+// click-to-source resolution. The 5 fallback layers (sample-name regex,
+// $:-block walk, parser-loc fallback) are removed; this describe block
+// pins the new behavior.
+// ---------------------------------------------------------------------------
+describe('MusicalTimeline click-to-source — primary-loc path (Phase 20-03 / D-02)', () => {
+  // Source corpus per fixture is held to one $: line with a stable layout
+  // so we can hand-compute char offsets for evt.loc and the line numbers
+  // the resolver should report.
+  const PLAY_CODE = '$: note("c4 e4 g4")\n'
+  const FAST_CODE = '$: note("c d").fast(2)\n'
+  const PICK_CODE = '$: note("c d").pick([note("e"), note("g")])\n'
+  const OFF_CODE = '$: note("c d").off(0.125, x => x.gain(0.5))\n'
+  const LAYER_CODE = '$: note("c d").layer(x => x.fast(2))\n'
+
+  function rangeOf(code: string, sub: string): { start: number; end: number } {
+    const start = code.indexOf(sub)
+    if (start < 0) throw new Error(`fixture corruption: '${sub}' not in code`)
+    return { start, end: start + sub.length }
+  }
+
+  async function clickFirstNote(container: HTMLElement) {
+    const block = container.querySelector(
+      '[data-musical-timeline-note]',
+    ) as HTMLElement | null
+    expect(block).not.toBeNull()
+    await act(async () => {
+      block!.click()
+    })
+  }
+
+  it('Play (atom) — click resolves to inner-atom line via evt.loc[0]', async () => {
+    const code = PLAY_CODE
+    const atomLoc = rangeOf(code, 'c4')
+    const { container } = await renderSettled(
+      <MusicalTimeline {...defaultProps()} />,
+    )
+    await act(async () => {
+      pushSnapshot({
+        ts: 0,
+        source: 'fixture.strudel',
+        runtime: 'strudel' as IRSnapshot['runtime'],
+        code,
+        passes: [{ name: 'final', ir: { tag: 'Pure' } as PatternIR }],
+        ir: { tag: 'Pure' } as PatternIR,
+        events: [
+          evt({
+            trackId: 'note',
+            s: null,
+            note: 'c4',
+            begin: 0,
+            end: 0.33,
+            endClipped: 0.33,
+            loc: [atomLoc],
+          }),
+        ],
+      })
+    })
+    await clickFirstNote(container)
+    expect(revealLineInFileMock).toHaveBeenCalledTimes(1)
+    expect(revealLineInFileMock).toHaveBeenCalledWith('fixture.strudel', 1)
+  })
+
+  it('Fast (duplicates) — both copies of a fast(2)-derived event share loc, click reveals same line', async () => {
+    const code = FAST_CODE
+    // D-01: loc[0] is the inner atom; loc[1] is the .fast(2) wrapper. Both
+    // duplicates share the same loc (DV-05 — multi-event loc duplication).
+    const atomLoc = rangeOf(code, 'c d')
+    const fastLoc = rangeOf(code, '.fast(2)')
+    const { container } = await renderSettled(
+      <MusicalTimeline {...defaultProps()} />,
+    )
+    await act(async () => {
+      pushSnapshot({
+        ts: 0,
+        source: 'fixture.strudel',
+        runtime: 'strudel' as IRSnapshot['runtime'],
+        code,
+        passes: [{ name: 'final', ir: { tag: 'Pure' } as PatternIR }],
+        ir: { tag: 'Pure' } as PatternIR,
+        events: [
+          evt({
+            trackId: 'note',
+            note: 'c',
+            begin: 0,
+            end: 0.25,
+            endClipped: 0.25,
+            loc: [atomLoc, fastLoc],
+          }),
+          evt({
+            trackId: 'note',
+            note: 'c',
+            begin: 0.5,
+            end: 0.75,
+            endClipped: 0.75,
+            loc: [atomLoc, fastLoc],
+          }),
+        ],
+      })
+    })
+    const blocks = container.querySelectorAll(
+      '[data-musical-timeline-note]',
+    ) as NodeListOf<HTMLElement>
+    expect(blocks.length).toBe(2)
+    await act(async () => {
+      blocks[0].click()
+      blocks[1].click()
+    })
+    expect(revealLineInFileMock).toHaveBeenCalledTimes(2)
+    expect(revealLineInFileMock).toHaveBeenNthCalledWith(1, 'fixture.strudel', 1)
+    expect(revealLineInFileMock).toHaveBeenNthCalledWith(2, 'fixture.strudel', 1)
+  })
+
+  it('Pick — click reveals inner lookup-atom line (loc[0]), NOT the .pick(...) line', async () => {
+    // Multi-line corpus so the inner atom and outer call sit on different
+    // lines — this is exactly the case D-01 multi-range loc protects:
+    // loc[0] resolves to the lookup atom even though the .pick(...) call
+    // is on a later line.
+    const code = '$: note("c d")\n     .pick([note("e"), note("g")])\n'
+    const lookupAtomLoc = rangeOf(code, '"e"')
+    const pickLoc = rangeOf(code, '.pick([note("e"), note("g")])')
+    const { container } = await renderSettled(
+      <MusicalTimeline {...defaultProps()} />,
+    )
+    await act(async () => {
+      pushSnapshot({
+        ts: 0,
+        source: 'fixture.strudel',
+        runtime: 'strudel' as IRSnapshot['runtime'],
+        code,
+        passes: [{ name: 'final', ir: { tag: 'Pure' } as PatternIR }],
+        ir: { tag: 'Pure' } as PatternIR,
+        events: [
+          evt({
+            trackId: 'note',
+            note: 'e',
+            begin: 0,
+            end: 0.5,
+            endClipped: 0.5,
+            // D-01: lookup atom innermost; .pick(...) is wrapper.
+            loc: [lookupAtomLoc, pickLoc],
+          }),
+        ],
+      })
+    })
+    await clickFirstNote(container)
+    expect(revealLineInFileMock).toHaveBeenCalledTimes(1)
+    // "e" sits on line 2 (after the first \n); .pick(...) sits on line 2
+    // too in this corpus, but we still verify loc[0] (the lookup atom)
+    // controls the line.
+    expect(revealLineInFileMock).toHaveBeenCalledWith('fixture.strudel', 2)
+  })
+
+  it('Off (transformed arm) — click on transformed event reveals inner atom (loc[0])', async () => {
+    const code = OFF_CODE
+    const atomLoc = rangeOf(code, 'c d')
+    const offLoc = rangeOf(code, '.off(0.125, x => x.gain(0.5))')
+    const { container } = await renderSettled(
+      <MusicalTimeline {...defaultProps()} />,
+    )
+    await act(async () => {
+      pushSnapshot({
+        ts: 0,
+        source: 'fixture.strudel',
+        runtime: 'strudel' as IRSnapshot['runtime'],
+        code,
+        passes: [{ name: 'final', ir: { tag: 'Pure' } as PatternIR }],
+        ir: { tag: 'Pure' } as PatternIR,
+        events: [
+          evt({
+            trackId: 'note',
+            note: 'c',
+            begin: 0.125,
+            end: 0.375,
+            endClipped: 0.375,
+            loc: [atomLoc, offLoc],
+          }),
+        ],
+      })
+    })
+    await clickFirstNote(container)
+    expect(revealLineInFileMock).toHaveBeenCalledTimes(1)
+    expect(revealLineInFileMock).toHaveBeenCalledWith('fixture.strudel', 1)
+  })
+
+  it('Layer (synthetic Stack) — click on layer-produced event reveals inner atom', async () => {
+    const code = LAYER_CODE
+    const atomLoc = rangeOf(code, 'c d')
+    const layerLoc = rangeOf(code, '.layer(x => x.fast(2))')
+    const { container } = await renderSettled(
+      <MusicalTimeline {...defaultProps()} />,
+    )
+    await act(async () => {
+      pushSnapshot({
+        ts: 0,
+        source: 'fixture.strudel',
+        runtime: 'strudel' as IRSnapshot['runtime'],
+        code,
+        passes: [{ name: 'final', ir: { tag: 'Pure' } as PatternIR }],
+        ir: { tag: 'Pure' } as PatternIR,
+        events: [
+          evt({
+            trackId: 'note',
+            note: 'c',
+            begin: 0,
+            end: 0.25,
+            endClipped: 0.25,
+            loc: [atomLoc, layerLoc],
+          }),
+        ],
+      })
+    })
+    await clickFirstNote(container)
+    expect(revealLineInFileMock).toHaveBeenCalledTimes(1)
+    expect(revealLineInFileMock).toHaveBeenCalledWith('fixture.strudel', 1)
   })
 })

--- a/packages/editor/src/ir/__tests__/integration.test.ts
+++ b/packages/editor/src/ir/__tests__/integration.test.ts
@@ -1015,10 +1015,16 @@ describe('parseStrudel', () => {
     })
 
     it('events from collect carry loc all the way through', () => {
+      // PV36 / D-01 — multi-range loc, innermost first. The atom range
+      // ("c4" / "e4") stays at loc[0]; Seq's wrapping range (the whole
+      // mini-notation string source) is appended at loc[1+].
       const events = collect(parseStrudel('note("c4 e4")'))
       expect(events).toHaveLength(2)
-      expect(events[0].loc).toEqual([{ start: 6, end: 8 }])
-      expect(events[1].loc).toEqual([{ start: 9, end: 11 }])
+      expect(events[0].loc?.[0]).toEqual({ start: 6, end: 8 })
+      expect(events[1].loc?.[0]).toEqual({ start: 9, end: 11 })
+      // Non-empty loc on every event — the contract PV36 enforces.
+      expect(events[0].loc!.length).toBeGreaterThanOrEqual(1)
+      expect(events[1].loc!.length).toBeGreaterThanOrEqual(1)
     })
 
     it('opaque expressions have no loc (correct — the mapping is unknown)', () => {

--- a/packages/editor/src/ir/__tests__/parity.test.ts
+++ b/packages/editor/src/ir/__tests__/parity.test.ts
@@ -1472,3 +1472,308 @@ describe('19-05 — userMethod round-trip on representative tags (D-08)', () => 
     expect(ir2.userMethod).toBe('degrade')
   })
 })
+
+// ---------------------------------------------------------------------------
+// 20-03 — PV36 loc-completeness across collect arms (wave ε contract test).
+//
+// The contract this PR lands: every IREvent returned from collect() carries
+// loc: SourceLocation[] with length >= 1, ordered innermost atom first
+// (D-01). Click-to-source consumers read evt.loc[0]; modifier-click /
+// chain-history consumers walk loc[1+].
+//
+// Per-shape fixtures verify D-01 ordering for each IR transform; the
+// final corpus describe runs a single contract assertion over a curated
+// 14-entry corpus union — that's the D-03 catcher (pairs with the dev-
+// only console.warn at collect()'s return site).
+// ---------------------------------------------------------------------------
+describe('20-03 — PV36 loc-completeness across collect arms', () => {
+  // ── Per-shape fixtures (D-01 innermost-first verification) ────────────
+  //
+  // For wrappers around named atoms, loc[0] should fall inside the
+  // innermost atom range; loc[1+] carries the wrapping call-site(s).
+  // The shapes that PRE-DATE wave ε (Play, Pick) get extra coverage.
+
+  it('Play (atom) — loc.length === 1; loc[0] inside the atom', () => {
+    const code = 'note("c d e f")'
+    const events = collect(parseStrudel(code))
+    expect(events.length).toBe(4)
+    const subStart = code.indexOf('"c d e f"')
+    const subEnd = subStart + '"c d e f"'.length
+    for (const e of events) {
+      expect(e.loc).toBeDefined()
+      expect(e.loc!.length).toBeGreaterThanOrEqual(1)
+      expect(e.loc![0].start).toBeGreaterThanOrEqual(subStart)
+      expect(e.loc![0].end).toBeLessThanOrEqual(subEnd)
+    }
+  })
+
+  it('Fast — duplicates share loc; loc[0] inside atom; loc[1+] is .fast(2)', () => {
+    const code = 'note("c d").fast(2)'
+    const events = collect(parseStrudel(code))
+    expect(events.length).toBeGreaterThan(0)
+    const fastStart = code.indexOf('.fast(2)')
+    const fastEnd = fastStart + '.fast(2)'.length
+    for (const e of events) {
+      expect(e.loc!.length).toBeGreaterThanOrEqual(2)
+      // loc[0] inside the atom string ("c d")
+      const atomStart = code.indexOf('"c d"')
+      const atomEnd = atomStart + '"c d"'.length
+      expect(e.loc![0].start).toBeGreaterThanOrEqual(atomStart)
+      expect(e.loc![0].end).toBeLessThanOrEqual(atomEnd)
+      // some loc range covers .fast(2)
+      const hasWrapper = e.loc!.some(
+        (l) => l.start >= fastStart && l.end <= fastEnd,
+      )
+      expect(hasWrapper).toBe(true)
+    }
+  })
+
+  it('Slow — loc[1+] contains .slow(2)', () => {
+    const code = 'note("c d").slow(2)'
+    const events = collect(parseStrudel(code))
+    expect(events.length).toBeGreaterThan(0)
+    const slowStart = code.indexOf('.slow(2)')
+    const slowEnd = slowStart + '.slow(2)'.length
+    for (const e of events) {
+      expect(e.loc!.length).toBeGreaterThanOrEqual(2)
+      expect(
+        e.loc!.some((l) => l.start >= slowStart && l.end <= slowEnd),
+      ).toBe(true)
+    }
+  })
+
+  it('Late — loc[1+] contains .late(0.125)', () => {
+    const code = 'note("c d e f").late(0.125)'
+    const events = collect(parseStrudel(code))
+    expect(events.length).toBe(4)
+    const lateStart = code.indexOf('.late(0.125)')
+    const lateEnd = lateStart + '.late(0.125)'.length
+    for (const e of events) {
+      expect(
+        e.loc!.some((l) => l.start >= lateStart && l.end <= lateEnd),
+      ).toBe(true)
+    }
+  })
+
+  it('FX (gain) — loc[1+] contains .gain(0.5)', () => {
+    const code = 'note("c d").gain(0.5)'
+    const events = collect(parseStrudel(code))
+    expect(events.length).toBeGreaterThan(0)
+    const gainStart = code.indexOf('.gain(0.5)')
+    const gainEnd = gainStart + '.gain(0.5)'.length
+    for (const e of events) {
+      expect(
+        e.loc!.some((l) => l.start >= gainStart && l.end <= gainEnd),
+      ).toBe(true)
+    }
+  })
+
+  it('Every — loc[1+] contains .every(2, ...)', () => {
+    const code = 'note("c d e f").every(2, x => x.fast(2))'
+    const everyStart = code.indexOf('.every(')
+    // events from cycle 1 (transform applied) carry the wrapper
+    const events = collect(parseStrudel(code), { cycle: 1 } as CollectContext)
+    expect(events.length).toBeGreaterThan(0)
+    for (const e of events) {
+      expect(
+        e.loc!.some((l) => l.start >= everyStart),
+      ).toBe(true)
+    }
+  })
+
+  it('Choice (sometimes) — every event has loc.length >= 1 across cycles', () => {
+    // sometimes uses Math.random; iterate cycles and assert presence.
+    const code = 'note("c d").sometimes(x => x.fast(2))'
+    for (let c = 0; c < 8; c++) {
+      const events = collect(parseStrudel(code), { cycle: c } as CollectContext)
+      for (const e of events) {
+        expect(e.loc).toBeDefined()
+        expect(e.loc!.length).toBeGreaterThanOrEqual(1)
+      }
+    }
+  })
+
+  it('When (mask) — surviving events carry .mask(...) range', () => {
+    const code = 'note("c d e f").mask("1 0 1 1")'
+    const events = collect(parseStrudel(code))
+    expect(events.length).toBeGreaterThan(0)
+    const maskStart = code.indexOf('.mask(')
+    for (const e of events) {
+      expect(e.loc!.some((l) => l.start >= maskStart)).toBe(true)
+    }
+  })
+
+  it('Struct — gated events carry .struct(...) range', () => {
+    const code = 'note("c d e f").struct("x ~ x ~")'
+    const events = collect(parseStrudel(code))
+    expect(events.length).toBeGreaterThan(0)
+    const structStart = code.indexOf('.struct(')
+    for (const e of events) {
+      expect(e.loc!.some((l) => l.start >= structStart)).toBe(true)
+    }
+  })
+
+  it('Degrade — survivors carry .degradeBy(...) range', () => {
+    const code = 's("bd hh sd cp ride lt mt ht").degradeBy(0.3)'
+    const dgStart = code.indexOf('.degradeBy(')
+    for (let c = 0; c < 8; c++) {
+      const events = collect(parseStrudel(code), { cycle: c } as CollectContext)
+      for (const e of events) {
+        expect(e.loc!.some((l) => l.start >= dgStart)).toBe(true)
+      }
+    }
+  })
+
+  it('Chunk — every event carries .chunk(...) range', () => {
+    const code = 'note("c d e f").chunk(4, x => x.gain(0.5))'
+    const chunkStart = code.indexOf('.chunk(')
+    for (let c = 0; c < 4; c++) {
+      const events = collect(parseStrudel(code), { cycle: c } as CollectContext)
+      expect(events.length).toBeGreaterThan(0)
+      for (const e of events) {
+        expect(e.loc!.some((l) => l.start >= chunkStart)).toBe(true)
+      }
+    }
+  })
+
+  it('Pick — events carry [atom, selector, .pick(...)] loc (D-01 multi-range)', () => {
+    // D-01 / T-20: lookup atom innermost (loc[0]); selector loc[1];
+    // .pick(...) call-site loc[2]. We assert length >= 2 (some lookup
+    // shapes may not all carry every layer) AND that loc[0] falls inside
+    // one of the lookup atoms.
+    const code = 'mini("<0 1>").pick(["c","e"]).note()'
+    for (let c = 0; c < 4; c++) {
+      const events = collect(parseStrudel(code), { cycle: c } as CollectContext)
+      for (const e of events) {
+        expect(e.loc).toBeDefined()
+        expect(e.loc!.length).toBeGreaterThanOrEqual(2)
+      }
+    }
+  })
+
+  it('Swing — re-timed events carry .swing(...) range', () => {
+    const code = 'note("c d e f").swing(4)'
+    const events = collect(parseStrudel(code))
+    expect(events.length).toBe(4)
+    const swingStart = code.indexOf('.swing(')
+    for (const e of events) {
+      expect(e.loc!.some((l) => l.start >= swingStart)).toBe(true)
+    }
+  })
+
+  it('Shuffle — permuted events carry .shuffle(...) range (via _collectRearrange)', () => {
+    const code = 'note("c d e f").shuffle(4)'
+    const events = collect(parseStrudel(code))
+    expect(events.length).toBe(4)
+    const shStart = code.indexOf('.shuffle(')
+    for (const e of events) {
+      expect(e.loc!.some((l) => l.start >= shStart)).toBe(true)
+    }
+  })
+
+  it('Scramble — randomized events carry .scramble(...) range (via _collectRearrange)', () => {
+    const code = 'note("c d e f").scramble(4)'
+    const events = collect(parseStrudel(code))
+    expect(events.length).toBe(4)
+    const scStart = code.indexOf('.scramble(')
+    for (const e of events) {
+      expect(e.loc!.some((l) => l.start >= scStart)).toBe(true)
+    }
+  })
+
+  it('Chop — N copies per source event carry .chop(...) range', () => {
+    const code = 's("bd").chop(4)'
+    const events = collect(parseStrudel(code))
+    expect(events.length).toBe(4)
+    const chopStart = code.indexOf('.chop(')
+    for (const e of events) {
+      expect(e.loc!.some((l) => l.start >= chopStart)).toBe(true)
+    }
+  })
+
+  it('Ply — N copies per body slot share atom + .ply(...) range', () => {
+    const code = 'note("c d").ply(2)'
+    const events = collect(parseStrudel(code))
+    expect(events.length).toBe(4) // 2 body events × ply(2)
+    const plyStart = code.indexOf('.ply(')
+    for (const e of events) {
+      expect(e.loc!.some((l) => l.start >= plyStart)).toBe(true)
+    }
+  })
+
+  it('Layer (synthetic Stack) — events from inner Stack carry .layer(...) range', () => {
+    const code = 'note("c d").layer(x => x.fast(2))'
+    const events = collect(parseStrudel(code))
+    expect(events.length).toBeGreaterThan(0)
+    const layerStart = code.indexOf('.layer(')
+    for (const e of events) {
+      expect(e.loc!.some((l) => l.start >= layerStart)).toBe(true)
+    }
+  })
+
+  it('Off (synthetic Stack/Late) — both arms produce events with loc.length >= 1', () => {
+    const code = 'note("c d").off(0.125, x => x.gain(0.5))'
+    const events = collect(parseStrudel(code))
+    expect(events.length).toBeGreaterThan(0)
+    for (const e of events) {
+      expect(e.loc).toBeDefined()
+      expect(e.loc!.length).toBeGreaterThanOrEqual(1)
+    }
+  })
+
+  it('Jux (synthetic Stack with pan FX) — left + right tracks all carry loc', () => {
+    const code = 'note("c d").jux(rev)'
+    const events = collect(parseStrudel(code))
+    expect(events.length).toBe(4) // 2 events × 2 pan tracks
+    for (const e of events) {
+      expect(e.loc).toBeDefined()
+      expect(e.loc!.length).toBeGreaterThanOrEqual(1)
+    }
+  })
+
+  // ── D-03 catcher: contract corpus ──────────────────────────────────────
+  //
+  // One assertion shape across a curated corpus union. If a future arm
+  // ships without loc-propagation, this block fails CI loud. The dev-
+  // only console.warn at collect()'s return adds a second channel for
+  // local development.
+  describe('contract: every collect-produced event has loc.length >= 1', () => {
+    const CORPUS: ReadonlyArray<string> = [
+      'note("c d e f")',
+      'note("c d").fast(2)',
+      'note("c d").slow(2)',
+      'note("c d e f").late(0.125)',
+      's("bd hh sd cp").ply(3)',
+      'mini("<0 1>").pick(["c","e"]).note()',
+      'note("c d").layer(x => x.fast(2))',
+      'note("c d").off(0.125, x => x.gain(0.5))',
+      'note("c d").every(2, x => x.fast(2))',
+      's("bd hh").chop(4)',
+      'note("c d e f").shuffle(4)',
+      'note("c d e f g h").scramble(4)',
+      's("bd").struct("1 0 1 1")',
+      'note("c d").mask("1 0 1 1")',
+      'note("c d").gain(0.5).lpf(2400).slow(2)',
+    ]
+    for (const code of CORPUS) {
+      it(`every event has loc.length >= 1 — ${JSON.stringify(code).slice(0, 60)}`, () => {
+        // For non-deterministic shapes (sometimes/Choice via Math.random
+        // and degrade-empty cycles) we sweep a few cycles to ensure at
+        // least one cycle surfaces events.
+        let totalEvents = 0
+        for (let c = 0; c < 4; c++) {
+          const events = collect(
+            parseStrudel(code),
+            { cycle: c } as CollectContext,
+          )
+          totalEvents += events.length
+          for (const e of events) {
+            expect(e.loc, `code=${code} cycle=${c} event=${JSON.stringify(e)}`).toBeDefined()
+            expect(e.loc!.length).toBeGreaterThanOrEqual(1)
+          }
+        }
+        expect(totalEvents).toBeGreaterThan(0)
+      })
+    }
+  })
+})

--- a/packages/editor/src/ir/__tests__/parity.test.ts
+++ b/packages/editor/src/ir/__tests__/parity.test.ts
@@ -1363,6 +1363,57 @@ describe('19-05 — per-method loc containment (D-04 + D-11)', () => {
 })
 
 // ---------------------------------------------------------------------------
+// 20-03 wave δ — outermost-IR-node loc-presence audit (PV36 + PK13 step 1).
+//
+// RESEARCH §5.8 enumerated every recognised applyMethod arm in
+// parseStrudel.ts:303-732 and confirmed each one calls tagMeta(...) or
+// literal-construction with [start, end]. Wave δ doesn't change any arm
+// — it confirms via test that the OUTERMOST IR node returned from
+// parseStrudel(code) carries loc.length >= 1 across the W7 corpus.
+//
+// The default: arm at parseStrudel.ts:729 is the only construction-time
+// gap; phase 20-04 (PV37) owns it. This audit explicitly does NOT cover
+// it — every fixture below is a recognised arm.
+//
+// Why these probes: they catch drift if a future arm ships without a
+// loc field on the outermost IR node, before wave-ε event-level checks
+// can even fire. parser-side regression caught at the parser boundary.
+// ---------------------------------------------------------------------------
+describe('20-03 — outermost IR node carries loc (wave δ audit)', () => {
+  const W7_OUTERMOST_FIXTURES: ReadonlyArray<{
+    name: string
+    code: string
+  }> = [
+    { name: 'every', code: 'note("c d e f").every(2, x => x.fast(2))' },
+    { name: 'sometimes', code: 'note("c d").sometimes(x => x.fast(2))' },
+    { name: 'sometimesBy', code: 'note("c d").sometimesBy(0.5, x => x.fast(2))' },
+    { name: 'chunk', code: 'note("c d e f").chunk(4, x => x.fast(2))' },
+    { name: 'off', code: 'note("c d").off(0.125, x => x.gain(0.5))' },
+    { name: 'jux', code: 'note("c d").jux(rev)' },
+    { name: 'layer', code: 'note("c d").layer(x => x.fast(2))' },
+    { name: 'late', code: 'note("c d e f").late(0.125)' },
+    { name: 'degrade', code: 's("bd hh sd cp ride lt mt ht").degrade()' },
+    { name: 'degradeBy', code: 's("bd hh sd cp ride lt mt ht").degradeBy(0.3)' },
+    { name: 'chop', code: 's("bd").chop(4)' },
+    { name: 'pick', code: 'mini("<0 1>").pick(["c","e"]).note()' },
+    { name: 'struct', code: 'note("c d e f").struct("x ~ x ~")' },
+    { name: 'swing', code: 'note("c d e f").swing(4)' },
+    { name: 'shuffle', code: 'note("c d e f").shuffle(4)' },
+    { name: 'scramble', code: 'note("c d e f").scramble(4)' },
+    { name: 'ply', code: 'note("c d").ply(2)' },
+    { name: '3-method chain', code: 's("bd").fast(2).late(0.125).gain(0.5)' },
+  ]
+
+  for (const { name, code } of W7_OUTERMOST_FIXTURES) {
+    it(`${name} — outermost IR node has loc.length >= 1`, () => {
+      const ir = parseStrudel(code) as PatternIR & { loc?: SourceLocation[] }
+      expect(ir.loc).toBeDefined()
+      expect(ir.loc!.length).toBeGreaterThanOrEqual(1)
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
 // 19-05 / #74 — `userMethod` round-trip on representative tags (D-08).
 //
 // D-08 exact-token taxonomy: `userMethod` is the literal method name the

--- a/packages/editor/src/ir/collect.ts
+++ b/packages/editor/src/ir/collect.ts
@@ -10,7 +10,7 @@
  */
 
 import type { PatternIR } from './PatternIR'
-import type { IREvent } from './IREvent'
+import type { IREvent, SourceLocation } from './IREvent'
 
 // ---------------------------------------------------------------------------
 // Deterministic seeded PRNG used by the `Degrade` tag. We mirror Strudel's
@@ -88,6 +88,31 @@ function seededRandsAtTime(t: number, n: number, seed: number): number[] {
     s = xorwise(s)
   }
   return out
+}
+
+/**
+ * Append a wrapper IR node's loc range to each event's existing loc array,
+ * preserving D-01 innermost-first ordering. Used by class-B/A collect arms
+ * to thread parent IR's source range onto produced events without
+ * overwriting child-atom provenance.
+ *
+ * Append, never prepend — child events arriving here may already carry
+ * multi-element loc[] (e.g. Play inside Late inside Off); the wrapper's
+ * range becomes loc[N], not loc[0]. Consumers reading loc[0] continue
+ * to get the most-specific atom range.
+ *
+ * PV36 / PK13 step 3.
+ */
+function withWrapperLoc(
+  events: IREvent[],
+  wrapper?: PatternIR['loc'],
+): IREvent[] {
+  if (!wrapper || wrapper.length === 0) return events
+  const range = wrapper[0]
+  return events.map((e) => ({
+    ...e,
+    loc: e.loc ? [...e.loc, range] : [range],
+  }))
 }
 
 export interface CollectContext {
@@ -187,6 +212,7 @@ function _collectRearrange(
   n: number,
   body: PatternIR,
   ctx: CollectContext,
+  wrapperLoc?: SourceLocation,
 ): IREvent[] {
   const bodyEvents = walk(body, ctx)
   const out: IREvent[] = []
@@ -212,7 +238,14 @@ function _collectRearrange(
       }
     }
   }
-  return out
+  // PV36 / D-01 — append the .shuffle(N)/.scramble(N) call-site range
+  // after each event's existing loc (innermost stays at loc[0]). When
+  // wrapperLoc is omitted (legacy callers), behaviour is unchanged.
+  if (!wrapperLoc) return out
+  return out.map((e) => ({
+    ...e,
+    loc: e.loc ? [...e.loc, wrapperLoc] : [wrapperLoc],
+  }))
 }
 
 /**
@@ -223,7 +256,21 @@ function _collectRearrange(
  */
 export function collect(ir: PatternIR, partialCtx?: Partial<CollectContext>): IREvent[] {
   const ctx: CollectContext = { ...DEFAULT_CONTEXT, ...partialCtx }
-  return walk(ir, ctx)
+  const events = walk(ir, ctx)
+  // PV36 / D-03 — dev-only loc-completeness catcher. esbuild substitutes
+  // process.env.NODE_ENV at build time; production builds dead-code-
+  // eliminate the entire block. vitest runs with NODE_ENV='test' so the
+  // warn fires alongside the contract test, giving two complementary
+  // signals when a future arm ships without loc-propagation.
+  if (process.env.NODE_ENV !== 'production') {
+    for (const e of events) {
+      if (!e.loc || e.loc.length === 0) {
+        // eslint-disable-next-line no-console
+        console.warn('[PV36] event produced without loc', { ir, event: e })
+      }
+    }
+  }
+  return events
 }
 
 function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
@@ -277,7 +324,10 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
         events.push(...childEvents)
         cursor += slotDuration / ctx.speed
       }
-      return events
+      // PV36 — top-level Seq nodes (synthetic from extractTracks) have
+      // no loc; user-visible Seq nodes (from sequence(...)) carry their
+      // call-site range. withWrapperLoc no-ops when ir.loc is empty.
+      return withWrapperLoc(events, ir.loc)
     }
 
     case 'Stack': {
@@ -286,20 +336,28 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
       for (const track of ir.tracks) {
         events.push(...walk(track, ctx))
       }
-      return events
+      // PV36 — synthetic Stack from layer/jux/off carries the call-site
+      // range as ir.loc (parseStrudel.ts:392-397/517-522/593-599); that
+      // becomes the wrapper provenance on every produced event. Multi-
+      // track top-level Stack from extractTracks has no loc; helper
+      // no-ops in that case.
+      return withWrapperLoc(events, ir.loc)
     }
 
     case 'Choice': {
       // Probabilistic: pick one branch (seeded determinism deferred to Phase 19)
       const chosen = Math.random() < ir.p ? ir.then : ir.else_
-      return walk(chosen, ctx)
+      // PV36 — the .sometimes(...) / .sometimesBy(...) call-site is the
+      // wrapper provenance the user clicked.
+      return withWrapperLoc(walk(chosen, ctx), ir.loc)
     }
 
     case 'Every': {
       // Periodic: body fires on matching cycles, default otherwise
       const fires = ctx.cycle % ir.n === 0
-      if (fires) return walk(ir.body, ctx)
-      if (ir.default_) return walk(ir.default_, ctx)
+      // PV36 — both branches share the .every(n, ...) call-site as wrapper.
+      if (fires) return withWrapperLoc(walk(ir.body, ctx), ir.loc)
+      if (ir.default_) return withWrapperLoc(walk(ir.default_, ctx), ir.loc)
       return []
     }
 
@@ -307,7 +365,7 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
       // Alternation: pick item based on current cycle
       if (ir.items.length === 0) return []
       const item = ir.items[ctx.cycle % ir.items.length]
-      return walk(item, ctx)
+      return withWrapperLoc(walk(item, ctx), ir.loc)
     }
 
     case 'When': {
@@ -319,7 +377,9 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
       const slotIndex = Math.floor((ctx.time % 1) * slots.length)
       const slot = slots[Math.min(slotIndex, slots.length - 1)]
       const active = slot !== '0' && slot !== '' && slot !== '~'
-      if (active) return walk(ir.body, ctx)
+      // PV36 — DV-06 atomic gate-token loc is deferred; loc on the
+      // entire .mask(...) / .struct(...) call site is sufficient for v1.
+      if (active) return withWrapperLoc(walk(ir.body, ctx), ir.loc)
       return []
     }
 
@@ -329,7 +389,8 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
         ...ctx,
         params: { ...ctx.params, ...ir.params },
       }
-      return walk(ir.body, childCtx)
+      // PV36 — .gain(N) / .pan(N) / .lpf(N) etc. call-site as wrapper.
+      return withWrapperLoc(walk(ir.body, childCtx), ir.loc)
     }
 
     case 'Ramp': {
@@ -340,7 +401,7 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
         ...ctx,
         params: { ...ctx.params, [ir.param]: value },
       }
-      return walk(ir.body, childCtx)
+      return withWrapperLoc(walk(ir.body, childCtx), ir.loc)
     }
 
     case 'Fast': {
@@ -350,7 +411,9 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
         speed: ctx.speed * ir.factor,
         duration: ctx.duration,
       }
-      return walk(ir.body, childCtx)
+      // PV36 — .fast(N) call-site. fast(2) duplicates inherit the same
+      // loc[1+] (DV-05 — Inspector dedupes by (loc[0], begin) pair).
+      return withWrapperLoc(walk(ir.body, childCtx), ir.loc)
     }
 
     case 'Slow': {
@@ -360,13 +423,13 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
         speed: ctx.speed / ir.factor,
         duration: ctx.duration,
       }
-      return walk(ir.body, childCtx)
+      return withWrapperLoc(walk(ir.body, childCtx), ir.loc)
     }
 
     case 'Loop': {
       // Loop is structural — the scheduler handles repetition.
       // collect() evaluates body once (for the current cycle window).
-      return walk(ir.body, ctx)
+      return withWrapperLoc(walk(ir.body, ctx), ir.loc)
     }
 
     case 'Elongate': {
@@ -375,7 +438,7 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
       // — there is no sibling to take time from, so we just walk the
       // body unchanged. The factor is recoverable from the tree if a
       // future consumer needs structural intent.
-      return walk(ir.body, ctx)
+      return withWrapperLoc(walk(ir.body, ctx), ir.loc)
     }
 
     case 'Late': {
@@ -391,7 +454,7 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
       // overwhelming-typical Strudel use case — at most one wrap unit is
       // needed.
       const events = walk(ir.body, ctx)
-      return events.map((e) => {
+      const shifted = events.map((e) => {
         let begin = e.begin + ir.offset
         let end = e.end + ir.offset
         let endClipped = e.endClipped + ir.offset
@@ -406,6 +469,9 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
         }
         return { ...e, begin, end, endClipped }
       })
+      // PV36 — .late(t) call-site (or off-derived synthetic Late carrying
+      // the .off(...) range as ir.loc per parseStrudel.ts:585-588).
+      return withWrapperLoc(shifted, ir.loc)
     }
 
     case 'Degrade': {
@@ -431,7 +497,11 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
       // when event onsets match.
       const events = walk(ir.body, ctx)
       const dropAmount = 1 - ir.p
-      return events.filter((e) => seededRand(e.begin, RAND_SEED) > dropAmount)
+      const survivors = events.filter(
+        (e) => seededRand(e.begin, RAND_SEED) > dropAmount,
+      )
+      // PV36 — .degrade() / .degradeBy(x) call-site as wrapper.
+      return withWrapperLoc(survivors, ir.loc)
     }
 
     case 'Chunk': {
@@ -482,13 +552,16 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
       // tolerance because Strudel uses Fraction; our IR uses Number.
       const findTransformed = (e: IREvent): IREvent | undefined =>
         transformedEvents.find((t) => Math.abs(t.begin - e.begin) < 1e-9)
-      return baseEvents.map((e) => {
+      const composed = baseEvents.map((e) => {
         if (inSlot(e)) {
           const replaced = findTransformed(e)
           return replaced ?? e
         }
         return e
       })
+      // PV36 — .chunk(n, transform) call-site as wrapper. Both branches
+      // (replaced and pass-through) need it; map after the swap.
+      return withWrapperLoc(composed, ir.loc)
     }
 
     case 'Pick': {
@@ -531,12 +604,22 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
           // its own cycle 0 within the selector event's slot.
         }
         const subEvents = walk(subIR, subCtx)
-        // Propagate the selector event's loc onto sub-events when the
-        // sub-event lacks its own loc (PV24 — every IREvent must carry
-        // loc; the selector's loc is the closest source range).
+        // PV36 / D-01 — multi-range loc: lookup atom is innermost
+        // (loc[0]), selector is loc[1], .pick(...) call-site is loc[2].
+        // Replaces the pre-PV36 conditional-assignment shape (which only
+        // wrote selector.loc when child lacked one). When the child has
+        // its own loc it stays at loc[0]; consumers reading loc[0]
+        // continue to get the most-specific atom range.
+        const selectorLoc = sel.loc?.[0]
+        const wrapperLoc = ir.loc?.[0]
         for (const e of subEvents) {
-          if (!e.loc && sel.loc) e.loc = sel.loc
-          out.push(e)
+          const childLoc = e.loc ?? []
+          const newLoc = [
+            ...childLoc,
+            ...(selectorLoc ? [selectorLoc] : []),
+            ...(wrapperLoc ? [wrapperLoc] : []),
+          ]
+          out.push(newLoc.length > 0 ? { ...e, loc: newLoc } : e)
         }
       }
       return out
@@ -592,7 +675,9 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
           }
         }
       }
-      return out
+      // PV36 — .struct("...") call-site as wrapper. DV-06 atomic gate-
+      // token loc is deferred.
+      return withWrapperLoc(out, ir.loc)
     }
 
     case 'Swing': {
@@ -615,9 +700,9 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
       // re-play body — same trap that promoted Ply to a forced tag).
       // Instead we apply lateness directly to body events.
       const events = walk(ir.body, ctx)
-      if (ir.n < 1) return events
+      if (ir.n < 1) return withWrapperLoc(events, ir.loc)
       const swingAmount = 1 / (6 * ir.n)
-      return events.map((e) => {
+      const swung = events.map((e) => {
         const cyclePos = e.begin - ctx.cycle
         const slotIdx = Math.floor(cyclePos * ir.n)
         if (slotIdx % 2 === 1) {
@@ -630,6 +715,9 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
         }
         return e
       })
+      // PV36 — .swing(n) call-site as wrapper. Both branches (swung and
+      // pass-through) need it; map after the lateness application.
+      return withWrapperLoc(swung, ir.loc)
     }
 
     case 'Ply': {
@@ -653,7 +741,7 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
       // copies whose `begin` and `end` carve up the original [begin, end)
       // window. `loc` flows through the spread (PV24).
       const baseEvents = walk(ir.body, ctx)
-      if (ir.n <= 1) return baseEvents
+      if (ir.n <= 1) return withWrapperLoc(baseEvents, ir.loc)
       const out: IREvent[] = []
       for (const e of baseEvents) {
         const slotLen = (e.end - e.begin) / ir.n
@@ -668,7 +756,9 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
           })
         }
       }
-      return out
+      // PV36 — .ply(n) call-site as wrapper. The n duplicates per source
+      // event share child atom (loc[0]) AND ply call-site (loc[1+]).
+      return withWrapperLoc(out, ir.loc)
     }
 
     case 'Shuffle': {
@@ -689,13 +779,15 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
       // `(a[0] > b[0]) - (a[0] < b[0])` — so we sort raw, not absolute.
       //
       // PV28: re-time direct via _collectRearrange, NOT through Fast.
-      if (ir.n < 1) return walk(ir.body, ctx)
+      // PV36 — pass .shuffle(n) call-site to the shared helper so both
+      // Shuffle and Scramble thread their wrapper provenance the same way.
+      if (ir.n < 1) return withWrapperLoc(walk(ir.body, ctx), ir.loc)
       const rands = seededRandsAtTime(ctx.cycle + 0.5, ir.n, RAND_SEED)
       const perm = rands
         .map((r, i) => [r, i] as const)
         .sort((a, b) => (a[0] > b[0] ? 1 : a[0] < b[0] ? -1 : 0))
         .map((x) => x[1])
-      return _collectRearrange(perm, ir.n, ir.body, ctx)
+      return _collectRearrange(perm, ir.n, ir.body, ctx, ir.loc?.[0])
     }
 
     case 'Scramble': {
@@ -710,13 +802,14 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
       // per slot (with replacement); slices may repeat or not appear.
       //
       // PV28: re-time direct via _collectRearrange, NOT through Fast.
-      if (ir.n < 1) return walk(ir.body, ctx)
+      // PV36 — pass .scramble(n) call-site to the shared helper.
+      if (ir.n < 1) return withWrapperLoc(walk(ir.body, ctx), ir.loc)
       const selector: number[] = []
       for (let slot = 0; slot < ir.n; slot++) {
         const r = seededRand(ctx.cycle + slot / ir.n, RAND_SEED)
         selector.push(Math.trunc(r * ir.n))
       }
-      return _collectRearrange(selector, ir.n, ir.body, ctx)
+      return _collectRearrange(selector, ir.n, ir.body, ctx, ir.loc?.[0])
     }
 
     case 'Chop': {
@@ -747,7 +840,7 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
       // PV28: direct emission per source event, NOT a desugar through Fast.
       // Fast scales speed; it does not re-play the body. The same trap that
       // promoted Ply to a forced tag.
-      if (ir.n <= 1) return walk(ir.body, ctx)
+      if (ir.n <= 1) return withWrapperLoc(walk(ir.body, ctx), ir.loc)
       const baseEvents = walk(ir.body, ctx)
       const out: IREvent[] = []
       for (const e of baseEvents) {
@@ -771,7 +864,9 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
           })
         }
       }
-      return out
+      // PV36 — .chop(n) call-site as wrapper. The n sub-events per
+      // source event share child atom (loc[0]) + chop call-site (loc[1+]).
+      return withWrapperLoc(out, ir.loc)
     }
   }
 }


### PR DESCRIPTION
First half of debugger v1 (debugger primary objective, PIVOT 2026-05-07).

## Summary

Every IREvent now carries `loc: SourceLocation[]` with `length >= 1`,
ordered innermost-atom first (D-01). Click-to-source in MusicalTimeline
resolves to the correct source range for events derived from any IR
transform — not just leaf Plays. The 5 click-to-source fallback commits
on the preceding branch (cc19d5b..eab49d5) are reverted; `evt.loc[0]`
is the single contract.

Codified as PV36 (loc-completeness contract); PK13 steps 1-3 land here.

## Changes

Three commit waves in this PR per D-04:

- **Wave γ** (`e7afe50`) — revert(app): drop click-to-source regex
  fallbacks; loc-driven primary. handleNoteClick is now one line:
  `countLines(snapshot.code, evt.loc[0].start)`. Adds 5 click-to-source
  primary-path tests covering Play / Fast duplicates (DV-05) / Pick
  multi-line (verifies loc[0] controls line, not wrapper) / Off / Layer.
  +5 app vitest tests.

- **Wave δ** (`875781d`) — chore(editor): audit applyMethod loc
  attribution + extend W7 probe. Audit confirms every recognised arm
  in parseStrudel.ts:303-732 calls tagMeta(...) or literal-construct
  with [start, end] (RESEARCH §5.8). Adds 18 outermost-IR-node
  loc-presence asserts across the W7 corpus. +18 editor vitest tests.

- **Wave ε** (`120d239`) — feat(editor): loc-propagation across all
  collect arms. Adds `withWrapperLoc(events, wrapper)` helper and
  threads it through 19 class-B/A arms (Seq, Stack, Choice, Every,
  Cycle, When, FX, Ramp, Loop, Elongate, Fast, Slow, Late, Degrade,
  Chunk, Struct, Swing, Ply, Chop). Upgrades Pick to multi-range
  append. Extends `_collectRearrange` signature with optional
  `wrapperLoc` for Shuffle + Scramble (PV28 shared infra). Adds D-03
  dev-only console.warn at collect()'s return (esbuild dead-code-
  eliminates in prod). Adds 18 per-shape D-01 ordering fixtures + a
  15-entry contract corpus in parity.test.ts. +35 editor vitest tests.

## Locked decisions (CONTEXT §0 + discuss-phase ratification)

- **D-01** Multi-range loc; `event.loc = [innermost-atom, ...wrappers]`
- **D-02** Slice-γ fallbacks REMOVED; `evt.loc[0]` is single contract
- **D-03** Dev-only `console.warn` + test-only contract assertion
- **D-04** One PR with three commit waves (γ + δ + ε)

## Test plan

- [x] Editor vitest: 1274 → 1327 (+53)
- [x] App vitest: 149 → 154 (+5)
- [x] Editor tsc: 53 unchanged
- [x] App tsc: 0 (clean)
- [x] No regression in 19-04/05 narrow-tag parity tests
- [x] No regression in useHighlighting tests
- [x] Slice-γ regex (`blockRe`/`simpleRe`/`sampleRe`) absent from
      MusicalTimeline.tsx (grep gate)
- [x] `withWrapperLoc` helper defined in collect.ts (grep gate)
- [x] `_collectRearrange` accepts `wrapperLoc?` (grep gate)
- [x] Pick old conditional-assignment shape removed (grep gate)
- [x] Dev-warn block fires under NODE_ENV=test

## Out of scope

- Phase 20-04: opaque-fragment wrapper (PV37) — `applyMethod` default
  arm at parseStrudel.ts:729; the only construction-time loc gap.
- IRInspectorPanel guards (`evt.loc.length === 0`) become harmless
  no-ops once the contract holds. Cleanup is a follow-up phase.
- Tightening `IREvent.loc?: SourceLocation[]` to required is a
  separate type-system phase per RESEARCH §5.5.