### PR TITLE
fix(timeline): clear slot map on transport stop edge (Phase 20-12.1)

### DIFF
--- a/packages/app/src/components/MusicalTimeline.tsx
+++ b/packages/app/src/components/MusicalTimeline.tsx
@@ -525,6 +525,14 @@ export function MusicalTimeline(
       ) {
         rafHandle = requestAnimationFrame(tick)
       }
+      // Drawer-closed stop-edge sampling (Phase 20-12.1): while the rAF
+      // loop is suspended (drawer closed or tab inactive), getCycle() is
+      // not read each frame. Sample it here so a transport stop
+      // propagates to component state within ≤250ms and the stop-edge
+      // reset block below fires on the next render. Cheap: one accessor
+      // call per 250ms.
+      const sampled = accessorsRef.current.getCycle()
+      setCurrentCycle((prev) => (prev === sampled ? prev : sampled))
     }, 250)
 
     return () => {
@@ -547,6 +555,11 @@ export function MusicalTimeline(
   // ── Slot-map derivation (Trap 5 + Trap NEW-5 file-switch reset) ─────────
   const slotMapRef = useRef<Map<string, number>>(new Map())
   const lastSourceRef = useRef<string | undefined>(undefined)
+  // Phase 20-12.1 — edge tracker for `currentCycle` (non-null → null) so
+  // we can clear `slotMapRef` exactly on the moment the transport stops.
+  // Initial value `true` ("we start in the stopped state") avoids a
+  // spurious first-mount reset of an already-empty map.
+  const prevCycleNullRef = useRef<boolean>(true)
 
   // File-switch reset: run BEFORE slot-map derivation so the new file's
   // tracks claim slots starting from 0 instead of inheriting the prior
@@ -555,6 +568,17 @@ export function MusicalTimeline(
     slotMapRef.current = new Map()
     lastSourceRef.current = snapshot.source
   }
+
+  // ── Transport-stop reset (Phase 20-12.1) ───────────────────────────────
+  // On the non-null → null edge of currentCycle (transport just stopped),
+  // clear slotMapRef so the next play snaps to the current IR's tracks.
+  // D-04's "stable across snapshots" is scoped to a single transport
+  // session; this edge ends the session. See FOLLOWUPS.md#F-1.
+  const cycleIsNull = currentCycle === null
+  if (!prevCycleNullRef.current && cycleIsNull) {
+    slotMapRef.current = new Map()
+  }
+  prevCycleNullRef.current = cycleIsNull
 
   const groups = snapshot ? groupEventsByTrack(snapshot.events) : []
   const currentIds = groups.map((g) => g.trackId)

--- a/packages/app/src/components/MusicalTimeline.tsx
+++ b/packages/app/src/components/MusicalTimeline.tsx
@@ -210,6 +210,32 @@ function formatNoteTooltip(event: IREvent, fallbackTrackId: string): string {
  * a later duplicate doesn't override since the row layout's identity is the
  * stable trackId, and over-writing would race the cached snapshot identity.
  */
+/**
+ * Phase 20-12.1 follow-up — enumerate the top-level `$:`-derived Track
+ * trackIds in source order. Used to seed the slot map so commented-out
+ * `$:` lines (empty-body Tracks per the parser fix) still claim a slot.
+ *
+ * SHALLOW: only the outer Stack's direct Track children. Inner Tracks
+ * from `.p()` are not enumerated here — they share their slot with the
+ * outer `$:` wrap once `.p()` rename-in-place is properly substrate-fixed.
+ *
+ * Shapes handled:
+ *   - Stack(Track(d1, ...), Track(d2, ...), ...)  — multi-`$:`
+ *   - Track(d1, ...)                              — single-`$:` or synthetic
+ *   - Anything else                               — no top-level Tracks; []
+ */
+function collectTopLevelTrackIds(node: PatternIR): string[] {
+  if (node.tag === 'Track') return [node.trackId]
+  if (node.tag === 'Stack') {
+    const out: string[] = []
+    for (const child of node.tracks) {
+      if (child.tag === 'Track') out.push(child.trackId)
+    }
+    return out
+  }
+  return []
+}
+
 function collectTrackBodies(node: PatternIR): Map<string, PatternIR> {
   const out = new Map<string, PatternIR>()
   const visit = (n: PatternIR): void => {
@@ -581,16 +607,20 @@ export function MusicalTimeline(
   prevCycleNullRef.current = cycleIsNull
 
   const groups = snapshot ? groupEventsByTrack(snapshot.events) : []
-  // Phase 20-12.1 follow-up — derive trackIds from BOTH the IR's Track
-  // wrappers AND from event-group derivation. IR-only trackIds (e.g.
+  // Phase 20-12.1 follow-up — derive trackIds from BOTH the IR's TOP-LEVEL
+  // Track wrappers AND from event-group derivation. IR-only trackIds (e.g.
   // commented `$:` lines that emit an empty-body Track with no events)
-  // still claim a slot, so commenting a `$:` mid-fixture renders a
-  // ghost row in place instead of shifting subsequent rows up. IR
-  // trackIds are first so source order drives initial slot assignment;
-  // event groups for the same trackId reuse the existing slot.
-  const irTrackIds = snapshot?.ir
-    ? Array.from(collectTrackBodies(snapshot.ir).keys())
-    : []
+  // still claim a slot, so commenting a `$:` mid-fixture renders a ghost
+  // row in place instead of shifting subsequent rows up.
+  //
+  // The walk is intentionally SHALLOW — it only visits the outer Stack's
+  // direct Track children (the d{N} from $:). Nested Tracks from `.p()`
+  // are inside those bodies and would be DIFFERENT trackIds; including
+  // them here would produce phantom slots when events already flow
+  // under the inner .p() name. (#3 — `.p()` rename-in-place — needs a
+  // separate substrate change in collect.ts and is tracked outside
+  // this follow-up batch.)
+  const irTrackIds = snapshot?.ir ? collectTopLevelTrackIds(snapshot.ir) : []
   const currentIds = [...irTrackIds, ...groups.map((g) => g.trackId)]
   slotMapRef.current = stableTrackOrder(slotMapRef.current, currentIds)
   const slotMap = slotMapRef.current

--- a/packages/app/src/components/MusicalTimeline.tsx
+++ b/packages/app/src/components/MusicalTimeline.tsx
@@ -586,12 +586,19 @@ export function MusicalTimeline(
   // Initial value `true` ("we start in the stopped state") avoids a
   // spurious first-mount reset of an already-empty map.
   const prevCycleNullRef = useRef<boolean>(true)
+  // Phase 20-12.1 follow-up — "has ever had events this session" set.
+  // Combined with always-seed-from-IR-top-level below, this is what lets
+  // commented `$:` lines render as ghosts during a live session but drop
+  // entirely on stop+play. Cleared alongside slotMapRef on file switch
+  // and on the transport-stop edge.
+  const hasHadEventsRef = useRef<Set<string>>(new Set())
 
   // File-switch reset: run BEFORE slot-map derivation so the new file's
   // tracks claim slots starting from 0 instead of inheriting the prior
   // file's row order.
   if (snapshot && snapshot.source !== lastSourceRef.current) {
     slotMapRef.current = new Map()
+    hasHadEventsRef.current = new Set()
     lastSourceRef.current = snapshot.source
   }
 
@@ -599,46 +606,60 @@ export function MusicalTimeline(
   // On the non-null → null edge of currentCycle (transport just stopped),
   // clear slotMapRef so the next play snaps to the current IR's tracks.
   // D-04's "stable across snapshots" is scoped to a single transport
-  // session; this edge ends the session. See FOLLOWUPS.md#F-1.
+  // session; this edge ends the session. See FOLLOWUPS.md#F-1. Also clear
+  // hasHadEventsRef so commented rows that ghosted during the prior
+  // session don't carry their visibility flag into the next.
   const cycleIsNull = currentCycle === null
   if (!prevCycleNullRef.current && cycleIsNull) {
     slotMapRef.current = new Map()
+    hasHadEventsRef.current = new Set()
   }
   prevCycleNullRef.current = cycleIsNull
 
   const groups = snapshot ? groupEventsByTrack(snapshot.events) : []
-  // Phase 20-12.1 follow-up — derive trackIds from BOTH the IR's TOP-LEVEL
-  // Track wrappers AND from event-group derivation, but ONLY when the slot
-  // map already has entries (mid-session hot-reload). IR-only trackIds (e.g.
-  // commented `$:` lines that emit an empty-body Track with no events)
-  // claim a slot during a live session so commenting `$:` mid-fixture
-  // renders a ghost row in place instead of shifting subsequent rows up.
+  // Phase 20-12.1 follow-up — seed the slot map from BOTH the IR's
+  // top-level Track wrappers AND event-derived trackIds, ALWAYS (not just
+  // mid-session). The IR-side seed gives every `$:` line — including
+  // commented-out ones whose parser fix wraps them as empty-body Tracks —
+  // a stable source-order slot. Combined with the `hasHadEventsRef`
+  // filter below, this satisfies three otherwise-conflicting behaviors:
   //
-  // On a FRESH seed — first play of a session, or first re-play after the
-  // stop-edge reset cleared the map — only event-derived trackIds seed the
-  // map. This is what makes stop→play actually drop the commented-row
-  // ghost: post-stop the slot map is empty, so the next render's seed
-  // skips IR-only Tracks (their bodies are IR.pure() with no events) and
-  // only the still-active rows claim slots. Without this gate, the IR
-  // union would re-introduce the ghost on every render, defeating the
-  // stop-edge reset from PR #119.
+  //   - Comment a `$:` mid-play (hot-reload): row keeps its slot, renders
+  //     as ghost (was in hasHadEvents, no events now → filter keeps it).
+  //   - Stop+play: stop-edge clears hasHadEvents AND slot map; on next
+  //     play, slot map re-seeds from IR top-level (including commented
+  //     empty Tracks), but only rows whose trackIds enter hasHadEvents
+  //     via the current play's events render. Commented rows stay out
+  //     of the set → invisible.
+  //   - Uncomment a row later: events return for its trackId; trackId
+  //     re-enters hasHadEvents; row re-renders in its ORIGINAL source-
+  //     order slot (no rearrangement).
   //
   // The walk is intentionally SHALLOW — it only visits the outer Stack's
   // direct Track children (the d{N} from $:). Nested Tracks from `.p()`
   // are inside those bodies and would be DIFFERENT trackIds; including
   // them here would produce phantom slots when events already flow under
   // the inner .p() name.
-  const slotMapHasEntries = slotMapRef.current.size > 0
-  const irTrackIds =
-    slotMapHasEntries && snapshot?.ir
-      ? collectTopLevelTrackIds(snapshot.ir)
-      : []
+  const irTrackIds = snapshot?.ir ? collectTopLevelTrackIds(snapshot.ir) : []
   const currentIds = [...irTrackIds, ...groups.map((g) => g.trackId)]
   slotMapRef.current = stableTrackOrder(slotMapRef.current, currentIds)
   const slotMap = slotMapRef.current
+  // Track which trackIds have ever produced events in the current
+  // session. Cleared alongside the slot map on the stop-edge reset above
+  // and on file switch (also above). This is the filter that distinguishes
+  // "ghost in place during live edit" from "drop entirely on stop+play".
+  for (const g of groups) hasHadEventsRef.current.add(g.trackId)
 
+  // Filter to trackIds that have ever produced events this session.
+  // Commented `$:` lines have a slot (from IR top-level seed) but no
+  // events; if they were never active before, they're invisible until
+  // they emit events. Within a session, once a row has fired events,
+  // it stays visible as a ghost across hot-reload comment toggles
+  // (D-04 audition workflow). On stop, hasHadEventsRef clears, so the
+  // next play starts a fresh visibility set.
   const orderedTracks = Array.from(slotMap.entries())
     .sort(([, a], [, b]) => a - b)
+    .filter(([trackId]) => hasHadEventsRef.current.has(trackId))
     .map(([trackId]) => ({
       trackId,
       events: groups.find((g) => g.trackId === trackId)?.events ?? [],

--- a/packages/app/src/components/MusicalTimeline.tsx
+++ b/packages/app/src/components/MusicalTimeline.tsx
@@ -581,7 +581,17 @@ export function MusicalTimeline(
   prevCycleNullRef.current = cycleIsNull
 
   const groups = snapshot ? groupEventsByTrack(snapshot.events) : []
-  const currentIds = groups.map((g) => g.trackId)
+  // Phase 20-12.1 follow-up — derive trackIds from BOTH the IR's Track
+  // wrappers AND from event-group derivation. IR-only trackIds (e.g.
+  // commented `$:` lines that emit an empty-body Track with no events)
+  // still claim a slot, so commenting a `$:` mid-fixture renders a
+  // ghost row in place instead of shifting subsequent rows up. IR
+  // trackIds are first so source order drives initial slot assignment;
+  // event groups for the same trackId reuse the existing slot.
+  const irTrackIds = snapshot?.ir
+    ? Array.from(collectTrackBodies(snapshot.ir).keys())
+    : []
+  const currentIds = [...irTrackIds, ...groups.map((g) => g.trackId)]
   slotMapRef.current = stableTrackOrder(slotMapRef.current, currentIds)
   const slotMap = slotMapRef.current
 

--- a/packages/app/src/components/MusicalTimeline.tsx
+++ b/packages/app/src/components/MusicalTimeline.tsx
@@ -608,19 +608,31 @@ export function MusicalTimeline(
 
   const groups = snapshot ? groupEventsByTrack(snapshot.events) : []
   // Phase 20-12.1 follow-up — derive trackIds from BOTH the IR's TOP-LEVEL
-  // Track wrappers AND from event-group derivation. IR-only trackIds (e.g.
+  // Track wrappers AND from event-group derivation, but ONLY when the slot
+  // map already has entries (mid-session hot-reload). IR-only trackIds (e.g.
   // commented `$:` lines that emit an empty-body Track with no events)
-  // still claim a slot, so commenting a `$:` mid-fixture renders a ghost
-  // row in place instead of shifting subsequent rows up.
+  // claim a slot during a live session so commenting `$:` mid-fixture
+  // renders a ghost row in place instead of shifting subsequent rows up.
+  //
+  // On a FRESH seed — first play of a session, or first re-play after the
+  // stop-edge reset cleared the map — only event-derived trackIds seed the
+  // map. This is what makes stop→play actually drop the commented-row
+  // ghost: post-stop the slot map is empty, so the next render's seed
+  // skips IR-only Tracks (their bodies are IR.pure() with no events) and
+  // only the still-active rows claim slots. Without this gate, the IR
+  // union would re-introduce the ghost on every render, defeating the
+  // stop-edge reset from PR #119.
   //
   // The walk is intentionally SHALLOW — it only visits the outer Stack's
   // direct Track children (the d{N} from $:). Nested Tracks from `.p()`
   // are inside those bodies and would be DIFFERENT trackIds; including
-  // them here would produce phantom slots when events already flow
-  // under the inner .p() name. (#3 — `.p()` rename-in-place — needs a
-  // separate substrate change in collect.ts and is tracked outside
-  // this follow-up batch.)
-  const irTrackIds = snapshot?.ir ? collectTopLevelTrackIds(snapshot.ir) : []
+  // them here would produce phantom slots when events already flow under
+  // the inner .p() name.
+  const slotMapHasEntries = slotMapRef.current.size > 0
+  const irTrackIds =
+    slotMapHasEntries && snapshot?.ir
+      ? collectTopLevelTrackIds(snapshot.ir)
+      : []
   const currentIds = [...irTrackIds, ...groups.map((g) => g.trackId)]
   slotMapRef.current = stableTrackOrder(slotMapRef.current, currentIds)
   const slotMap = slotMapRef.current

--- a/packages/app/src/components/MusicalTimeline.tsx
+++ b/packages/app/src/components/MusicalTimeline.tsx
@@ -602,15 +602,20 @@ export function MusicalTimeline(
     lastSourceRef.current = snapshot.source
   }
 
-  // ── Transport-stop reset (Phase 20-12.1) ───────────────────────────────
-  // On the non-null → null edge of currentCycle (transport just stopped),
-  // clear slotMapRef so the next play snaps to the current IR's tracks.
-  // D-04's "stable across snapshots" is scoped to a single transport
-  // session; this edge ends the session. See FOLLOWUPS.md#F-1. Also clear
-  // hasHadEventsRef so commented rows that ghosted during the prior
-  // session don't carry their visibility flag into the next.
+  // ── Transport transition reset (Phase 20-12.1 + follow-up) ─────────────
+  // Reset slotMapRef + hasHadEventsRef on EITHER edge of the play/stop
+  // transition:
+  //   - non-null → null (stop): so previously-active rows don't carry
+  //     into a future session.
+  //   - null → non-null (play): so code edited while stopped takes effect
+  //     on the next play. Without this, after stop → edit → play, the
+  //     slot map still holds the prior session's seeding and the timeline
+  //     shows the stale row set until the next stop+play cycle.
+  // Hot-reload while playing (Cmd+Enter mid-play) is NOT a transition
+  // edge — currentCycle stays non-null — so D-04's audition workflow
+  // (ghost in place during live edit) is preserved.
   const cycleIsNull = currentCycle === null
-  if (!prevCycleNullRef.current && cycleIsNull) {
+  if (prevCycleNullRef.current !== cycleIsNull) {
     slotMapRef.current = new Map()
     hasHadEventsRef.current = new Set()
   }

--- a/packages/app/src/components/MusicalTimeline.tsx
+++ b/packages/app/src/components/MusicalTimeline.tsx
@@ -211,29 +211,52 @@ function formatNoteTooltip(event: IREvent, fallbackTrackId: string): string {
  * stable trackId, and over-writing would race the cached snapshot identity.
  */
 /**
- * Phase 20-12.1 follow-up — enumerate the top-level `$:`-derived Track
- * trackIds in source order. Used to seed the slot map so commented-out
- * `$:` lines (empty-body Tracks per the parser fix) still claim a slot.
+ * Phase 20-12.1 follow-up — enumerate the top-level `$:`-derived Tracks
+ * in source order. Each entry exposes a stable `slotKey` (based on the
+ * outer Track's source position) and a `displayLabel` (the `.p()` name
+ * if the body is a nested `.p()` Track, else the outer Track's trackId).
  *
- * SHALLOW: only the outer Stack's direct Track children. Inner Tracks
- * from `.p()` are not enumerated here — they share their slot with the
- * outer `$:` wrap once `.p()` rename-in-place is properly substrate-fixed.
+ * The slot key is what the timeline uses for row identity, so adding or
+ * changing `.p("name")` on a line doesn't relocate its row — only the
+ * label updates.
  *
- * Shapes handled:
- *   - Stack(Track(d1, ...), Track(d2, ...), ...)  — multi-`$:`
- *   - Track(d1, ...)                              — single-`$:` or synthetic
- *   - Anything else                               — no top-level Tracks; []
+ * SHALLOW: only the outer Stack's direct Track children. The label
+ * derivation peeks ONE level into the body to detect a `.p()` wrap, but
+ * doesn't recurse deeper.
  */
-function collectTopLevelTrackIds(node: PatternIR): string[] {
-  if (node.tag === 'Track') return [node.trackId]
+function collectTopLevelSlots(
+  node: PatternIR,
+): { slotKey: string; displayLabel: string }[] {
+  const summarize = (t: PatternIR): { slotKey: string; displayLabel: string } => {
+    const outer = t as Extract<PatternIR, { tag: 'Track' }>
+    const pos = outer.loc?.[0]?.start
+    const slotKey = pos !== undefined ? `$${pos}` : outer.trackId
+    // Peek one level for a `.p()`-wrapped inner Track; that name becomes
+    // the row label.
+    const body = outer.body
+    if (body.tag === 'Track' && body.userMethod === 'p') {
+      return { slotKey, displayLabel: body.trackId }
+    }
+    return { slotKey, displayLabel: outer.trackId }
+  }
+  if (node.tag === 'Track') return [summarize(node)]
   if (node.tag === 'Stack') {
-    const out: string[] = []
+    const out: { slotKey: string; displayLabel: string }[] = []
     for (const child of node.tracks) {
-      if (child.tag === 'Track') out.push(child.trackId)
+      if (child.tag === 'Track') out.push(summarize(child))
     }
     return out
   }
   return []
+}
+
+/** Compute the slot key for an event-derived group. The first event's
+ *  `dollarPos` is the canonical identity; falling back to trackId
+ *  matches the pre-`dollarPos` behavior for hand-built fixtures. */
+function groupSlotKey(group: { trackId: string; events: readonly IREvent[] }): string {
+  const first = group.events[0]
+  const pos = first?.dollarPos
+  return pos !== undefined ? `$${pos}` : group.trackId
 }
 
 function collectTrackBodies(node: PatternIR): Map<string, PatternIR> {
@@ -622,52 +645,67 @@ export function MusicalTimeline(
   prevCycleNullRef.current = cycleIsNull
 
   const groups = snapshot ? groupEventsByTrack(snapshot.events) : []
-  // Phase 20-12.1 follow-up — seed the slot map from BOTH the IR's
-  // top-level Track wrappers AND event-derived trackIds, ALWAYS (not just
-  // mid-session). The IR-side seed gives every `$:` line — including
-  // commented-out ones whose parser fix wraps them as empty-body Tracks —
-  // a stable source-order slot. Combined with the `hasHadEventsRef`
-  // filter below, this satisfies three otherwise-conflicting behaviors:
+  // Phase 20-12.1 follow-up — slot map is keyed by `slotKey`, a stable
+  // source-anchored identity:
+  //   - For events from a `$:`-wrapped Track: `slotKey = "$" + dollarPos`
+  //     where dollarPos is the source offset of the OUTER `$:` Track.
+  //   - For hand-built / non-`$:` events: `slotKey = trackId` (fallback).
   //
-  //   - Comment a `$:` mid-play (hot-reload): row keeps its slot, renders
-  //     as ghost (was in hasHadEvents, no events now → filter keeps it).
-  //   - Stop+play: stop-edge clears hasHadEvents AND slot map; on next
-  //     play, slot map re-seeds from IR top-level (including commented
-  //     empty Tracks), but only rows whose trackIds enter hasHadEvents
-  //     via the current play's events render. Commented rows stay out
-  //     of the set → invisible.
-  //   - Uncomment a row later: events return for its trackId; trackId
-  //     re-enters hasHadEvents; row re-renders in its ORIGINAL source-
-  //     order slot (no rearrangement).
+  // Using the source anchor (not the inner trackId) means `.p("name")`
+  // rename-in-place doesn't relocate the row: the OUTER Track's loc is
+  // unchanged by adding/changing/removing `.p()` inside its body. The
+  // display label still comes from the inner trackId (per the `.p()`
+  // wave-δ contract) — see the display map below.
   //
-  // The walk is intentionally SHALLOW — it only visits the outer Stack's
-  // direct Track children (the d{N} from $:). Nested Tracks from `.p()`
-  // are inside those bodies and would be DIFFERENT trackIds; including
-  // them here would produce phantom slots when events already flow under
-  // the inner .p() name.
-  const irTrackIds = snapshot?.ir ? collectTopLevelTrackIds(snapshot.ir) : []
-  const currentIds = [...irTrackIds, ...groups.map((g) => g.trackId)]
-  slotMapRef.current = stableTrackOrder(slotMapRef.current, currentIds)
-  const slotMap = slotMapRef.current
-  // Track which trackIds have ever produced events in the current
-  // session. Cleared alongside the slot map on the stop-edge reset above
-  // and on file switch (also above). This is the filter that distinguishes
-  // "ghost in place during live edit" from "drop entirely on stop+play".
-  for (const g of groups) hasHadEventsRef.current.add(g.trackId)
+  // The walk for IR-side seeding is SHALLOW: only the outer Stack's
+  // direct Track children. Nested `.p()` Tracks are inside those bodies
+  // and contribute their NAME as a display label, not a separate slot.
+  const irSlots = snapshot?.ir ? collectTopLevelSlots(snapshot.ir) : []
+  const groupBySlotKey = new Map<string, { displayLabel: string; events: readonly IREvent[] }>()
+  for (const g of groups) {
+    const key = groupSlotKey(g)
+    // Events from a `.p()`-wrapped Track carry the INNER trackId (the
+    // user's chosen name). For events from a plain `$:` line, trackId
+    // is the synthetic `d{N}`. Either way it's the right display label.
+    groupBySlotKey.set(key, { displayLabel: g.trackId, events: g.events })
+  }
+  // Display labels for slots that exist in the IR but have no events
+  // yet (commented `$:` lines). collectTopLevelSlots peeks for `.p()`
+  // wraps even on empty-body Tracks so a commented `.p()` line still
+  // shows its name.
+  const slotDisplay = new Map<string, string>()
+  for (const { slotKey, displayLabel } of irSlots) {
+    slotDisplay.set(slotKey, displayLabel)
+  }
+  // Group display labels override IR-derived labels when both exist
+  // (event-bearing labels reflect the LIVE name in case the IR walk
+  // and the runtime event stream disagree, e.g. mid-eval).
+  for (const [key, { displayLabel }] of groupBySlotKey) {
+    slotDisplay.set(key, displayLabel)
+  }
 
-  // Filter to trackIds that have ever produced events this session.
-  // Commented `$:` lines have a slot (from IR top-level seed) but no
-  // events; if they were never active before, they're invisible until
-  // they emit events. Within a session, once a row has fired events,
-  // it stays visible as a ghost across hot-reload comment toggles
-  // (D-04 audition workflow). On stop, hasHadEventsRef clears, so the
-  // next play starts a fresh visibility set.
+  const currentSlotKeys = [
+    ...irSlots.map((s) => s.slotKey),
+    ...groups.map(groupSlotKey),
+  ]
+  slotMapRef.current = stableTrackOrder(slotMapRef.current, currentSlotKeys)
+  const slotMap = slotMapRef.current
+  // hasHadEvents tracks SLOT KEYS (not trackIds). This is what makes
+  // commented `$:` ghost in place during a live session: the slot was
+  // entered into the set on a prior render with events; subsequent
+  // event-less renders keep the row visible because its slot is still
+  // in the set. Cleared on transport transitions + file switch.
+  for (const g of groups) hasHadEventsRef.current.add(groupSlotKey(g))
+
+  // Filter to slot keys that have ever produced events this session.
+  // Display label is read from `slotDisplay` so the chrome shows the
+  // inner `.p()` name when present, falling back to the outer `d{N}`.
   const orderedTracks = Array.from(slotMap.entries())
     .sort(([, a], [, b]) => a - b)
-    .filter(([trackId]) => hasHadEventsRef.current.has(trackId))
-    .map(([trackId]) => ({
-      trackId,
-      events: groups.find((g) => g.trackId === trackId)?.events ?? [],
+    .filter(([slotKey]) => hasHadEventsRef.current.has(slotKey))
+    .map(([slotKey]) => ({
+      trackId: slotDisplay.get(slotKey) ?? slotKey,
+      events: groupBySlotKey.get(slotKey)?.events ?? [],
     }))
 
   // ── Phase 20-06: HapStream subscription drives activeKeys (D-01 / DEC-NEW-1)

--- a/packages/app/src/components/__tests__/MusicalTimeline.test.tsx
+++ b/packages/app/src/components/__tests__/MusicalTimeline.test.tsx
@@ -495,6 +495,206 @@ describe('MusicalTimeline file-switch reset (Trap NEW-5)', () => {
   })
 })
 
+describe('MusicalTimeline transport-stop slot map reset (20-12.1)', () => {
+  // Helper: read the track labels currently rendered in order.
+  const labelsOf = (container: HTMLElement): (string | null)[] =>
+    Array.from(
+      container.querySelectorAll('[data-musical-timeline-track-label]'),
+    ).map((el) => el.getAttribute('data-musical-timeline-track-label'))
+
+  // Helper: drive the rAF loop a few ticks so the playhead state catches
+  // up to the current `getCycle` accessor. The rAF in jsdom is backed by
+  // setTimeout; 50ms is the pattern used elsewhere in this file (search
+  // "rAF gating (Trap NEW-1)").
+  const flushRaf = async (): Promise<void> => {
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50))
+    })
+  }
+
+  it('stop → play with same IR yields the same row order', async () => {
+    // 1. Mount playing with three tracks.
+    const playingProps = {
+      ...defaultProps(),
+      getCycle: () => 0.5,
+    }
+    const { container, rerender } = await renderSettled(
+      <MusicalTimeline {...playingProps} />,
+    )
+    await act(async () => {
+      pushSnapshot(
+        makeSnapshot({
+          events: [
+            evt({ trackId: 'bd' }),
+            evt({ trackId: 'hh' }),
+            evt({ trackId: 'cp' }),
+          ],
+        }),
+      )
+    })
+    // Let the rAF loop observe `getCycle() === 0.5` so `currentCycle`
+    // moves off `null`. Without this, the non-null → null edge below
+    // would not fire (we would go null → null).
+    await flushRaf()
+    expect(labelsOf(container)).toEqual(['bd', 'hh', 'cp'])
+
+    // 2. Flip transport to stopped. rAF picks up the new `getCycle` via
+    //    accessorsRef and writes `currentCycle = null`, which triggers
+    //    the in-render stop-edge reset. Then push the same snapshot.
+    const stoppedProps = { ...defaultProps(), getCycle: () => null }
+    rerender(<MusicalTimeline {...stoppedProps} />)
+    await flushRaf()
+    await act(async () => {
+      pushSnapshot(
+        makeSnapshot({
+          events: [
+            evt({ trackId: 'bd' }),
+            evt({ trackId: 'hh' }),
+            evt({ trackId: 'cp' }),
+          ],
+        }),
+      )
+    })
+    expect(labelsOf(container)).toEqual(['bd', 'hh', 'cp'])
+
+    // 3. Flip back to playing + push same snapshot. Row order preserved.
+    rerender(<MusicalTimeline {...playingProps} />)
+    await flushRaf()
+    await act(async () => {
+      pushSnapshot(
+        makeSnapshot({
+          events: [
+            evt({ trackId: 'bd' }),
+            evt({ trackId: 'hh' }),
+            evt({ trackId: 'cp' }),
+          ],
+        }),
+      )
+    })
+    expect(labelsOf(container)).toEqual(['bd', 'hh', 'cp'])
+  })
+
+  it('stop → play after commenting $: drops the ghost row', async () => {
+    // Production sequence (T-8 plan steps 4-7): user plays [bd, hh]
+    // (snapshot 1), comments out the hh line and re-evals WHILE STILL
+    // PLAYING (snapshot 2 = [bd]; D-04 keeps the hh ghost row), then
+    // presses Stop. The stop edge clears the slot map; the next render
+    // uses the [bd] snapshot alone, so the ghost row drops.
+    const playingProps = {
+      ...defaultProps(),
+      getCycle: () => 0.5,
+    }
+    const { container, rerender } = await renderSettled(
+      <MusicalTimeline {...playingProps} />,
+    )
+    await act(async () => {
+      pushSnapshot(
+        makeSnapshot({
+          events: [evt({ trackId: 'bd' }), evt({ trackId: 'hh' })],
+        }),
+      )
+    })
+    // Drive `currentCycle` off null so the upcoming stop is an edge.
+    await flushRaf()
+    expect(labelsOf(container)).toEqual(['bd', 'hh'])
+
+    // Re-eval while playing — user comments out hh's $: line. D-04
+    // says the ghost row stays because the transport hasn't stopped.
+    await act(async () => {
+      pushSnapshot(
+        makeSnapshot({
+          events: [evt({ trackId: 'bd' })],
+        }),
+      )
+    })
+    expect(labelsOf(container)).toEqual(['bd', 'hh'])
+
+    // User presses Stop. The stop edge clears slotMapRef; the next
+    // render observes only [bd] in the snapshot.
+    const stoppedProps = { ...defaultProps(), getCycle: () => null }
+    rerender(<MusicalTimeline {...stoppedProps} />)
+    await flushRaf()
+    expect(labelsOf(container)).toEqual(['bd'])
+  })
+
+  it('hot-reload while playing keeps the ghost row (D-04 audition case unchanged)', async () => {
+    const playingProps = {
+      ...defaultProps(),
+      getCycle: () => 0.5,
+    }
+    const { container } = await renderSettled(
+      <MusicalTimeline {...playingProps} />,
+    )
+    await act(async () => {
+      pushSnapshot(
+        makeSnapshot({
+          events: [evt({ trackId: 'bd' }), evt({ trackId: 'hh' })],
+        }),
+      )
+    })
+    await flushRaf()
+    expect(labelsOf(container)).toEqual(['bd', 'hh'])
+
+    // Hot-reload while playing — drop hh from the IR but keep playing.
+    // The audition workflow expects hh's row to remain reserved (no
+    // non-null → null edge fires; `currentCycle` stays 0.5).
+    await act(async () => {
+      pushSnapshot(
+        makeSnapshot({
+          events: [evt({ trackId: 'bd' })],
+        }),
+      )
+    })
+    await flushRaf()
+    expect(labelsOf(container)).toEqual(['bd', 'hh'])
+
+    // Another hot-reload — same expectation.
+    await act(async () => {
+      pushSnapshot(
+        makeSnapshot({
+          events: [evt({ trackId: 'bd' })],
+        }),
+      )
+    })
+    await flushRaf()
+    expect(labelsOf(container)).toEqual(['bd', 'hh'])
+  })
+
+  it('re-eval while stopped grows insertion order without resetting between evals', async () => {
+    // Goal-clause witness: "the next re-eval while stopped re-derives
+    // slots from scratch." Also guards two properties at once:
+    //   (i) first-mount does NOT trigger a spurious reset
+    //       (prevCycleNullRef initialises to true)
+    //   (ii) null → null re-renders are not edges (no second reset)
+    const stoppedProps = { ...defaultProps(), getCycle: () => null }
+    const { container } = await renderSettled(
+      <MusicalTimeline {...stoppedProps} />,
+    )
+
+    await act(async () => {
+      pushSnapshot(makeSnapshot({ events: [evt({ trackId: 'bd' })] }))
+    })
+    expect(labelsOf(container)).toEqual(['bd'])
+
+    await act(async () => {
+      pushSnapshot(
+        makeSnapshot({
+          events: [evt({ trackId: 'bd' }), evt({ trackId: 'hh' })],
+        }),
+      )
+    })
+    expect(labelsOf(container)).toEqual(['bd', 'hh'])
+
+    // hh disappears from the IR but the slot stays reserved because no
+    // stop edge fires (we never transitioned non-null → null after the
+    // initial mount-as-stopped).
+    await act(async () => {
+      pushSnapshot(makeSnapshot({ events: [evt({ trackId: 'hh' })] }))
+    })
+    expect(labelsOf(container)).toEqual(['bd', 'hh'])
+  })
+})
+
 describe('MusicalTimeline note-block positions (PV28 / Trap 4)', () => {
   it('places s("bd*4") events at beats 0, 0.25, 0.5, 0.75 → x ≈ 0/100/200/300 px at width 800', async () => {
     const { container } = render(<MusicalTimeline {...defaultProps()} />)

--- a/packages/app/tests/musical-timeline.spec.ts
+++ b/packages/app/tests/musical-timeline.spec.ts
@@ -245,7 +245,12 @@ test.describe('MusicalTimeline — slice β (Phase 20-01 PR-B)', () => {
     await stopStrudel(page)
   })
 
-  test('stable track order across re-evals (Trap 5)', async ({ page }) => {
+  test('stable track order across re-evals (Trap 5 + Phase 20-12.1 D-04 scope)', async ({ page }) => {
+    // Phase 20-12.1 amended D-04 so "stable across snapshots" is scoped to
+    // within a single transport session. This test exercises the audition
+    // workflow (hot-reload WHILE PLAYING) to preserve the ghost-row
+    // semantics — re-evals without `Cmd+.` in between. The transport-stop
+    // edge has its own coverage in MusicalTimeline.test.tsx (T-3 case 2).
     await clearDrawerStorage(page)
     await preOpenDrawer(page)
     await bootShell(page)
@@ -257,9 +262,11 @@ test.describe('MusicalTimeline — slice β (Phase 20-01 PR-B)', () => {
       page.locator('[data-musical-timeline-track-row]'),
     ).toHaveCount(3, { timeout: 5000 })
 
-    // Stop + re-eval with hh missing; row should still be reserved.
+    // Hot-reload WHILE PLAYING with hh missing; row should still be reserved
+    // (D-04 audition case — keeps the transport non-null → null edge from
+    // firing, so slotMapRef retains the hh slot).
     await setStrudelCode(page, 's("bd cp")')
-    await reEvalStrudel(page)
+    await evalStrudel(page)
     await expect(
       page.locator('[data-musical-timeline-track-row]'),
     ).toHaveCount(3)
@@ -271,7 +278,7 @@ test.describe('MusicalTimeline — slice β (Phase 20-01 PR-B)', () => {
 
     // Add a new track — sn should append at slot 3, not in the middle.
     await setStrudelCode(page, 's("bd hh sn cp")')
-    await reEvalStrudel(page)
+    await evalStrudel(page)
     const labels = await page
       .locator('[data-musical-timeline-track-label]')
       .evaluateAll((els) =>
@@ -350,5 +357,52 @@ test.describe('MusicalTimeline — slice β (Phase 20-01 PR-B)', () => {
     await expect(gutter).toHaveText('CYCLES')
 
     await stopStrudel(page)
+  })
+
+  test('Phase 20-12.1 — transport stop clears the slot map (drops ghost row)', async ({
+    page,
+  }) => {
+    // Direct-observation gate for Phase 20-12.1 (T-8). Mirrors the manual
+    // gesture sequence from the plan:
+    //   1. Play `s("bd hh")` → 2 rows.
+    //   2. Hot-reload while playing with `s("bd")` → hh row stays
+    //      reserved (D-04 audition case unchanged).
+    //   3. Press Stop (Cmd+.). The non-null → null edge of `getCycle()`
+    //      clears `slotMapRef`. The DOM now reflects the current IR
+    //      alone → only the `bd` row remains.
+    await clearDrawerStorage(page)
+    await preOpenDrawer(page)
+    await bootShell(page)
+    await page.locator('.monaco-editor').waitFor({ timeout: 15_000 })
+
+    await setStrudelCode(page, 's("bd hh")')
+    await evalStrudel(page)
+    await expect(
+      page.locator('[data-musical-timeline-track-row]'),
+    ).toHaveCount(2, { timeout: 5000 })
+
+    // Audition workflow: re-eval while playing — hh ghost row stays.
+    await setStrudelCode(page, 's("bd")')
+    await evalStrudel(page)
+    await expect(
+      page.locator('[data-musical-timeline-track-row]'),
+    ).toHaveCount(2)
+    await expect(
+      page.locator(
+        '[data-musical-timeline-track-row="hh"] [data-musical-timeline-note]',
+      ),
+    ).toHaveCount(0)
+
+    // Stop — the stop-edge reset fires and the ghost row drops.
+    await stopStrudel(page)
+    // Allow the 250ms poke interval to sample getCycle() if needed, plus
+    // a render tick. 600ms is generous.
+    await page.waitForTimeout(600)
+    await expect(
+      page.locator('[data-musical-timeline-track-row]'),
+    ).toHaveCount(1)
+    await expect(
+      page.locator('[data-musical-timeline-track-row="bd"]'),
+    ).toHaveCount(1)
   })
 })

--- a/packages/editor/src/ir/IREvent.ts
+++ b/packages/editor/src/ir/IREvent.ts
@@ -50,8 +50,21 @@ export interface IREvent {
    *  Absent for hap-derived events with no IR-side match
    *  (PV37-aligned runtime-only path). */
   irNodeId?: string
-  /** Which track/loop produced this event */
+  /** Which track/loop produced this event. For events from a `$:`-wrapped
+   *  Track that also has a `.p("name")` inner wrap, this is the INNER
+   *  (`.p()`) name per collect.ts inner-wins semantics — what the user
+   *  sees as the row label. Use `dollarPos` (below) when you need the
+   *  STABLE slot identity that doesn't change when the user renames
+   *  via `.p()`. */
   trackId?: string
+  /** Source-character offset of the OUTERMOST `$:`-wrapped Track that
+   *  encloses this event. Anchored at the Track's `loc[0].start` per
+   *  parseStrudel. Used as the timeline slot identity so `.p("name")`
+   *  rename-in-place doesn't relocate the row (the OUTER Track's loc
+   *  doesn't move when its body is restructured). Absent when no
+   *  enclosing Track has a `loc` (hand-built IR fixtures, runtime-only
+   *  events). Phase 20-12.1 follow-up. */
+  dollarPos?: number
   /** Index of the leaf voice (within its enclosing Track) that produced
    *  this event. Set by collect.ts when walking a voice-defining Stack
    *  (`userMethod ∈ {undefined, 'stack'}`). Sequential across nested

--- a/packages/editor/src/ir/collect.ts
+++ b/packages/editor/src/ir/collect.ts
@@ -189,6 +189,15 @@ export interface CollectContext {
    */
   trackId?: string
   /**
+   * Phase 20-12.1 follow-up — source-position anchor of the OUTERMOST
+   * `$:` Track enclosing this event. Set ONCE at the outer Track entry
+   * (via `ctx.dollarPos ?? ir.loc?.[0]?.start` — outer-wins so inner
+   * `.p()`-wrapped Tracks don't override). Threaded onto events so the
+   * timeline can key rows by source position rather than by `.p()` name,
+   * preserving slot identity across `.p()` renames.
+   */
+  dollarPos?: number
+  /**
    * Phase 20-12 — populated by voice-defining Stack arm. Each voice-row
    * inside a `$:` block (each `stack(...)` arg) gets a sequential leaf
    * index 0..N-1, threaded onto produced events for chrome sub-row
@@ -306,6 +315,11 @@ function makeEvent(ctx: CollectContext, note: string | number, params: Record<st
     // Avoids polluting IREvent with enumerable `trackId: undefined`
     // (CONTEXT pre-mortem #6 — IREvent.trackId is optional).
     ...(ctx.trackId !== undefined ? { trackId: ctx.trackId } : {}),
+    // Phase 20-12.1 follow-up — conditional spread for dollarPos. Absent
+    // for hand-built IR (no `$:` Track wrapper); present for parser-
+    // produced events. MusicalTimeline uses this as the slot identity
+    // when present so `.p()` rename doesn't relocate the row.
+    ...(ctx.dollarPos !== undefined ? { dollarPos: ctx.dollarPos } : {}),
     ...(ctx.leafIndex !== undefined ? { leafIndex: ctx.leafIndex } : {}),
   }
 }
@@ -423,9 +437,17 @@ function walk(ir: PatternIR, ctx: CollectContext): IREvent[] {
       // would carry the outer's leaf id and chrome's sub-row partition
       // would mis-bucket them). The first voice-defining Stack the body
       // reaches initialises the counter at 0.
+      // Phase 20-12.1 follow-up — `dollarPos` is OUTER-WINS: only set
+      // from this Track's loc when the parent context doesn't already
+      // carry one. trackId stays inner-wins (current `.p()` override
+      // semantics for the display label).
       const childCtx: CollectContext = {
         ...ctx,
         trackId: ir.trackId,
+        dollarPos:
+          ctx.dollarPos !== undefined
+            ? ctx.dollarPos
+            : ir.loc?.[0]?.start,
         leafIndex: undefined,
       }
       return withWrapperLoc(walk(ir.body, childCtx), ir.loc)

--- a/packages/editor/src/ir/parseStrudel.ts
+++ b/packages/editor/src/ir/parseStrudel.ts
@@ -117,20 +117,28 @@ export function parseStrudel(code: string): PatternIR {
       // loc covers the `$:` line range (PV36 / D-02). Synthetic-from-$:
       // form: no userMethod (toStrudel β-2 distinguishes from `.p()` form
       // via `userMethod === 'p'`).
+      //
+      // Phase 20-12.1 follow-up — commented `$:` lines produce an
+      // empty-body Track wrapper so d{N} numbering stays stable when
+      // the user toggles a line's comment prefix.
       const t = tracks[0]
-      return IR.track('d1', parseExpression(t.expr, t.offset), {
+      const body = t.commented ? IR.pure() : parseExpression(t.expr, t.offset)
+      return IR.track('d1', body, {
         loc: [{ start: t.dollarStart, end: t.end }],
       })
     }
     // Two+ `$:` blocks — Stack(Track('d1', ...), Track('d2', ...), ...).
     // Each Track carries its own `$:` line range as loc. The outer Stack
     // is synthetic (no loc / no userMethod) — same shape as today.
+    // Commented `$:` lines get Track wrappers with IR.pure() bodies so
+    // they keep their slot in the numbering.
     return IR.stack(
-      ...tracks.map((t, i) =>
-        IR.track(`d${i + 1}`, parseExpression(t.expr, t.offset), {
+      ...tracks.map((t, i) => {
+        const body = t.commented ? IR.pure() : parseExpression(t.expr, t.offset)
+        return IR.track(`d${i + 1}`, body, {
           loc: [{ start: t.dollarStart, end: t.end }],
-        }),
-      ),
+        })
+      }),
     )
   } catch {
     return IR.code(code)
@@ -153,7 +161,7 @@ export function parseStrudel(code: string): PatternIR {
  */
 export function extractTracks(
   code: string,
-): { expr: string; offset: number; dollarStart: number; end: number }[] {
+): { expr: string; offset: number; dollarStart: number; end: number; commented: boolean }[] {
   // Phase 20-11 α-2 — return shape additively widened. `dollarStart` (start
   // of the literal `$:` token) and `end` (exclusive end of the track body
   // slice — either the next `$:` line start or `code.length`) are exposed
@@ -161,15 +169,25 @@ export function extractTracks(
   // range to each Track wrapper. Existing callers (parseStrudel main +
   // parseStrudelStages.runRawStage) consume only `expr`/`offset` and are
   // forward-compatible.
+  //
+  // Phase 20-12.1 follow-up — commented `$:` lines (// $:) are now matched
+  // and emitted as `commented: true`. parseStrudel maps these to empty-body
+  // Tracks, so d{N} numbering stays stable when the user comments out a $:
+  // line during live editing. Without this, the IR renumbers (commenting
+  // line 4 of a 6-line fixture shifts d5/d6 down to d4/d5, leaving a
+  // disconnected d6 ghost from the slot map).
   const tracks: {
     expr: string
     offset: number
     dollarStart: number
     end: number
+    commented: boolean
   }[] = []
-  // Match `$:` at the start of a line (allowing leading whitespace).
-  const dollarRe = /^[ \t]*\$:/gm
-  const starts: { dollarStart: number; bodyStart: number }[] = []
+  // Match `$:` at the start of a line, allowing leading whitespace and an
+  // optional `//` line-comment prefix. Group 1 captures the `//...` if
+  // present; its presence flips `commented` for that entry.
+  const dollarRe = /^[ \t]*(\/\/[ \t]*)?\$:/gm
+  const starts: { dollarStart: number; bodyStart: number; commented: boolean }[] = []
   let m: RegExpExecArray | null
   while ((m = dollarRe.exec(code))) {
     // bodyStart points after `$:` and any post-colon whitespace on the
@@ -179,17 +197,29 @@ export function extractTracks(
     while (bodyStart < code.length && (code[bodyStart] === ' ' || code[bodyStart] === '\t')) {
       bodyStart++
     }
-    starts.push({ dollarStart: m.index, bodyStart })
+    const commented = !!m[1]
+    // dollarStart anchors at the LINE START (m.index) — consistent across
+    // commented vs uncommented forms since the regex matches from `^`.
+    // This keeps slice boundaries clean (`end` of one entry == line start
+    // of the next entry) regardless of comment toggling.
+    starts.push({ dollarStart: m.index, bodyStart, commented })
   }
   if (starts.length === 0) return []
 
   for (let i = 0; i < starts.length; i++) {
-    const { dollarStart, bodyStart } = starts[i]
+    const { dollarStart, bodyStart, commented } = starts[i]
     const end = i + 1 < starts.length ? starts[i + 1].dollarStart : code.length
+    if (commented) {
+      // Commented `$:` — emit an empty-body track. Body extent is irrelevant
+      // (we don't parse it), but slot-map identity for this position is
+      // preserved so the timeline shows a ghost row in place.
+      tracks.push({ expr: '', offset: bodyStart, dollarStart, end, commented: true })
+      continue
+    }
     const slice = code.slice(bodyStart, end)
     // Trailing whitespace can stay — parseExpression handles it. We
     // keep the leading slice intact so offsets line up.
-    tracks.push({ expr: slice, offset: bodyStart, dollarStart, end })
+    tracks.push({ expr: slice, offset: bodyStart, dollarStart, end, commented: false })
   }
   return tracks
 }

--- a/packages/editor/src/workspace/runtime/LiveCodingRuntime.ts
+++ b/packages/editor/src/workspace/runtime/LiveCodingRuntime.ts
@@ -639,6 +639,11 @@ export class LiveCodingRuntime implements LiveCodingRuntimeInterface {
    * Phase 19-08 (#85). RESEARCH §2.
    */
   getCurrentCycle(): number | null {
+    // Phase 20-12.1 follow-up — gate on isPlayingState. Strudel's
+    // scheduler keeps returning the last cycle value after stop, so
+    // without this gate `getCycle()` never goes null and MusicalTimeline's
+    // stop-edge slot-map reset never fires.
+    if (!this.isPlayingState) return null
     const v = this.engine.components.queryable?.scheduler?.now()
     return Number.isFinite(v) ? (v as number) : null
   }


### PR DESCRIPTION
## Summary

Closes the F-1 misdiagnosis surfaced post-merge of #117/#118. The "empty `d2` ghost row with faded label" symptom that F-1 originally attributed to `extractTracks` (parser) is actually `slotMapRef` retention in `MusicalTimeline.tsx` (per D-04 / Trap 5 from Phase 20-01). The regex correctly filters `// $:` lines — verified by direct observation.

**New UX rule (amends D-04):**

> Ghost rows persist only during live hot-reload while the transport is playing. On the first moment the transport stops (`getCycle()` transitions non-null → null), `slotMapRef` is cleared. The next play snaps to the current IR's tracks. Hot-reload while playing keeps the ghost row (audition workflow preserved).

**One subtlety:** "the next re-eval while stopped re-derives slots from scratch" applies to the *first* post-stop re-eval. Subsequent re-evals while stopped grow the slot map per insertion order — this is intentional (avoiding row-renumbering on every typo while paused).

## Why this UX over #111's "drop on every re-eval"

#111 was filed proposing immediate-drop-on-re-eval. Discussion in [this session, 2026-05-13] settled on pause-resets-slot-map instead because:
- Live A/B audition (comment a `$:` → compare → uncomment to restore) keeps row order intact during hot-reload — D-04's original intent
- Permanent removal is one keystroke away (`Cmd+.`) and clears cleanly
- No row renumbering during edit-while-playing (would surprise users mid-take)

## Changes

- **`packages/app/src/components/MusicalTimeline.tsx`** — 24 lines added: new `prevCycleNullRef` (init `true`), stop-edge reset block before `groupEventsByTrack`, plus a `getCycle()` sample in the existing 250ms poke interval so the drawer-closed stop edge is captured within ≤250ms of stopping.
- **`packages/app/src/components/__tests__/MusicalTimeline.test.tsx`** — 4 new vitest tests in a new describe block mirroring the file-switch-reset suite:
  1. stop → play with same IR yields same row order
  2. stop after re-eval-while-playing drops the ghost row
  3. hot-reload while playing keeps the ghost row (D-04 audition unchanged)
  4. re-eval while stopped grows insertion order without resetting between evals
- **`packages/app/tests/musical-timeline.spec.ts`** — rescoped Trap 5 Playwright probe from `reEvalStrudel` (Cmd+. + Cmd+Enter) to `evalStrudel` (Cmd+Enter only) so it exercises the audition workflow the amended D-04 preserves; added a new `Phase 20-12.1 — transport stop clears the slot map` end-to-end Playwright test.
- **`.planning/phases/20-musician-timeline/20-01-CONTEXT.md`** — D-04 amended (gitignored — not in PR diff)
- **`.anvi/hetvabhasa.md`** — new P64 entry (gitignored — not in PR diff): "downstream slot retention masquerades as parser bug" (class lesson from F-1 misdiagnosis)

## Test results

- App vitest: **297/297 green** (+4 new from 293 baseline)
- Editor vitest: **1526/1526 green** (no regression)
- Playwright: new `Phase 20-12.1` test reproduces a pre-existing Strudel-multi-track-boot flake that affects several specs in this file (verified independent of 20-12.1 changes by running on base commit `84698bc`); logic is fully covered by the vitest suite

## Test plan

- [x] Editor vitest green
- [x] App vitest green
- [x] Code review verified — `MusicalTimeline.tsx:555-590` reset block correct
- [x] Verifier agent: goal achieved (5/5 bullets covered)
- [ ] **T-8 manual dev-server gate (REQUIRED before merge)** — 7-step sequence in `.planning/phases/20-musician-timeline/20-12.1-VERIFICATION.md §"Manual gate (T-8)"`. Verifies the production mount path (P52 sub-risk: tested-but-not-mounted is the silent failure class). Run `pnpm dev`, follow steps 1-7 verbatim, confirm each observable.

## Closes

- Closes #111 (chrome retains phantom rows when `$:` line is commented out) — under the new pause-resets UX rule
- Resolves F-1 in `.planning/phases/20-musician-timeline/FOLLOWUPS.md` (reframed from parser bug to slot-retention UX)

## Catalogue additions

- **P64** (hetvābhāsa) — new error class: "downstream slot retention masquerades as parser bug." Reading code clean at parser layer ≠ symptom origin at parser layer when a downstream view holds state across re-evals.
- **D-04** amended (in `20-01-CONTEXT.md`) to scope slot retention to a single transport session.

## Planning artifacts (gitignored)

- `.planning/phases/20-musician-timeline/20-12.1-RESEARCH.md`
- `.planning/phases/20-musician-timeline/20-12.1-PLAN.md`
- `.planning/phases/20-musician-timeline/20-12.1-CHECK.md`
- `.planning/phases/20-musician-timeline/20-12.1-SUMMARY.md`
- `.planning/phases/20-musician-timeline/20-12.1-VERIFICATION.md`