### PR TITLE
feat(editor): engine ↔ IR identity channel (phase 20-05)

### DIFF
--- a/packages/editor/src/engine/NormalizedHap.ts
+++ b/packages/editor/src/engine/NormalizedHap.ts
@@ -53,6 +53,36 @@ function extractLoc(hap: unknown): SourceLocation[] | undefined {
 }
 
 /**
+ * Resolve a hap's leaf-loc to an irNodeId by structural lookup against
+ * the published snapshot's loc map (PV38 clause 2). Single-strategy:
+ *
+ *   key = `${loc[0].start}:${loc[0].end}`   (innermost leaf range)
+ *   tie-break = closest event by `whole.begin`
+ *
+ * On miss: returns undefined. The runtime-only-hap path (PV37-aligned) —
+ * NO fallback ladder (P50 awareness). If user patterns produce haps that
+ * don't structurally match, that's the runtime-only path; the corpus
+ * test catches genuine regressions, not the resolver.
+ */
+function findMatch(
+  loc: SourceLocation[] | undefined,
+  begin: number,
+  locLookup: ReadonlyMap<string, IREvent[]> | undefined,
+): string | undefined {
+  if (!locLookup || !loc || loc.length === 0) return undefined
+  const key = `${loc[0].start}:${loc[0].end}`
+  const candidates = locLookup.get(key)
+  if (!candidates || candidates.length === 0) return undefined
+  let best = candidates[0]
+  let bestDist = Math.abs(best.begin - begin)
+  for (let i = 1; i < candidates.length; i++) {
+    const d = Math.abs(candidates[i].begin - begin)
+    if (d < bestDist) { best = candidates[i]; bestDist = d }
+  }
+  return best.irNodeId
+}
+
+/**
  * Convert a raw Strudel hap into an IREvent (NormalizedHap).
  * Handles Fraction objects (Number() coercion), missing fields, and optional value bag.
  *
@@ -60,11 +90,16 @@ function extractLoc(hap: unknown): SourceLocation[] | undefined {
  * but per-track schedulers (`$:` blocks) know their id and pass it
  * through so downstream consumers (DAW view, transform debugger) can
  * attribute every event to a producer.
+ *
+ * `irNodeLocLookup` is caller-supplied — engine threads the published
+ * snapshot's loc map so each hap can be enriched with its `irNodeId`
+ * by structural match (PV38 clause 2). Both optional — additive widening.
  */
 export function normalizeStrudelHap(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   hap: any,
   trackId?: string,
+  irNodeLocLookup?: ReadonlyMap<string, IREvent[]>,
 ): NormalizedHap {
   const begin = Number(hap.whole?.begin ?? 0)
   const end = Number(hap.whole?.end ?? begin + 0.25)
@@ -84,6 +119,13 @@ export function normalizeStrudelHap(
   const loc = extractLoc(hap)
   if (loc) event.loc = loc
   if (trackId) event.trackId = trackId
+  // PV38 clause 2 — single-strategy structural match. Miss → undefined
+  // (PV37-aligned runtime-only path; no fallback ladder per P50).
+  const id = findMatch(loc, begin, irNodeLocLookup)
+  // IMPORTANT: only set when truthy — preserves "absent" vs "present:undefined"
+  // distinction (PV37 alignment). Unconditional `event.irNodeId = id` would
+  // serialize an `undefined`-valued key, breaking any future shape-deep probe.
+  if (id) event.irNodeId = id
   const params = extractParams(value)
   if (params) event.params = params
   return event

--- a/packages/editor/src/engine/StrudelEngine.ts
+++ b/packages/editor/src/engine/StrudelEngine.ts
@@ -100,6 +100,11 @@ export class StrudelEngine implements LiveCodingEngine {
   // Pattern IR from the last successful evaluate() — derived by propagation
   private lastPatternIR: PatternIR | null = null
   private lastIREvents: IREvent[] = []
+  // PV38 clause 2 — loc-keyed lookup over lastIREvents; both queryArc
+  // callbacks (per-track + convenience) read this to enrich haps with
+  // `irNodeId`. Mirrors the lifecycle of lastIREvents (built on eval
+  // success, cleared on failure).
+  private lastIRNodeLocLookup: ReadonlyMap<string, IREvent[]> | null = null
 
   async init(): Promise<void> {
     if (this.initialized) return
@@ -365,7 +370,7 @@ export class StrudelEngine implements LiveCodingEngine {
               try {
                 return captured
                   .queryArc(begin, end)
-                  .map((hap: unknown) => normalizeStrudelHap(hap, trackId))
+                  .map((hap: unknown) => normalizeStrudelHap(hap, trackId, this.lastIRNodeLocLookup ?? undefined))
               } catch {
                 return []
               }
@@ -390,10 +395,31 @@ export class StrudelEngine implements LiveCodingEngine {
         )
         this.lastPatternIR = irBag.patternIR ?? null
         this.lastIREvents = irBag.irEvents ?? []
+        // PV38 clause 2 — build the loc lookup once per eval; queryArc
+        // callbacks read it to enrich haps with irNodeId. Mirrors how
+        // lastIREvents is stored alongside lastPatternIR. ReadonlyMap
+        // (via type) enforces PV33 immutability per snapshot lifetime.
+        // NOTE: this duplicates the loc-lookup build in irInspector.ts's
+        // `enrichWithLookups` — kept separate per phase 20-05 PLAN §7
+        // T-γ-4 "Note on duplication": two specific sites today (engine's
+        // lastIREvents from `propagate()` vs published snapshot from
+        // `collect(finalIR)` in StrudelEditorClient.tsx). DEC-NEW-1:
+        // consolidation requires a third occurrence + span-check signal.
+        const locLookup = new Map<string, IREvent[]>()
+        for (const e of this.lastIREvents) {
+          if (e.loc && e.loc.length > 0) {
+            const key = `${e.loc[0].start}:${e.loc[0].end}`
+            const arr = locLookup.get(key)
+            if (arr) arr.push(e)
+            else locLookup.set(key, [e])
+          }
+        }
+        this.lastIRNodeLocLookup = locLookup
       } else {
         // Failed evaluate — clear stale IR
         this.lastPatternIR = null
         this.lastIREvents = []
+        this.lastIRNodeLocLookup = null
       }
 
       return result
@@ -577,7 +603,15 @@ export class StrudelEngine implements LiveCodingEngine {
     return {
       now: () => sched.now(),
       query: (begin: number, end: number) => {
-        try { return pattern.queryArc(begin, end).map(normalizeStrudelHap) } catch { return [] }
+        // Side-fix (closes #101): the previous bare normalizeStrudelHap reference
+        // passed directly to Array#map received the `index` arg as trackId
+        // (latent bug since the trackId param landed). Arrow-wrap explicitly
+        // to pass undefined trackId AND the loc lookup. PV38 clause 2 + Trap 8.
+        try {
+          return pattern
+            .queryArc(begin, end)
+            .map((hap: unknown) => normalizeStrudelHap(hap, undefined, this.lastIRNodeLocLookup ?? undefined))
+        } catch { return [] }
       },
     }
   }

--- a/packages/editor/src/engine/__tests__/NormalizedHap.test.ts
+++ b/packages/editor/src/engine/__tests__/NormalizedHap.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { normalizeStrudelHap } from '../NormalizedHap'
+import type { IREvent } from '../../ir/IREvent'
 
 describe('normalizeStrudelHap', () => {
   it('extracts all fields from a full Strudel hap with Fraction-like objects', () => {
@@ -176,5 +177,63 @@ describe('normalizeStrudelHap', () => {
       expect(n.trackId).toBe('bass')
       expect(n.params).toEqual({ cutoff: 800 })
     })
+  })
+})
+
+describe('20-05 — normalizeStrudelHap resolves irNodeId from snapshot lookup (PV38 clause 2)', () => {
+  it('matches when hap.context.locations[0] + whole.begin agree with a candidate', () => {
+    const irEvent: IREvent = {
+      begin: 0.5, end: 1.0, endClipped: 1.0,
+      note: 'c4', freq: null, s: null, gain: 1, velocity: 1, color: null,
+      loc: [{ start: 5, end: 10 }],
+      irNodeId: 'fnv1abcd',
+    }
+    const lookup = new Map<string, IREvent[]>([['5:10', [irEvent]]])
+    const hap = {
+      whole: { begin: 0.5, end: 1.0 },
+      value: { note: 'c4' },
+      context: { locations: [{ start: 5, end: 10 }] },
+    }
+    const n = normalizeStrudelHap(hap, undefined, lookup)
+    expect(n.irNodeId).toBe('fnv1abcd')
+  })
+
+  it('returns undefined irNodeId when hap has no context (pure(...) / runtime-only path; PV37-aligned)', () => {
+    const lookup = new Map<string, IREvent[]>()
+    const hap = { whole: { begin: 0.5, end: 1.0 }, value: { note: 'c4' } }
+    const n = normalizeStrudelHap(hap, undefined, lookup)
+    expect(n.irNodeId).toBeUndefined()
+  })
+
+  it('returns undefined irNodeId when loc has no match in snapshot (runtime-only PV37 alignment; no fallback ladder per P50)', () => {
+    const lookup = new Map<string, IREvent[]>([['5:10', []]])
+    const hap = {
+      whole: { begin: 0.5, end: 1.0 },
+      value: { note: 'c4' },
+      context: { locations: [{ start: 99, end: 100 }] },
+    }
+    const n = normalizeStrudelHap(hap, undefined, lookup)
+    expect(n.irNodeId).toBeUndefined()
+  })
+
+  it('disambiguates among multiple events sharing a loc by closest begin (fast(N) / ply duplicate scenario)', () => {
+    const ev0: IREvent = {
+      begin: 0.0, end: 0.5, endClipped: 0.5,
+      note: 'c4', freq: null, s: null, gain: 1, velocity: 1, color: null,
+      loc: [{ start: 5, end: 10 }], irNodeId: 'idA',
+    }
+    const ev1: IREvent = {
+      begin: 0.5, end: 1.0, endClipped: 1.0,
+      note: 'c4', freq: null, s: null, gain: 1, velocity: 1, color: null,
+      loc: [{ start: 5, end: 10 }], irNodeId: 'idB',
+    }
+    const lookup = new Map<string, IREvent[]>([['5:10', [ev0, ev1]]])
+    const hap = {
+      whole: { begin: 0.5, end: 1.0 },
+      value: { note: 'c4' },
+      context: { locations: [{ start: 5, end: 10 }] },
+    }
+    const n = normalizeStrudelHap(hap, undefined, lookup)
+    expect(n.irNodeId).toBe('idB')
   })
 })

--- a/packages/editor/src/engine/__tests__/irInspector.integration.test.ts
+++ b/packages/editor/src/engine/__tests__/irInspector.integration.test.ts
@@ -24,7 +24,7 @@ import {
   type Pass,
 } from '../../ir'
 import type { PatternIR } from '../../ir/PatternIR'
-import { publishIRSnapshot, clearIRSnapshot, type IRSnapshot } from '../irInspector'
+import { publishIRSnapshot, clearIRSnapshot, type IRSnapshotInput } from '../irInspector'
 import { getCaptureBuffer, __resetCaptureForTest } from '../timelineCapture'
 
 const v4Passes: readonly Pass<PatternIR>[] = [
@@ -99,7 +99,7 @@ describe('irInspector integration — parse → run → collect', () => {
 // refactors that accidentally break the fan-out trip a clear test
 // here, separate from the unit-level coverage in timelineCapture.test.ts.
 
-function buildSnap(code: string = 'note("c3")'): IRSnapshot {
+function buildSnap(code: string = 'note("c3")'): IRSnapshotInput {
   const seed = IR.code(code)
   const passes = runPasses(seed, v4Passes)
   const finalIR = passes[passes.length - 1].ir
@@ -125,8 +125,18 @@ describe('publishIRSnapshot also captures into timelineCapture (PK9 step 8a)', (
     const snap = buildSnap()
     publishIRSnapshot(snap, { cycleCount: 1.5 })
     expect(getCaptureBuffer()).toHaveLength(1)
-    // PV27-cousin: snapshot stored BY REFERENCE, not cloned.
-    expect(getCaptureBuffer()[0].snapshot).toBe(snap)
+    // PV27-cousin: snapshot stored without deep-cloning. Phase 20-05: the
+    // publisher now wraps the input via `enrichWithLookups` (PV38 clause 1)
+    // — a shallow spread that adds `irNodeIdLookup` + `irNodeLocLookup`
+    // and preserves all inner references (events, passes, ir). The
+    // captured snapshot is the enriched object; inner refs equal the
+    // input's inner refs (no deep clone, only a shallow wrap).
+    const captured = getCaptureBuffer()[0].snapshot
+    expect(captured.events).toBe(snap.events)
+    expect(captured.passes).toBe(snap.passes)
+    expect(captured.ir).toBe(snap.ir)
+    expect(captured.irNodeIdLookup).toBeInstanceOf(Map)
+    expect(captured.irNodeLocLookup).toBeInstanceOf(Map)
     expect(getCaptureBuffer()[0].cycleCount).toBe(1.5)
   })
 

--- a/packages/editor/src/engine/__tests__/irInspector.test.ts
+++ b/packages/editor/src/engine/__tests__/irInspector.test.ts
@@ -5,10 +5,11 @@ import {
   getIRSnapshot,
   subscribeIRSnapshot,
   type IRSnapshot,
+  type IRSnapshotInput,
 } from '../irInspector'
 import { IR } from '../../ir/PatternIR'
 
-const sample = (): IRSnapshot => {
+const sample = (): IRSnapshotInput => {
   const ir = IR.play('c4')
   return {
     ts: 1000,
@@ -104,7 +105,7 @@ describe('irInspector store', () => {
   it('multi-pass: ir alias matches passes[last]', () => {
     const irA = IR.play('c4')
     const irB = IR.play('d4')
-    const snap: IRSnapshot = {
+    const snap: IRSnapshotInput = {
       ts: 1,
       source: 'pattern.strudel',
       runtime: 'strudel',
@@ -136,5 +137,13 @@ describe('irInspector store', () => {
     // ts-expect-error directive load-bearing (the literal above is the
     // sole reason this assignment is type-checked).
     expect(bad).toBeDefined()
+  })
+
+  it('publishIRSnapshot enriches with frozen lookup tables (PV38 clause 1 / PV33)', () => {
+    publishIRSnapshot(sample())
+    const got = getIRSnapshot()
+    expect(got).not.toBeNull()
+    expect(got!.irNodeIdLookup).toBeInstanceOf(Map)
+    expect(got!.irNodeLocLookup).toBeInstanceOf(Map)
   })
 })

--- a/packages/editor/src/engine/__tests__/timelineCapture.test.ts
+++ b/packages/editor/src/engine/__tests__/timelineCapture.test.ts
@@ -13,6 +13,9 @@ import { IR } from '../../ir/PatternIR'
 
 // Mirror irInspector.test.ts:11-22 sample shape; freshen each call so
 // Object.freeze in captureSnapshot doesn't poison cross-test references.
+// Phase 20-05: IRSnapshot grew two ReadonlyMap lookup fields (PV38 clause 1)
+// — empty Maps are fine here since captureSnapshot is called directly,
+// bypassing the publisher's enrichWithLookups.
 function sample(label: string = 'a'): IRSnapshot {
   const ir = IR.play('c4')
   return {
@@ -23,6 +26,8 @@ function sample(label: string = 'a'): IRSnapshot {
     passes: [{ name: 'Parsed', ir }],
     ir, // alias of passes[last].ir per IRSnapshot contract
     events: [],
+    irNodeIdLookup: new Map(),
+    irNodeLocLookup: new Map(),
   }
 }
 

--- a/packages/editor/src/engine/irInspector.ts
+++ b/packages/editor/src/engine/irInspector.ts
@@ -28,12 +28,47 @@ export interface IRSnapshot {
   ir: PatternIR
   /** Collected events for one cycle window starting at t=0. */
   events: IREvent[]
+  /** Lookup: irNodeId → IREvent. PV38 clause 1.
+   *  Built at publish time by enrichWithLookups; ReadonlyMap enforces
+   *  PV33 (snapshot immutability post-publish). */
+  irNodeIdLookup: ReadonlyMap<string, IREvent>
+  /** Lookup: `${loc[0].start}:${loc[0].end}` → IREvent[]. Used by
+   *  engine-side hap matching (normalizeStrudelHap); haps don't carry
+   *  the hash, only the loc. ReadonlyMap enforces PV33. */
+  irNodeLocLookup: ReadonlyMap<string, IREvent[]>
 }
+
+/** Input shape for publishIRSnapshot — caller does not construct lookups;
+ *  the publisher enriches via enrichWithLookups. Type-system enforces
+ *  this contract (Trap 9 mitigation — caller cannot bypass the publisher). */
+export type IRSnapshotInput = Omit<IRSnapshot, 'irNodeIdLookup' | 'irNodeLocLookup'>
 
 type Listener = (snap: IRSnapshot | null) => void
 
 let current: IRSnapshot | null = null
 const listeners = new Set<Listener>()
+
+/** Build the two lookup tables from snap.events. Pure function; returns
+ *  a NEW IRSnapshot with the lookups attached. Original `snap` is unchanged
+ *  (PV33 alignment — caller's input shape is never mutated). */
+function enrichWithLookups(snap: IRSnapshotInput): IRSnapshot {
+  const idLookup = new Map<string, IREvent>()
+  const locLookup = new Map<string, IREvent[]>()
+  for (const e of snap.events) {
+    if (e.irNodeId) idLookup.set(e.irNodeId, e)
+    if (e.loc && e.loc.length > 0) {
+      const key = `${e.loc[0].start}:${e.loc[0].end}`
+      const arr = locLookup.get(key)
+      if (arr) arr.push(e)
+      else locLookup.set(key, [e])
+    }
+  }
+  return {
+    ...snap,
+    irNodeIdLookup: idLookup,
+    irNodeLocLookup: locLookup,
+  }
+}
 
 /**
  * Publish a snapshot. Two parallel side-effects fire on every publish
@@ -49,18 +84,21 @@ const listeners = new Set<Listener>()
  * defaults `cycleCount` to `null` in that case.
  */
 export function publishIRSnapshot(
-  snap: IRSnapshot,
+  snap: IRSnapshotInput,
   meta?: { cycleCount?: number | null },
 ): void {
-  current = snap
+  // Enrich BEFORE storing/capturing/notifying so all consumers see the
+  // same lookup tables. PV33: lookups join the immutable snapshot.
+  const enriched = enrichWithLookups(snap)
+  current = enriched
   // PK9 step 8a — timeline capture fan-out (Phase 19-08).
-  captureSnapshot(snap, {
-    ts: snap.ts,
+  captureSnapshot(enriched, {
+    ts: enriched.ts,
     cycleCount: meta?.cycleCount ?? null,
   })
   // PK9 step 8b — listener fan-out (single-slot consumers).
   for (const l of listeners) {
-    try { l(snap) } catch { /* listener errors don't block the publish */ }
+    try { l(enriched) } catch { /* listener errors don't block the publish */ }
   }
 }
 

--- a/packages/editor/src/ir/IREvent.ts
+++ b/packages/editor/src/ir/IREvent.ts
@@ -44,6 +44,12 @@ export interface IREvent {
 
   /** Source code ranges for highlighting */
   loc?: SourceLocation[]
+  /** Stable content-addressed id of the IR node that produced this event.
+   *  REQUIRED-by-convention for collect-produced events at the leaf arm
+   *  (PV38 clause 1; assigned by collect.ts:assignNodeId at the Play leaf).
+   *  Absent for hap-derived events with no IR-side match
+   *  (PV37-aligned runtime-only path). */
+  irNodeId?: string
   /** Which track/loop produced this event */
   trackId?: string
   /** Engine-specific extended parameters */

--- a/packages/editor/src/ir/__tests__/fnv1a.test.ts
+++ b/packages/editor/src/ir/__tests__/fnv1a.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { fnv1a } from '../collect'
+
+describe('20-05 — fnv1a (PV38 D-02 hash)', () => {
+  it('is deterministic — same input twice yields same digest', () => {
+    expect(fnv1a('5:10:Play:0')).toBe(fnv1a('5:10:Play:0'))
+  })
+  it('returns 8-char hex digest', () => {
+    const out = fnv1a('5:10:Play:0')
+    expect(out).toMatch(/^[0-9a-f]{8}$/)
+  })
+  it('different inputs yield different digests (sanity, not pairwise-distinct)', () => {
+    expect(fnv1a('5:10:Play:0')).not.toBe(fnv1a('5:10:Play:1'))
+    expect(fnv1a('5:10:Play:0')).not.toBe(fnv1a('5:11:Play:0'))
+    expect(fnv1a('5:10:Play:0')).not.toBe(fnv1a('5:10:Pure:0'))
+  })
+})

--- a/packages/editor/src/ir/__tests__/parity.test.ts
+++ b/packages/editor/src/ir/__tests__/parity.test.ts
@@ -1788,6 +1788,73 @@ describe('20-03 — PV36 loc-completeness across collect arms', () => {
 
 
 // ---------------------------------------------------------------------------
+// Phase 20-05 wave β — irNodeId determinism + corpus uniqueness/lookup
+// (PV38 clause 1 / PK13 step 4 / D-02). Pairs with the Play-arm
+// assignNodeId wiring in collect.ts. Wrapper arms preserve irNodeId via
+// existing {...e, ...} spread semantics — no per-arm wiring needed
+// (RESEARCH DEC-NEW-1: leaf-only assignment).
+// ---------------------------------------------------------------------------
+
+describe('20-05 — irNodeId determinism + lookup-resolution (PV38 / D-02)', () => {
+  it('same code parsed twice yields identical irNodeIds for every event', () => {
+    const code = 'note("c d e f").fast(2)'
+    const events1 = collect(parseStrudel(code))
+    const events2 = collect(parseStrudel(code))
+    expect(events1.length).toBe(events2.length)
+    for (let i = 0; i < events1.length; i++) {
+      expect(events1[i].irNodeId).toBeTruthy()
+      expect(events1[i].irNodeId).toBe(events2[i].irNodeId)
+    }
+  })
+})
+
+describe('20-05 — irNodeId set per event + resolves in id→event map (PV38 / D-02)', () => {
+  // CORPUS reused from line 1749 (PV36 loc-completeness contract).
+  const CORPUS: ReadonlyArray<string> = [
+    'note("c d e f")',
+    'note("c d").fast(2)',
+    'note("c d").slow(2)',
+    'note("c d e f").late(0.125)',
+    's("bd hh sd cp").ply(3)',
+    'mini("<0 1>").pick(["c","e"]).note()',
+    'note("c d").layer(x => x.fast(2))',
+    'note("c d").off(0.125, x => x.gain(0.5))',
+    'note("c d").every(2, x => x.fast(2))',
+    's("bd hh").chop(4)',
+    'note("c d e f").shuffle(4)',
+    'note("c d e f g h").scramble(4)',
+    's("bd").struct("1 0 1 1")',
+    'note("c d").mask("1 0 1 1")',
+    'note("c d").gain(0.5).lpf(2400).slow(2)',
+  ]
+  for (const code of CORPUS) {
+    it(`every event has a truthy irNodeId; the id resolves to an event in id→event map — ${JSON.stringify(code).slice(0, 60)}`, () => {
+      let totalEvents = 0
+      // Build a synthesised id→event map across all cycles
+      const idMap = new Map<string, IREvent>()
+      for (let c = 0; c < 4; c++) {
+        const events = collect(parseStrudel(code), { cycle: c } as CollectContext)
+        totalEvents += events.length
+        for (const e of events) {
+          expect(e.irNodeId, `code=${code} cycle=${c} event=${JSON.stringify(e)}`).toBeTruthy()
+          // Lookup resolves: same id → same leaf-loc (the underlying contract)
+          const existing = idMap.get(e.irNodeId!)
+          if (existing) {
+            // Duplicates from fast/ply/chunk are EXPECTED — assert they share leaf-loc
+            expect(existing.loc?.[0]).toEqual(e.loc?.[0])
+          } else {
+            idMap.set(e.irNodeId!, e)
+          }
+        }
+      }
+      expect(totalEvents).toBeGreaterThan(0)
+      expect(idMap.size).toBeGreaterThan(0)
+    })
+  }
+})
+
+
+// ---------------------------------------------------------------------------
 // Phase 20-04 wave β — parser-side wrap probes (D-03 / P33 / PV37).
 // ---------------------------------------------------------------------------
 

--- a/packages/editor/src/ir/collect.ts
+++ b/packages/editor/src/ir/collect.ts
@@ -354,6 +354,11 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
       // sees an atom; nodes built by hand via IR.play() without loc
       // produce events with loc undefined.
       if (ir.loc && ir.loc.length > 0) event.loc = ir.loc
+      // PV38 clause 1 / PK13 step 4 / D-02 — assign content-addressed
+      // identity at the Play leaf. Wrapper arms preserve via existing
+      // {...e, ...} spread semantics (see withWrapperLoc, line 106-116).
+      // Position is 0: Play emits exactly one event per execution.
+      event.irNodeId = assignNodeId(ir, 0)
       return [event]
     }
 

--- a/packages/editor/src/ir/collect.ts
+++ b/packages/editor/src/ir/collect.ts
@@ -115,6 +115,54 @@ function withWrapperLoc(
   }))
 }
 
+/**
+ * FNV-1a 32-bit hash. Used by `assignNodeId` to derive content-addressed
+ * irNodeIds (PV38 D-02). Inputs: `${loc.start}:${loc.end}:${tag}:${position}`.
+ *
+ * Determinism: pure function, same input → same output.
+ * Uniqueness: 32-bit space; corpus-wide collision probability negligible
+ * for snapshot-scoped event counts. The uniqueness/lookup-resolves probe
+ * in parity.test.ts catches any real-world collision before ship.
+ *
+ * Why FNV-1a over crypto.subtle.digest: subtle is async; synchronous
+ * digestSync does not exist; the entire walk is sync. Why over DJB2: FNV-1a
+ * has slightly better avalanche on short keys (the str-length here is ~10).
+ *
+ * Exported as the documentation-grade public surface for the test harness
+ * (`packages/editor/src/ir/__tests__/fnv1a.test.ts`); no other consumer
+ * imports it directly — `assignNodeId` is the production caller.
+ */
+export function fnv1a(input: string): string {
+  let h = 0x811c9dc5 // FNV offset basis
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i)
+    h = Math.imul(h, 0x01000193) // FNV prime, 32-bit safe via Math.imul
+  }
+  // >>> 0 forces unsigned 32-bit; toString(16) hex; padStart for stable width.
+  return (h >>> 0).toString(16).padStart(8, '0')
+}
+
+/**
+ * Compute a stable content-addressed id for an IR node that produced this
+ * event (PV38 clause 1 / D-02). Inputs: `loc[0].start + loc[0].end + tag +
+ * position`. Hash function: FNV-1a 32-bit, hex-encoded.
+ *
+ * Under the leaf-only-assignment scheme (RESEARCH DEC-NEW-1), this is
+ * called from the Play arm with position=0; future leaf arms (e.g. a
+ * hypothetical RawHap tag) can pass meaningful positions if they emit
+ * multiple events per direct return.
+ *
+ * If the IR node is loc-less (which violates PV36 and dev-warns at the
+ * collect() boundary), this falls back to start=-1, end=-1 so the id is
+ * still produced — but the dev-warn surfaces the underlying contract
+ * violation. PV36 enforcement remains the loud gate.
+ */
+function assignNodeId(ir: PatternIR, position: number): string {
+  const start = ir.loc?.[0]?.start ?? -1
+  const end = ir.loc?.[0]?.end ?? -1
+  return fnv1a(`${start}:${end}:${ir.tag}:${position}`)
+}
+
 export interface CollectContext {
   /** Query window start (cycles) */
   begin: number


### PR DESCRIPTION
Closes #101 (StrudelEngine convenience queryArc index-as-trackId latent bug; filed at wave γ T-γ-1, fixed inline at T-γ-5).

First sub-phase of debugger v2. Lands **PV38** (engine ↔ IR identity channel) clauses 1-4 — the structural data channel that 20-06 (live highlighting) and 20-07 (scheduler-level breakpoints) consume. **PK13 step 4** lands here.

## Problem

PK13 step 4 (assign IR-node identity) was dark. `StrudelEditorClient.tsx` publishes a static IR snapshot from `collect(parseStrudel(code))`; `StrudelEngine` emits runtime haps from `pattern.queryArc()` via `normalizeStrudelHap`. Two parallel pipelines that never reconciled. For breakpoints to work — and for live highlighting on real haps (vs the current snapshot-events approximation) — when a hap fires, the engine must answer "which IR node produced this?" Without an identity channel, the inspector can't render the chain, the editor can't highlight, the scheduler can't match a breakpoint condition to a specific source range.

PV38 was codified 2026-05-07 but had no enforcement. PV38 clause 2 also cited the wrong path for hap loc (`hap.value.context.locations` → `hap.context.locations`); this PR corrects the catalogue inline (locally — `.anvi/` is gitignored in this repo).

## Fix

Three atomic commits, reviewable independently:

- **α** (types + helper, `496cb63`): `IREvent.irNodeId?: string` field + module-private FNV-1a 32-bit hash + `assignNodeId(ir, position)` helper. No collect arm wires the helper yet. 3 unit tests.

- **β** (collect-side assignment + corpus contract, `afa37de`): wire `assignNodeId(ir, 0)` at the Play arm (single-site change; wrapper arms preserve via existing `{...e, ...}` spread — leaf-only assignment per RESEARCH DEC-NEW-1). Determinism contract test (1) + corpus uniqueness/lookup-resolves probe over 15 representative shapes (15) extending parity.test.ts's PV36 CORPUS. P51 audit confirmed zero existing shape-locking assertions.

- **γ** (engine-side enrichment + lookup table + path correction, `0f92c72`): `IRSnapshot` grows two `ReadonlyMap` fields (`irNodeIdLookup`, `irNodeLocLookup`) built at publish time by `enrichWithLookups`. New `IRSnapshotInput = Omit<IRSnapshot, 'irNodeIdLookup'|'irNodeLocLookup'>` makes the publisher the only path to a complete snapshot (PV33 enforced; Trap 9 structurally impossible). `normalizeStrudelHap` signature widened additively to `(hap, trackId?, irNodeLocLookup?)` with single-strategy structural match (loc[0] key + `whole.begin` tie-break; miss → `irNodeId` absent per PV37; **NO fallback ladder per P50**). `StrudelEngine.lastIRNodeLocLookup` field threads the lookup into both queryArc callbacks. Side-fix at convenience queryArc: bare `.map(normalizeStrudelHap)` was passing `Array.prototype.map`'s index as trackId; now arrow-wrapped explicitly. PV38 catalogue clause 2 path correction (local). 5 new tests.

After this phase: every IREvent carries a stable content-addressed `irNodeId`; every hap that structurally matches a published IR node is enriched with the matching id; the snapshot exposes O(1) lookup by id and by leaf-loc for downstream 20-06 / 20-07 consumers.

## Out of scope (deferred per D-01)

- Monaco source-range highlighting on hap dispatch (20-06)
- MusicalTimeline glow synchronized to real haps (20-06)
- Scheduler clock control / breakpoint condition language (20-07)
- Audio-pause infrastructure (20-07)

## Test plan

- [x] Editor vitest: 1369 → 1393 (+24; plan target +25 with audit margin)
- [x] App vitest: 166 unchanged
- [x] Editor tsc: 53 baseline unchanged
- [x] App tsc: 0 baseline unchanged
- [x] No regression in existing PV36 / PV37 / 19-04/05 parity tests
- [x] No regression in useHighlighting tests
- [x] grep audits per PLAN §8 verification spec all pass
- [x] PV38 catalogue path correction confirmed (local; `.anvi/` gitignored)
- [x] P51 audit returns zero hits before and after wave β
- [x] Verifier agent: PASS, 23/23 must-haves verified