### PR TITLE
Phase 20-14 α: mirror upstream evalScope + sample manifests + tier flag schema

### DIFF
--- a/.planning/phases/20-musician-timeline/20-14-CONTEXT.md
+++ b/.planning/phases/20-musician-timeline/20-14-CONTEXT.md
@@ -1,0 +1,239 @@
+---
+phase: 20-14
+title: Strudel.cc parity — eval-scope mirror + alias layer
+created: 2026-05-14
+decisions: 4
+closes: "#110"
+---
+
+# Phase 20-14 — Strudel.cc Parity
+
+## Goal
+
+Any code that runs on strudel.cc should run on Stave with the same audible +
+visual result. Closes the silent-gap class surfaced by 20-12's manual gate
+(`s("piano")` failing because Stave registers GM names as `gm_piano` and there
+is no bare-name alias).
+
+Three waves anticipated:
+
+- **α — Bootstrap mirror.** Read upstream `tidalcycles/strudel` REPL init,
+  enumerate every `evalScope` / `samples()` / `register*()` call, copy into
+  `StrudelEngine.init()` with tier flags for heavy modules.
+- **β — Alias layer.** Curated alias map (`piano → gm_piano`, `kick → bd`, etc.)
+  consulted before `soundMap.get()` reports a miss. Closes the most painful UX gap.
+- **γ — Parity smoke test corpus + CI gate.** 10-20 canonical strudel.cc
+  examples vendored at a pinned upstream SHA, asserted on every PR.
+
+## Locked Decisions
+
+### D-01: Parity rung — structural only for v1
+
+**Decision:** Smoke test asserts **IR shape + event count + param keys** match
+after eval. No scheduler-time comparison. No waveform comparison.
+
+**Rationale:** Three rungs (structural / schedule / audible). Structural is the
+cheapest reliable signal — deterministic, no audio rendering, drift surfaces as
+IR shape difference. Schedule + audible parity have well-known fragility:
+floating-point sample-rate edges, AudioWorklet timing variance, OfflineAudioContext
+divergence from live. Defer schedule (B) to a future phase once we have a stable
+shape gate; defer audible (C) unless real drift surfaces that structural can't catch.
+
+**Implication:** The CI gate is a vitest spec, not a Playwright spec. Eval each
+corpus example through Stave's pipeline → IR → assert shape against a snapshot
+captured from the same example. Updates to the corpus require regenerating
+snapshots (intentional — that's the "drift moment").
+
+---
+
+### D-02: Alias source — hand-curated TS const
+
+**Decision:** Maintain alias map as a TypeScript constant
+(`packages/editor/src/engine/aliases.ts`), ~20-50 entries, imported by
+`StrudelEngine` and consulted **before** `soundMap.get()` reports a miss.
+
+**Rationale:** Three alternatives (curated / generated-from-upstream / runtime
+JSON fetch). Hand-curated wins on explicitness and reviewability — every alias
+is a deliberate choice, easy to grep, easy to extend in a PR. Drift risk is
+real (upstream adds a name we don't alias) but is caught by the D-04 corpus
+smoke test, not silently shipped to users. Generated-from-upstream creates a
+build-time coupling to strudel.cc's internal registration script structure
+(brittle through their refactors). Runtime fetch introduces a network
+dependency on engine boot.
+
+**Implication:** The alias resolution lives at `s()` call interception point,
+not as a soundMap mutation. Two reasons: (1) keeps `loadedSoundNames`
+honest for autocomplete (don't pollute it with alias keys), (2) preserves the
+"GM names are GM names" invariant for advanced users who want to address them
+directly.
+
+---
+
+### D-03: Tier policy — settings panel toggle
+
+**Decision:** Heavy modules (`@strudel/csound`, `@strudel/midi` with
+`enableWebMidi`, `@strudel/osc`, `@strudel/serial`, additional soundfont packs
+beyond GM) are **off by default**. Each gets a toggle in `EditorSettingsModal`.
+Toggles persist via the workspace's existing settings store. `StrudelEngine.init()`
+reads the settings snapshot at boot and conditionally `await import()`s + registers.
+
+**Rationale:** Four alternatives considered (settings / per-file directive /
+both / build flag). Settings panel wins on UX clarity for the 90% case — a one-time
+opt-in, no per-program ritual, boot cost stays low for users who never touch
+Csound/MIDI. Per-file directive (B) is closer to Strudel's own idioms (`await samples(...)`,
+`await initHydra()`) and matches the spirit of "any program that runs on strudel.cc
+runs on Stave" — but it forces a runtime layer change for every imported module,
+which is α-wave scope creep. Option C (both) is a logical v2 once settings are
+in place — defer.
+
+**Implication:**
+- α-wave registers all **audio-pure** modules unconditionally (current 7 modules
+  + any audio-only additions enumerated from upstream).
+- α-wave introduces the tier flag schema in settings; flags default OFF; init
+  reads them at boot.
+- β-wave threads MIDI / OSC behind their flags (already partially wired —
+  `enableWebMidi()` is intentionally NOT called at init, per comment in
+  StrudelEngine.ts:141-142).
+- Per-file directive deferred to a follow-up issue. Note the decision in
+  α-wave SUMMARY so future-us doesn't re-litigate.
+
+---
+
+### D-04: Parity corpus — vendor 10-20 examples with upstream-SHA pin
+
+**Decision:** Copy canonical examples from `tidalcycles/strudel/website/src/examples/`
+(or equivalent) into `packages/app/tests/parity-corpus/`. Record the upstream
+commit SHA in a `CORPUS-SOURCE.md` alongside. Refresh manually when upstream
+moves and the maintainer wants to re-verify parity.
+
+**Rationale:** Three alternatives (vendor with SHA pin / live fetch at CI /
+author own corpus). Vendor + SHA wins because:
+- No network at CI time — deterministic, fast, no rate-limit risk.
+- Explicit drift moments — refresh requires a PR, which documents the parity
+  surface as it evolves.
+- Authoritative — these are the examples strudel.cc users see; passing them
+  is the strongest signal we provide parity.
+
+Live fetch is fragile (CI network flake, upstream availability). Stave-owned
+corpus loses the authoritativeness argument — we'd be testing what we think
+parity means, not what upstream demonstrates.
+
+**Implication:**
+- α-wave creates the corpus directory + CORPUS-SOURCE.md with initial SHA.
+- γ-wave writes the vitest spec that loads each `.strudel` file, evals through
+  Stave's pipeline, asserts IR shape against a snapshot.
+- A separate `pnpm parity:refresh` script (γ-wave) re-fetches upstream and
+  diffs — surfaces upstream changes for review but does NOT run on PRs.
+
+---
+
+## Scope Boundary
+
+**In scope (v1):**
+- Audit upstream REPL init + enumerate calls (α-wave research output).
+- Mirror missing audio-pure registrations into `StrudelEngine.init()`.
+- Alias map + interception layer at `s()` call site.
+- Tier flag schema in settings + UI toggles in `EditorSettingsModal`.
+- Parity corpus + vitest smoke test + CI gate.
+- A single Ground Truth doc traceable to the upstream init path (created as
+  part of α-wave if absent).
+
+**Out of scope (v1, queued for follow-ups):**
+- Bakery UI (sample-pack sharing) — separate phase, eval parity ≠ UI parity.
+- Per-file `await tier(...)` directive — D-03 part B; v2 once settings ship.
+- Csound bundle by default — opt-in only via the tier flag.
+- Schedule-time parity (parity rung B) — defer until structural surfaces drift
+  that shape can't catch.
+- Audible parity (parity rung C) — same.
+- Migration of existing GM-name code in user files (no breaking changes — bare
+  names work via alias, gm-prefixed names continue to work too).
+
+## Codebase Context
+
+**StrudelEngine.init()** — `packages/editor/src/engine/StrudelEngine.ts:121-180`
+- Current init order: dynamic imports → `evalScope` → `miniAllStrings` →
+  transpiler → `initAudio` → `registerSynthSounds` → `registerZZFXSounds` →
+  `registerSoundfonts` → `samples('github:.../Dirt-Samples/master')` →
+  analyser tap + onTrigger fan-out.
+- Comments at 141-145 already document `enableWebMidi()` not being called +
+  `@strudel/draw` intentional exclusion — established pattern of explicit
+  opt-out documentation. β-wave's tier comments should match this style.
+- `loadedSoundNames` (line 179) is the autocomplete source — D-02 keeps it
+  honest by aliasing at call site, not by polluting `soundMap`.
+
+**Settings infrastructure** — `packages/app/src/components/EditorSettingsModal.tsx`
+- Existing modal hosts editor preferences (track row height, etc. per
+  `layoutTrackRows.ts:97`). Tier toggles plug in here.
+- Settings persistence already wired through workspace's existing store
+  (review during α-wave research; document in RESEARCH.md).
+
+**Friendly errors** — `packages/editor/src/engine/friendlyErrors.ts:240,269`
+- The alias resolution layer interacts with friendly-error detection (an
+  unknown sound name currently produces a friendly hint). After β-wave the
+  hint flow should reflect "tried alias `kick` → resolved to `bd`" or "tried
+  alias `xyz` → no match, no alias".
+- Pre-existing fuzzy-match (`detect.alias` field) is separate from the new
+  curated alias layer — different intent (suggestion vs. resolution).
+
+**Discovery memory** — `feedback_strudel_init.md`
+- Required init sequence: `evalScope` → `miniAllStrings` → `registerSynthSounds`
+  → `transpiler`. α-wave must preserve this order when adding new
+  `register*()` calls from upstream — likely they slot AFTER the existing
+  registrations, not before.
+
+## Anticipated Gray Areas (Pre-α)
+
+These don't need user input now but should surface in α-wave RESEARCH:
+
+- **Upstream init path discovery.** Where exactly is strudel.cc's REPL
+  bootstrap? `tidalcycles/strudel/website/src/repl/` is the educated guess but
+  needs verification. May be split across multiple files. May have changed
+  recently.
+- **Csound footprint.** Confirm the WASM size + whether it's tree-shakeable at
+  all (some WASM modules are monolithic). If it's ~5MB unshakable, tier toggle
+  is non-negotiable; if smaller / shakeable, revisit default.
+- **MIDI permission UX.** `enableWebMidi()` triggers a browser permission
+  prompt. β-wave needs to decide if the settings toggle calls it immediately
+  on enable (early prompt) or lazily on first MIDI op (late prompt). User-facing
+  decision — surface in β-wave's discuss-phase if it makes it that far.
+- **soundMap mutation timing.** Some upstream `register*()` calls may mutate
+  `soundMap` after init returns. If alias layer caches the keyset, it gets stale.
+  α-wave research: confirm whether alias resolution must be a live lookup or
+  can snapshot.
+
+## Catalogue Pointers
+
+- `hetvabhasa.md` P11 — re-applied registrations can throw or no-op silently.
+  α-wave's new `register*()` calls must be idempotent or guarded.
+- `hetvabhasa.md` P62 — Strudel transpiler quote-rewriting. Confirmed gotcha;
+  parity examples that use string args must use single quotes — corpus
+  curation must respect this.
+- `feedback_strudel_init.md` — exact init-sequence ordering rule (above).
+- `feedback_editor_watch_mode.md` PV48 — when iterating on StrudelEngine.ts
+  during this phase, `pnpm --filter @stave/editor dev` MUST run.
+
+## Wave Plan (Preview — Detailed in PLAN.md)
+
+| Wave | Output | User-facing? |
+|---|---|---|
+| α | Bootstrap mirror: missing register calls + tier flag schema | No (engine boot only) |
+| β | Alias layer + EditorSettingsModal tier toggles + friendly-errors integration | Yes (toggles + alias-resolution hint) |
+| γ | Parity corpus + vitest smoke test + CI gate + refresh script | No (CI infra) |
+
+## Verification Gate Sketch (For PLAN.md)
+
+- **α gate:** Init succeeds with all audio-pure upstream registrations; tier
+  flags default off; engine boots in ≤ previous boot time + 100ms.
+- **β gate:** `s("piano")` plays a piano; `s("kick")` plays a kick. Settings
+  toggles persist across reloads. Friendly errors mention the alias path on miss.
+- **γ gate:** All vendored corpus examples eval to stable IR; vitest spec runs
+  in CI; refresh script surfaces upstream diff without running on PRs.
+
+## Open Items Carried Forward
+
+- File a follow-up issue for the per-file `await tier(...)` directive (D-03
+  part B) when α lands.
+- File a follow-up issue for schedule-parity / audible-parity if drift
+  surfaces structural can't catch (D-01 rungs B/C).
+- Document the corpus-refresh cadence in CORPUS-SOURCE.md (proposed: every
+  upstream minor version OR when a Stave user reports a parity gap).

--- a/.planning/phases/20-musician-timeline/20-14-OBSERVATIONS.md
+++ b/.planning/phases/20-musician-timeline/20-14-OBSERVATIONS.md
@@ -1,0 +1,74 @@
+---
+phase: 20-14
+title: α-wave runtime observations + settingPatterns audit
+created: 2026-05-15
+note: appended during α-wave execution; kept separate from RESEARCH.md to keep that pristine
+---
+
+# Phase 20-14 — α-wave Observations
+
+This file holds notes generated during α-wave execution that need a stable
+home but don't belong in the locked CONTEXT/RESEARCH/PLAN trio.
+
+## α-6 — `settingPatterns` audit (RESEARCH §7 open question #5)
+
+**Upstream source:** `website/src/settings.mjs` at the pinned SHA
+`f73b395648645aabe699f91ba0989f35a6fd8a3c`.
+
+**What `settingPatterns` is:** a single named export at upstream
+`settings.mjs:154` of shape `{ theme, fontFamily, fontSize }`. The three
+values are pattern-method `register()`s produced by the local
+`patternSetting(key)` helper (`settings.mjs:139-148`):
+
+```js
+const patternSetting = (key) =>
+  register(key, (value, pat) =>
+    pat.onTrigger(() => {
+      value = Array.isArray(value) ? value.join(' ') : value;
+      if (value !== settingsMap.get()[key]) {
+        settingsMap.setKey(key, value);
+      }
+      return pat;
+    }, false),   // ← the `false` 2nd arg to onTrigger means "no audio"
+  );
+```
+
+`settingsMap` is a `persistentMap(settings_key, defaultSettings)` of the
+upstream React editor's preferences — theme, font, panel state, zen mode,
+etc. It is **the strudel.cc website's settings store**, not a Strudel core
+concept.
+
+`settingPatterns` is passed as the FIRST positional arg to `evalScope` in
+upstream `util.mjs:97`:
+```js
+return evalScope(settingPatterns, ...modules);
+```
+
+So user code on strudel.cc can write things like:
+```js
+$: theme("dracula")
+$: fontSize("16")
+```
+and the editor mutates its own appearance on each hap fire.
+
+**Classification:** **UI-only.** The `false` second arg to `onTrigger`
+explicitly disables audio output for this register. The body's side
+effect is `settingsMap.setKey(...)`, a write into the strudel.cc website's
+state store. The transformation is purely cosmetic at the website layer.
+
+**Verdict for Stave:** Nothing **audio-pure** is missing. Re-exposing
+`theme` / `fontFamily` / `fontSize` on Stave would silently write to a
+settings object that doesn't exist here (or worse, would need a
+Stave-side equivalent that maps to its own theme/font store — which
+duplicates work in `editorRegistry.ts` for no audio benefit).
+
+**Action:** None for α. None for β. If γ surfaces a corpus tune that
+relies on `theme(...)`/`fontSize(...)` chain-method calls (none of the
+16 in RESEARCH §5 do), file a follow-up. Otherwise this is a closed loop.
+
+**Follow-up issues to file:** none — settingPatterns surface is fully
+UI-only.
+
+---
+
+## (Reserved for future α-wave observations)

--- a/.planning/phases/20-musician-timeline/20-14-PLAN.md
+++ b/.planning/phases/20-musician-timeline/20-14-PLAN.md
@@ -24,6 +24,19 @@ trace, tier matrix, and intercept sketch live in
 [20-14-RESEARCH.md](./20-14-RESEARCH.md). This plan translates those into
 executable tasks — it does not redesign them.
 
+**Audience.** Musician evaluating strudel.cc programs in Stave — NOT the IR
+debugger audience. Per `feedback_audience_classification.md` (PV35) the
+audience determines what "parity" means; for this phase it means *the program
+runs and sounds the same*, not *the IR can be inspected step-for-step*. The
+inspector exists but is a separate concern.
+
+**Visual-parity scope.** "Same visual result" in this phase is restricted to
+**audio-event-driven visuals owned by Stave** — MusicalTimeline, viz layer,
+IR Inspector. **DOM-injected upstream visuals from `@strudel/draw`
+(`pianoroll`, `scope`, `spectrum`) are explicitly out of scope.** Stave owns
+visuals; the user-visible difference of "those upstream draw calls do not
+render" is an accepted divergence for this phase.
+
 ## 2. Operational rules (read before touching code)
 
 - **Watch mode is mandatory.** Per PV48: when iterating on
@@ -43,6 +56,20 @@ executable tasks — it does not redesign them.
   after `evalScope` populates `Pattern` on `globalThis`.
 - **Tier toggles take effect on reload**, not immediately. That copy must be
   visible in the settings UI in β-wave.
+- **Tier-flag UI honesty (load-bearing).** β-3 ships **all 8 toggles** but
+  only the MIDI toggle is interactive. The other 7 (csound, tidal, osc, serial,
+  gamepad, motion, mqtt) are rendered **disabled** with a tooltip
+  `"Module wiring planned — see issue #NNN."` Rationale for option B over
+  hide-it option A: the schema is the contract. Showing the disabled toggles
+  signals *"Stave knows about csound, just not wired yet"* to musicians coming
+  from strudel.cc, which prevents the worse failure mode of users assuming
+  Stave silently dropped a tier. Each wiring follow-up issue (queued in §7)
+  lights up exactly one toggle.
+- **Non-corpus snapshot drift policy.** Any non-corpus PR that touches
+  `packages/editor/src/engine/` or `packages/editor/src/ir/` AND causes a
+  γ-2 parity snapshot diff must call out the diff in the PR body. The diff
+  itself is the news — explicit acknowledgement gates merge. (γ-3 handles
+  corpus-side drift via the refresh script.)
 - **Catalogue patterns to honor**: P1 (transpiler reify — intercept post-reify
   in `wrappedOutput`), P2 / UV2 (prototype install timing — boot-time only),
   P11 (re-applied registrations — confirmed idempotent in α), P62 (quote
@@ -58,12 +85,24 @@ but UI lands in β.
 
 ### Task α-1: Add `@strudel/edo` + `@strudel/mondo` to evalScope
 
-- **Files:** `packages/editor/src/engine/StrudelEngine.ts:129-137`
-- **Action:** Extend the `Promise.all` import set in `init()` to include
-  `import('@strudel/edo')` and `import('@strudel/mondo')`. Both packages must be
-  added to `packages/editor/package.json` dependencies. Both flow into the
-  existing `evalScope(...)` call alongside the current 7 modules — no other
-  init step changes. Verify pnpm lockfile updates cleanly.
+- **Files:** `packages/editor/src/engine/StrudelEngine.ts:129-147`,
+  `packages/editor/package.json`
+- **Pre-task note:** Before opening the α-1 PR, fetch upstream
+  `edo/index.mjs` and `mondo/index.mjs` (at the pinned SHA) and identify 1-2
+  named exports per package (e.g. `edoFromKey`, `mondo`) to verify at the dev
+  console after install. Record the chosen verification names in the PR body.
+- **Action — three explicit edits inside `init()`:**
+  1. **Promise.all import set (around line 129-137):** Add
+     `import('@strudel/edo')` and `import('@strudel/mondo')` to the existing
+     `Promise.all([...])` list of dynamic imports.
+  2. **Destructure (line 129, leading the await):** Add `edoMod` and
+     `mondoMod` (or the chosen local names) to the destructure that pulls
+     module values out of the resolved `Promise.all`.
+  3. **`evalScope` call (around line 147):** Add `edoMod, mondoMod` to the
+     positional arg list passed into `coreMod.evalScope(...)` alongside the
+     existing 7 modules.
+  Both packages must be added to `packages/editor/package.json` dependencies.
+  Verify pnpm lockfile updates cleanly.
 - **Ownership:** Created at boot by `StrudelEngine.init`. Consumed by user
   patterns at eval-time via `globalThis` symbols. No teardown ownership.
 - **Lifecycle:** Boot-time only, inside the existing
@@ -73,40 +112,49 @@ but UI lands in β.
   RESEARCH §8 (evalScope is `globalThis[name] = value` per export). Risk is
   package install failure (registry hiccup); mitigation: pin to specific
   upstream versions matching the SHA in frontmatter.
-- **Verify (Lokayata gate):** In dev console after engine boots, type
-  `globalThis.edoFromKey` and `globalThis.mondo` (or the respective module
-  exports — confirm names from upstream `loadModules`). Both must be defined.
-  Existing test suite must remain green.
+- **Verify (Lokayata gate):** In dev console after engine boots, type the two
+  chosen export names (e.g. `globalThis.edoFromKey`, `globalThis.mondo`).
+  Both must be defined. Existing test suite must remain green.
 
 ### Task α-2: Add six sample-manifest fetches to init
 
-- **Files:** `packages/editor/src/engine/StrudelEngine.ts:175` (after the
-  existing `samples('github:tidalcycles/Dirt-Samples/master')` call)
-- **Action:** Append six additional `samples(...)` calls in the order listed
-  in RESEARCH §1c, each awaited so the `loadedSoundNames` snapshot at line 179
-  captures all registered names:
-  1. `samples('${baseCDN}/piano.json', '${baseCDN}/piano/', { prebake: true })`
-  2. `samples('${baseCDN}/vcsl.json', '${baseCDN}/VCSL/', { prebake: true })`
-  3. `samples('${baseCDN}/tidal-drum-machines.json', baseCDN, { tag: 'drum-machines' })`
-  4. `samples('${baseCDN}/uzu-drumkit.json', baseCDN, { tag: 'drum-machines' })`
-  5. `samples('${baseCDN}/uzu-wavetables.json', baseCDN)`
-  6. `samples('${baseCDN}/mridangam.json', baseCDN, { tag: 'drum-machines' })`
+- **Files:** `packages/editor/src/engine/StrudelEngine.ts` (insertions around
+  the existing `samples('github:tidalcycles/Dirt-Samples/master')` call at
+  line ~175)
+- **Action — explicit insertion sequence inside `init()` (after
+  `registerSoundfonts` resolves at ~line 170):**
+
+  ```
+  1. await samples('github:tidalcycles/Dirt-Samples/master')   ← STAYS at line ~175 (existing)
+  2. await Promise.all([                                        ← NEW (this task)
+       samples(`${baseCDN}/piano.json`,                 `${baseCDN}/piano/`, { prebake: true }),
+       samples(`${baseCDN}/vcsl.json`,                  `${baseCDN}/VCSL/`,  { prebake: true }),
+       samples(`${baseCDN}/tidal-drum-machines.json`,   baseCDN,             { tag: 'drum-machines' }),
+       samples(`${baseCDN}/uzu-drumkit.json`,           baseCDN,             { tag: 'drum-machines' }),
+       samples(`${baseCDN}/uzu-wavetables.json`,        baseCDN),
+       samples(`${baseCDN}/mridangam.json`,             baseCDN,             { tag: 'drum-machines' }),
+       samples({ casio: [...], crow: [...], … },        `${baseCDN}/Dirt-Samples/`, { prebake: true }),
+     ])
+  3. await aliasBank(`${baseCDN}/tidal-drum-machines-alias.json`)  ← α-3 (NEXT task)
+  4. const soundMapData = …; loadedSoundNames snapshot          ← STAYS at line ~178-179
+  ```
+
   Define `baseCDN = 'https://strudel.b-cdn.net'` as a const at module scope
   with a comment citing upstream `prebake.mjs:13`. Keep the existing
   `github:tidalcycles/Dirt-Samples/master` call intact per RESEARCH §1c
   (second `samples()` wins on duplicate keys, so order matters — Dirt-Samples
-  stays FIRST, b-cdn manifests follow).
+  stays FIRST in step 1, b-cdn manifests follow in step 2).
 - **Ownership:** `samples()` mutates `soundMap` via `setKey`. Each manifest is
   owned by upstream b-cdn. Stave is a consumer only — never writes to the
   manifest URL.
-- **Lifecycle:** All six run in parallel inside a `Promise.all` after
-  `registerSoundfonts` resolves, before the `loadedSoundNames` snapshot. Each
-  is a manifest-JSON fetch at boot; individual audio sample URLs lazy-load on
-  first trigger.
+- **Lifecycle:** All six b-cdn manifests run in parallel inside the step-2
+  `Promise.all` after `registerSoundfonts` and the Dirt-Samples fetch resolve,
+  before the `loadedSoundNames` snapshot. Each is a manifest-JSON fetch at
+  boot; individual audio sample URLs lazy-load on first trigger.
 - **Pre-mortem:** RESEARCH §7 open-question #2 — b-cdn.net availability. A
   failed manifest fetch should not break boot; wrap each `samples()` call in
   a try/catch that logs and continues, matching the existing Dirt-Samples call
-  pattern. Document the accepted risk in code comment + §7 of this plan.
+  pattern. Document the accepted risk in code comment + §6 of this plan.
 - **Verify (Lokayata gate):** Boot the engine, then in dev console:
   `Object.keys(soundMap.get()).filter(k => /piano|tr909|RolandTR808|mridangam/i.test(k))`
   must return a non-empty array. Run an `s("piano")` pattern — audio must
@@ -114,50 +162,72 @@ but UI lands in β.
 
 ### Task α-3: Add `aliasBank()` fetch after manifests
 
-- **Files:** `packages/editor/src/engine/StrudelEngine.ts:175` (after the
-  Promise.all from α-2)
-- **Action:** Add a single `await` call:
-  `aliasBank('${baseCDN}/tidal-drum-machines-alias.json')`. Import `aliasBank`
-  from `@strudel/webaudio` alongside the existing imports. This registers the
-  69 bank-name aliases (e.g., `RolandTR909 → 909`) — bank-level only, NOT the
-  bare-name alias layer (that's β).
+- **Files:** `packages/editor/src/engine/StrudelEngine.ts` (insertion at step
+  3 of the α-2 sequence above)
+- **Action:** Add the single `await` call shown as step 3 in α-2:
+  `await aliasBank(\`${baseCDN}/tidal-drum-machines-alias.json\`)`. Import
+  `aliasBank` from `@strudel/webaudio` alongside the existing imports. This
+  registers the 69 bank-name aliases (e.g., `RolandTR909 → 909`) —
+  bank-level only, NOT the bare-name alias layer (that's β).
 - **Ownership:** Upstream-owned JSON. Mutates `aliasBankMap` inside superdough
   via `soundMap.set` (RESEARCH §3). Stave is consumer only.
 - **Lifecycle:** Runs once at boot, after all six manifest fetches resolve, so
   `aliasBank` sees a populated `soundMap`.
 - **Pre-mortem:** RESEARCH §7 open-question #3 — confirm `.bank("tr909")`
-  produces the expected IR shape after this lands. Mitigation: run `flatrave`
-  (corpus member #10) manually after α-2 + α-3 land; if shape differs from
-  upstream, surface in α SUMMARY before β starts.
-- **Verify (Lokayata gate):** Eval `s("[bd <hh oh>]*2").bank("tr909").dec(.4)`
-  (upstream's default REPL line per RESEARCH §1d). Audio must play with TR-909
-  samples, not Dirt-Samples bd/hh.
+  produces the expected IR shape after this lands. **AND** RESEARCH §3 flagged
+  that `aliasBank` internally calls `soundMap.set({...soundDictionary})` —
+  this could either MERGE alias entries into the existing map (safe) or
+  REPLACE the whole map (would wipe the six manifests just registered, a
+  krama violation). Mitigation: the verify step below must distinguish these
+  two cases before β starts.
+- **Verify (Lokayata gate):**
+  1. **aliasBank semantics check (gates the rest of the task).** In dev
+     console, BEFORE `aliasBank()` resolves log
+     `Object.keys(soundMap.get()).length`. AFTER it resolves, log the same.
+     If the count is monotonic (grew or stayed equal), the call merges and
+     current ordering is safe. **If the count dropped, the call replaces
+     the map — STOP and escalate as a PLAN-LEVEL ISSUE** (we would need to
+     call `aliasBank` BEFORE the manifest fetches instead, contradicting the
+     current sequence). Record the BEFORE/AFTER counts in α-7 SUMMARY.
+  2. **Functional check.** Eval `s("[bd <hh oh>]*2").bank("tr909").dec(.4)`
+     (upstream's default REPL line per RESEARCH §1d). Audio must play with
+     TR-909 samples, not Dirt-Samples bd/hh.
 
-### Task α-4: Vendor or port `piano.mjs` for `Pattern.prototype.piano`
+### Task α-4: Vendor `piano.mjs` for `Pattern.prototype.piano`
 
 - **Files:** `packages/editor/src/engine/vendored/piano.ts` (new, ~30 lines),
   `packages/editor/src/engine/StrudelEngine.ts` (import call)
-- **Action:** Port the upstream `prebake.mjs` piano injection (clip=1,
+- **License note (resolved):** `@stave/editor` is `AGPL-3.0-or-later` (see
+  `packages/editor/package.json`). Upstream `prebake.mjs` is also AGPL-3.0,
+  so **vendoring is license-compatible — no porting/rewrite required**. The
+  vendored file MUST carry a header citing:
+  1. Upstream source URL (Codeberg path to `prebake.mjs`).
+  2. Pinned SHA from this plan's frontmatter
+     (`f73b395648645aabe699f91ba0989f35a6fd8a3c`).
+  3. A pointer to the existing `LICENSE` file at the repo root
+     (e.g. `// License: AGPL-3.0-or-later — see /LICENSE`).
+- **Action:** Vendor the upstream `prebake.mjs` piano injection (clip=1,
   `.s('piano')`, `.release(.1)`, pan by pitch — see RESEARCH §1c row "piano.mjs"
   and §7 open-question #1) into a TypeScript module that, on import, attaches
   `Pattern.prototype.piano`. Import this module at the END of `init()` AFTER
-  `evalScope` resolves (so `Pattern` exists on globalThis). Include header
-  comment citing upstream `prebake.mjs:165` and license note (AGPL-3.0).
+  `evalScope` resolves (so `Pattern` exists on globalThis).
 - **Ownership:** Vendored module owns the prototype assignment. Stave's
   `injectPatternMethods` (per UV2/P2) owns `.p`, `.viz`, legacy viz names —
-  `.piano` is NOT in that list. The two systems coexist.
+  `.piano` is NOT in that list. The two systems coexist. License-compatible;
+  both Stave editor and upstream `prebake.mjs` are AGPL-3.0.
 - **Lifecycle:** Imported ONCE at boot, after `evalScope`. Side-effect on
   import attaches the method. Does NOT re-run per eval — that would be the
   P2 trap.
 - **Pre-mortem:** P2 / UV2 — `.p()` setter trap and `injectPatternMethods`
   overwrite. RESEARCH §7 open-question #1 says trap is on `.p`, `.viz`, and
-  legacy viz names, so `.piano` should be safe. **OBSERVE in α**: after boot,
-  call `Pattern.prototype.piano` directly — must be a function. Then eval
-  `note("c4 e4 g4").piano()` and confirm the same method survives across an
-  eval cycle (i.e., evaluate, then re-check the prototype — must still be the
-  ported function, not overwritten/stripped). If overwrite occurs, the
-  mitigation is moving the install into post-eval, but this is anticipated
-  unlikely.
+  legacy viz names, so `.piano` should be safe. License-compatible
+  (AGPL-3.0 ↔ AGPL-3.0) so no porting concern. **OBSERVE in α**: after
+  boot, call `Pattern.prototype.piano` directly — must be a function. Then
+  eval `note("c4 e4 g4").piano()` and confirm the same method survives
+  across an eval cycle (i.e., evaluate, then re-check the prototype — must
+  still be the vendored function, not overwritten/stripped). If overwrite
+  occurs, the mitigation is moving the install into post-eval, but this is
+  anticipated unlikely.
 - **Verify (Lokayata gate):** Console: `typeof Pattern.prototype.piano`
   returns `'function'` after boot AND after one full eval cycle. Eval
   `note("c4 e4 g4").piano()` — audio plays with Salamander piano samples.
@@ -176,6 +246,10 @@ but UI lands in β.
   function returns all-false until β adds toggles. Schema only — no
   conditional imports yet (β threads MIDI/OSC behind their flags; csound/tidal
   gating lands when those tunes enter the corpus, queued as follow-up).
+  Inside `StrudelEngine.init()`, **read the flags once and store them on the
+  engine instance** so β can thread MIDI gating off them; also add a dev-only
+  `console.log('[StrudelEngine] tierFlags read at init:', tierFlags)` so the
+  consumed-at-init contract is observable.
 - **Ownership:** Schema owned by `tierFlags.ts`. Storage owned by workspace
   settings store. Engine init is a READER only; never writes.
 - **Lifecycle:** Read ONCE at boot inside `StrudelEngine.init()`. Mid-session
@@ -184,19 +258,28 @@ but UI lands in β.
   breaks persisted settings. Mitigation: defaults are derived from the type at
   read-time, so missing keys read as `false`. Document this in the file
   header.
-- **Verify (Lokayata gate):** In dev console after boot:
-  `getTierFlags()` returns an object with exactly 8 boolean false fields. Type
-  the keyset and confirm it matches the documented schema.
+- **Verify (Lokayata gate):**
+  1. In dev console after boot: `getTierFlags()` returns an object with
+     exactly 8 boolean false fields. Type the keyset and confirm it matches
+     the documented schema.
+  2. **Consumed-at-init check.** Reload the dev server. The console must
+     show `[StrudelEngine] tierFlags read at init: { csound: false, … }`.
+     If the log does not appear, the schema is wired but init is not
+     actually consuming it — α-5 is incomplete.
 
 ### Task α-6: OBSERVE — open question #5 (`settingPatterns` audit)
 
 - **Files:** none modified; output is a findings note appended to
   `20-14-RESEARCH.md` or a new `20-14-OBSERVATIONS.md` if RESEARCH stays
-  pristine
+  pristine. Findings are ALSO summarized as a bullet list at the bottom of
+  α-7 SUMMARY.
 - **Action:** Read upstream `settings.mjs` (Codeberg, same SHA) and enumerate
   what `settingPatterns` exports. Classify each export: audio-pure / UI-only /
-  permissioned. If any audio-pure exports are missing from Stave, file a
-  follow-up issue (do NOT add in α — α scope is locked to edo/mondo).
+  permissioned. If any audio-pure exports are missing from Stave, file ONE
+  follow-up issue per missing audio-pure call. **Important: a missing
+  audio-pure call discovered here does NOT block α-7 / α shipping** — it
+  becomes its own follow-up issue and is referenced from α-7 SUMMARY. α scope
+  is locked to edo/mondo per D-03.
 - **Ownership:** Read-only investigation. Output is documentation, not code.
 - **Lifecycle:** Out-of-band — runs during α-wave but does not block α
   shipping. Findings inform γ corpus selection.
@@ -204,32 +287,55 @@ but UI lands in β.
   footnote, exactly because skipping it leaves a known blind spot RESEARCH §7
   flagged.
 - **Verify:** A written note exists with the enumeration and the
-  audio-pure-missing list (or "none missing").
+  audio-pure-missing list (or "none missing"). α-7 SUMMARY's bottom bullet
+  list references the note and contains one follow-up issue link per missing
+  audio-pure call (or "none — settingPatterns surface is fully audio-pure or
+  fully UI-only").
 
 ### Task α-7: SUMMARY commit — α-wave gate
 
 - **Files:** `.planning/phases/20-musician-timeline/20-14-α-SUMMARY.md` (new)
-- **Action:** Write a one-page summary capturing: what landed, observations
-  from α-4 (piano prototype install timing), observations from α-6
-  (settingPatterns audit result), `.bank("tr909")` IR shape confirmation from
-  α-3, the "tier flag toggle requires reload" UX decision (carried into β),
-  and the explicit note that per-file `await tier(...)` directive is queued
-  follow-up (D-03 part B).
+- **Action:** Write a one-page summary with **one paragraph per α-1 through
+  α-6, each containing at least one cited Lokayata observation**:
+  - **α-1 paragraph:** confirm the two named `globalThis` exports were
+    defined post-boot.
+  - **α-2 paragraph:** confirm the regex from α-2 verify returned at least
+    one match.
+  - **α-3 paragraph:** record the BEFORE/AFTER `soundMap` key counts around
+    `aliasBank` (proves merge vs replace).
+  - **α-4 paragraph:** record the **post-eval prototype check result** —
+    explicitly state whether `Pattern.prototype.piano` was still the
+    vendored function after one `evaluate()` cycle (yes/no).
+  - **α-5 paragraph:** record that the `[StrudelEngine] tierFlags read at
+    init: …` console log was observed on reload.
+  - **α-6 paragraph:** the `settingPatterns` audit result + bullet list of
+    follow-up issue links (or explicit "none missing").
+  Also document: the "tier flag toggle requires reload" UX decision
+  (carried into β-3), and the explicit note that per-file `await tier(...)`
+  directive is queued follow-up (D-03 part B).
 - **Ownership:** Documentation owned by this plan.
 - **Lifecycle:** Final α task. Gates β-wave start.
-- **Pre-mortem:** Vague claims. Mitigation: every assertion in the summary
-  must cite a Lokayata observation from α-1 through α-6.
-- **Verify:** File exists and is complete; α gate (below) holds.
+- **Pre-mortem:** Vague claims. Mitigation: every paragraph must cite a
+  concrete observation; reviewer rejects any paragraph that contains only
+  inference language ("should", "expected to").
+- **Verify:** The file exists and contains one paragraph per α-1..α-6, each
+  citing at least one observation from the corresponding task's Lokayata
+  gate. The α-4 paragraph specifically records the post-eval prototype check
+  result (yes/no). α gate (below) holds.
 
 ### α verification gate
 
 Before opening the α PR:
 - Engine boots without throwing (no friendly-error panel on empty workspace).
-- `globalThis.edoFromKey` and `globalThis.mondo` exports defined.
+- The two chosen `@strudel/edo` + `@strudel/mondo` exports are defined on
+  `globalThis`.
 - `s("piano")` audibly plays piano samples (not "sound not found").
 - `s("[bd <hh oh>]*2").bank("tr909").dec(.4)` audibly plays TR-909 kick/hat.
+- `aliasBank` was observed to merge (not replace) the `soundMap` per α-3's
+  count-check.
 - `Pattern.prototype.piano` survives one full eval cycle.
-- `getTierFlags()` returns 8 falses.
+- `getTierFlags()` returns 8 falses AND the `[StrudelEngine] tierFlags read
+  at init:` log appears on reload.
 - Existing test suite remains green (no regressions).
 - Engine boot time within previous + 100ms (rough check via dev console
   `performance.now()` delta — manifests lazy-load samples, so manifest fetches
@@ -239,7 +345,8 @@ Before opening the α PR:
 
 **Goal:** Bare-name resolution (`piano`, `kick`, `snare`, etc.) works without
 the user reaching for `gm_*` GM names. Settings panel exposes tier toggles
-behind 8 flags. Friendly errors surface alias path on resolution and on miss.
+behind 8 flags (1 functional, 7 disabled-scaffolded — see §2). Friendly errors
+surface alias path on resolution and on miss.
 
 ### Task β-1: Hand-curated alias map
 
@@ -270,7 +377,7 @@ behind 8 flags. Friendly errors surface alias path on resolution and on miss.
   in a fresh post-α `soundMap.get()`, must return `undefined` — confirming the
   alias is needed and not redundant.
 
-### Task β-2: Strategy A intercept in `wrappedOutput`
+### Task β-2: Strategy A intercept in `wrappedOutput` (+ accumulator plumbing)
 
 - **Files:** `packages/editor/src/engine/StrudelEngine.ts:207` (the
   `wrappedOutput` function — see RESEARCH §3 sketch)
@@ -279,45 +386,79 @@ behind 8 flags. Friendly errors surface alias path on resolution and on miss.
   `hap.value.s`; if string AND raw name unregistered AND alias exists in
   `ALIASES`, replace `hap.value.s` with the aliased name. Preserve hap value
   identity via shallow clone so other consumers see the same hap object
-  shape. Import `ALIASES` from β-1.
+  shape. Import `ALIASES` from β-1. **Also plumb the per-eval
+  `lastAliasResolutions: Map<string, string>` accumulator described in β-5
+  here**: declare it as an **instance field on `StrudelEngine`** (NOT module
+  state), expose a `_resetAliasResolutions()` method called from
+  `evaluate()`'s entry, and have `wrappedOutput` append `{ from, to }` to it
+  whenever a rewrite happens. The accumulator is the load-bearing change of
+  β-2 + β-5; the friendly-error message text in β-5 just reads it.
 - **Ownership:** `hap` is owned by the scheduler. `wrappedOutput` is a
   transformer in the middle. After this task, `wrappedOutput` also owns the
   optional rewrite of `hap.value.s` from bare name to canonical name. The
   scheduler downstream consumes the rewritten hap.
+  **`lastAliasResolutions` is owned by the `StrudelEngine` instance**
+  (instance state, not module state). Reset at each `evaluate()` start by
+  `StrudelEngine`. Written by `wrappedOutput` (engine-owned method). Read by
+  `friendlyErrors` at message-build time. Single owner = `StrudelEngine`.
 - **Lifecycle:** Runs per hap on the audio-thread message path. Strategy A
   operates POST-reify (P1) — `hap.value.s` is always a string by the time
-  `wrappedOutput` sees it (RESEARCH §3, §8 invariant UV3).
+  `wrappedOutput` sees it (RESEARCH §3, §8 invariant UV3). Accumulator
+  lifecycle: reset at `evaluate()` entry → append-only during eval window →
+  read at friendly-error build time.
 - **Pre-mortem:** P1 (transpiler reification) — Strategy A is the correct
   layer because reification has already collapsed Patterns to per-event
   strings. Cite this in the inline comment. Second risk: hot-path cost.
   Mitigation: a single `Map.get` + null check per hap is sub-microsecond;
-  irrelevant compared to existing scheduler overhead.
+  irrelevant compared to existing scheduler overhead. Third risk: accumulator
+  leaks across evals if reset is missed — mitigation: reset is the FIRST
+  statement of `evaluate()`, not buried in helpers.
 - **Verify (Lokayata gate):** Eval `s("kick").n(0)`. Audio plays a kick drum
   (`bd` sample). Then eval `s("bd")` — same audible result. Confirm
   `soundMap.get().kick` is still `undefined` (no pollution of autocomplete).
+  Confirm `engine.lastAliasResolutions` (or whatever the field is named)
+  contains `{ kick → bd }` after the first eval and gets reset on the second.
 
-### Task β-3: Tier toggles in `EditorSettingsModal`
+### Task β-3: Tier toggles in `EditorSettingsModal` (1 live + 7 disabled)
 
 - **Files:** `packages/app/src/components/EditorSettingsModal.tsx`
-- **Action:** Add a "Strudel modules" section to the settings modal with 8
-  toggles (csound, tidal, midi, osc, serial, gamepad, motion, mqtt). Each row
-  shows: name, one-sentence description, current state. Below the section, a
-  visible caption: "Changes take effect when you reload the page." Toggles
-  persist through the existing workspace settings store; reading uses
-  `getTierFlags()` from α-5.
+- **Action:** Add a "Strudel modules" section to the settings modal with **all
+  8 toggles** (csound, tidal, midi, osc, serial, gamepad, motion, mqtt). Per
+  §2 tier-flag UI honesty rule:
+  - **MIDI:** interactive. Toggling persists via the workspace settings store;
+    read on next boot via `getTierFlags()` from α-5.
+  - **The other 7 (csound, tidal, osc, serial, gamepad, motion, mqtt):**
+    rendered DISABLED. Each disabled toggle carries a tooltip
+    `"Module wiring planned — see issue #NNN."` (Each follow-up issue from
+    §7 supplies its own #NNN; placeholder text `"see follow-up issue"` is
+    acceptable for the first PR if the issues haven't been filed yet, but
+    the follow-up issues must be filed before β PR merges.)
+  Each row shows: name, one-sentence description, current state. Below the
+  section, a visible caption: `"Changes take effect when you reload the
+  page."` Add size hint captions to the csound and tidal rows (still
+  disabled): `"Will load ~6MB when enabled."`
 - **Ownership:** UI owned by `EditorSettingsModal`. Persistence owned by the
   workspace settings store. Engine reads at next boot only.
-- **Lifecycle:** User interaction → settings store write → state persists.
-  Engine does NOT observe the change until the next page load. The reload
-  copy makes this explicit.
+- **Lifecycle:** User interaction (MIDI only) → settings store write → state
+  persists. Engine does NOT observe the change until the next page load. The
+  reload copy makes this explicit. The 7 disabled toggles do nothing on
+  click; their state remains `false`.
 - **Pre-mortem:** User toggles, expects immediate effect, sees nothing happen
   → reports as bug. Mitigation: the reload copy is non-negotiable. RESEARCH
-  §4 + §8 documented this. Also: if user enables `csound` or `tidal` and
-  reloads, the dynamic import will pull a 6MB+ bundle on next boot — add a
-  size hint to those two rows ("loads ~6MB on enable").
-- **Verify (Lokayata gate):** Open settings, toggle `midi` on, close modal,
-  reload page. Verify the toggle state persists (modal reflects on). Confirm
-  via dev console that the engine init read the flag.
+  §4 + §8 documented this. Second pre-mortem: shipping 7 toggles that look
+  active but no-op silently — mitigation: disabled state + tooltip telegraphs
+  "scaffolded, not yet wired" so users do not assume Stave dropped support.
+- **Verify (Lokayata gate):**
+  1. Open `EditorSettingsModal` in the browser. Capture a screenshot (or
+     paste into β-6 summary). Confirm the
+     `"Changes take effect when you reload the page."` caption is visible
+     and not clipped, AND that the 7 disabled toggles carry the
+     "Module wiring planned" tooltip on hover.
+  2. Toggle `midi` on, close modal, reload page. Verify the toggle state
+     persists (modal reflects on). Confirm via the α-5 dev console log that
+     `tierFlags.midi === true` was read at init.
+  3. Click a disabled toggle (e.g. `csound`). It must NOT change state and
+     must NOT write to the settings store.
 
 ### Task β-4: Thread MIDI tier flag through engine init
 
@@ -340,31 +481,38 @@ behind 8 flags. Friendly errors surface alias path on resolution and on miss.
 - **Verify (Lokayata gate):** With midi flag OFF, boot — no permission prompt.
   Enable, reload — browser shows MIDI permission dialog during init.
 
-### Task β-5: Friendly-errors integration
+### Task β-5: Friendly-errors message integration
 
 - **Files:** `packages/editor/src/engine/friendlyErrors.ts:240` (resolved
   path), `:269` (miss path)
-- **Action:** Two one-line additions per RESEARCH §6:
+- **Action — cosmetic message-text updates only; the load-bearing
+  accumulator was already plumbed in β-2.** Two one-line additions per
+  RESEARCH §6:
   1. **Resolved path:** when `wrappedOutput` rewrote `hap.value.s` via alias,
-     attach an `aliasResolved: { from, to }` field to the friendly-error
-     payload (when one is produced for downstream diagnostics — not on every
-     hap). UI surfaces: `tried alias "kick" → "bd" (resolved)`. Plumb the
-     alias context through `wrappedOutput` so this is observable; simplest is
-     a per-eval `lastAliasResolutions: Map<string,string>` accumulator
-     consulted only when a friendly error is built.
+     surface the resolution in the friendly-error payload as
+     `aliasResolved: { from, to }` (when one is produced for downstream
+     diagnostics — not on every hap). Read from the per-eval
+     `lastAliasResolutions` accumulator on `StrudelEngine` (owned/reset by
+     β-2). UI surfaces: `tried alias "kick" → "bd" (resolved)`.
   2. **Miss path:** in the "sound X not found" message builder, check
      `ALIASES` for the missing name; if absent, append "alias map: no entry
      for `xyz`." If present in ALIASES but the aliased target also missing,
      append "alias map: `xyz` → `target` (but `target` is not loaded)."
 - **Ownership:** `friendlyErrors.ts` owns the message text. The alias map is
-  the input. `wrappedOutput` writes the per-eval accumulator.
+  the input. `StrudelEngine` owns the `lastAliasResolutions` accumulator
+  (per β-2). `friendlyErrors` is read-only against it.
 - **Lifecycle:** Resolved-path runs at message-build time (rare; only on
   error). Miss-path runs when superdough throws the "not found" error
   upstream-side. Separate from `detect.alias` (orthogonal CommonMistake
   mechanism in friendlyErrors — RESEARCH §6).
 - **Pre-mortem:** Pre-existing `detect.alias` field collision. Mitigation:
   use distinct key `aliasResolved` (or namespace under `soundAlias`) to keep
-  the two concepts separate per RESEARCH §6.
+  the two concepts separate per RESEARCH §6. **Note on atomicity:** kept
+  β-5 atomic rather than splitting into β-5a/β-5b because once the
+  accumulator is owned by β-2, the remaining work here is pure
+  message-text — splitting would add ceremony without buying
+  reviewability. The accumulator plumbing is the load-bearing change and
+  lives in β-2; the message text here is cosmetic.
 - **Verify (Lokayata gate):** Eval `s("kick")` — no error. Eval `s("xyz123")`
   — friendly error shows the "alias map: no entry" suffix. Eval `s("bell")`
   when bell sample isn't loaded — friendly error shows the resolved-to-target
@@ -373,10 +521,18 @@ behind 8 flags. Friendly errors surface alias path on resolution and on miss.
 ### Task β-6: SUMMARY commit — β-wave gate
 
 - **Files:** `.planning/phases/20-musician-timeline/20-14-β-SUMMARY.md` (new)
-- **Action:** Document: alias map final entry list + rationale per entry,
-  resolved Strategy A observations, settings UI screenshots (or `<details>`
-  links to dev screencaps), MIDI prompt UX confirmation, friendly-error
-  behavior in the three β-5 test cases.
+- **Action:** Document:
+  - Alias map final entry list + rationale per entry.
+  - Resolved Strategy A observations (β-2 Lokayata results).
+  - Settings UI screenshots (or `<details>` links to dev screencaps).
+  - **Explicit toggle wiring matrix:** for each of the 8 tier flags, state
+    which are **functional** (MIDI) vs **scaffolded / disabled** (csound,
+    tidal, osc, serial, gamepad, motion, mqtt) and link the follow-up issue
+    per scaffolded toggle. This is the load-bearing line of the SUMMARY —
+    a reader scanning β-6 must learn from this paragraph which toggles
+    actually do something.
+  - MIDI prompt UX confirmation.
+  - Friendly-error behavior in the three β-5 test cases.
 - **Verify:** β gate (below) holds.
 
 ### β verification gate
@@ -384,8 +540,9 @@ behind 8 flags. Friendly errors surface alias path on resolution and on miss.
 - `s("piano")`, `s("kick")`, `s("snare")`, `s("clap")` all play their
   intended sounds without manual `gm_*` prefix.
 - `soundMap.get().kick` remains `undefined` post-boot (autocomplete clean).
-- Settings modal exposes 8 toggles; toggling one + reload reads true on next
-  boot via `getTierFlags()`.
+- Settings modal exposes 8 toggles; MIDI is interactive and the other 7 are
+  rendered disabled with the "Module wiring planned" tooltip.
+- Toggling MIDI + reload reads true on next boot via `getTierFlags()`.
 - Enabling `midi` triggers permission prompt on next reload, not before.
 - Friendly errors show the alias-resolution suffix on the three β-5 test
   cases.
@@ -418,9 +575,10 @@ manual upstream sync without running on PRs.
   (verify by re-running the fetch on the pinned SHA — git diff is empty).
   CORPUS-SOURCE.md lists exactly 16 tunes.
 
-### Task γ-2: Vitest spec — eval each tune, assert IR shape
+### Task γ-2: Vitest spec — eval each tune, assert IR shape (+ normalizer subtask)
 
 - **Files:** `packages/app/tests/parity-corpus/parity.test.ts` (new),
+  `packages/app/tests/parity-corpus/normalize.ts` (new — see subtask),
   `packages/app/tests/parity-corpus/snapshots/__snapshots__/parity.test.ts.snap`
   (new, generated)
 - **Action:** Vitest spec that for each `.strudel` file in the corpus:
@@ -434,19 +592,33 @@ manual upstream sync without running on PRs.
      locks this rung.
   4. Initial snapshots generated by running the spec once with `-u` —
      committed alongside the test.
+- **Subtask — IR-shape normalizer (named deliverable):**
+  `packages/app/tests/parity-corpus/normalize.ts` exports
+  `normalizeIRShape(ir)` that strips fields known to vary between runs.
+  Each stripped field MUST be listed with an inline-comment rationale, e.g.:
+  ```
+  // timestamps: wall-clock drift between runs
+  // internal node ids: assigned by the IR builder, not stable across evals
+  // source-loc offsets: byte offsets from the parser, vary with newline normalization
+  ```
+  The normalizer is part of γ-2's deliverable, not an afterthought.
 - **Ownership:** Stave's eval pipeline owns the IR shape. The snapshot is the
-  current declared truth. Drift = snapshot change = PR review moment.
+  current declared truth. The `normalizeIRShape` helper owns the
+  "what counts as stable" definition; future drift here is a deliberate
+  contract change documented in the rationale comments. Drift = snapshot
+  change = PR review moment.
 - **Lifecycle:** Runs on every CI PR. Reads vendored `.strudel` files at
   test-start, evals each in isolation (new engine instance per tune to avoid
   cross-tune state).
 - **Pre-mortem:** Snapshot flakiness from non-deterministic IR fields (e.g.,
-  random seeds, timestamps). Mitigation: serialize IR through a normalization
-  function that strips timing fields, sorts param keys, and drops `id` fields
-  if any. The normalizer is part of this task — write it explicitly, not as
-  an afterthought.
+  random seeds, timestamps). Mitigation: the `normalizeIRShape` helper strips
+  these explicitly with rationale comments — anyone tempted to add a new
+  stripped field must justify it in the comment.
 - **Verify (Lokayata gate):** Run the test suite — all 16 tunes pass. Manually
   break one corpus file by adding a `.fast(2)` and re-run — that single test
-  fails with a clear snapshot diff (not a runtime error).
+  fails with a clear snapshot diff (not a runtime error). The non-corpus
+  drift policy in §2 applies to PRs that change the engine and incidentally
+  shift the snapshot.
 
 ### Task γ-3: `pnpm parity:refresh` script + CI wiring
 
@@ -480,8 +652,9 @@ manual upstream sync without running on PRs.
 - **Files:** `.planning/phases/20-musician-timeline/20-14-γ-SUMMARY.md` (new)
 - **Action:** Document: which 16 tunes are vendored, snapshot regeneration
   policy ("regen with `-u` only in a PR titled `corpus: refresh from
-  upstream SHA <x>`"), CI runtime of the parity spec, examples of what a
-  shape drift looks like in a PR diff.
+  upstream SHA <x>`"), how the non-corpus drift policy (PLAN §2) interacts
+  with engine PRs, CI runtime of the parity spec, examples of what a shape
+  drift looks like in a PR diff.
 - **Verify:** γ gate (below) holds.
 
 ### γ verification gate
@@ -501,9 +674,9 @@ Mapped from RESEARCH §7:
 |---|---|---|---|
 | 1 | `Pattern.prototype.piano` install timing vs `.p()` setter trap | α observation | Task α-4 + α-7 summary |
 | 2 | b-cdn.net availability | Documented risk | Task α-2 try/catch + α-7 summary call-out |
-| 3 | `.bank("tr909")` IR shape match | α observation | Task α-3 verify + α-7 summary; failure mode escalates to γ-2 |
+| 3 | `.bank("tr909")` IR shape match + `aliasBank` merge-vs-replace semantics | α observation | Task α-3 verify (both checks) + α-7 summary; semantics-replace finding would escalate to a plan-level rework, IR-shape mismatch would escalate to γ-2 |
 | 4 | Pre-init alias lookup race | Documented risk | β-1 header comment (precedence rule) |
-| 5 | `settingPatterns` audit | α observation | Task α-6 |
+| 5 | `settingPatterns` audit | α observation | Task α-6; missing audio-pure calls become follow-up issues, not blockers |
 | 6 | Codemirror-specific globals | Queue-if-surfaces | Will be caught by γ-2 if a corpus tune relies on one; otherwise ignored |
 | 7 | Audio-pure-but-heavy boundary case (`xen` vs `tidal`) | Documented risk + decision rule | α-7 summary documents the "already in bundle" rule |
 
@@ -522,11 +695,20 @@ Mapped from RESEARCH §7:
 - **Pianoroll / scope re-export decision** — `@strudel/draw` provides
   `pianoroll`/`scope`/etc. Stave excludes the module entirely. If users want
   these specific functions without the DOM injection, re-export them.
-  RESEARCH §1b open question.
-- **`@strudel/csound` + `@strudel/tidal` dynamic-import wiring** — schema
-  exists in α-5, UI in β-3, but the actual conditional `await import()` for
-  those two heavy modules is not landed in this phase. File follow-up issue
-  when the first user requests csound/tidal support.
+  RESEARCH §1b open question. (Out-of-scope per §1 visual-parity scope.)
+- **Heavy-module dynamic-import wiring (one follow-up issue per disabled
+  toggle in β-3).** The schema in α-5 and the disabled UI in β-3 set the
+  contract; the actual conditional `await import()` lands as a separate
+  follow-up per module:
+  - `@strudel/csound`
+  - `@strudel/tidal`
+  - `@strudel/osc`
+  - `@strudel/serial`
+  - `@strudel/gamepad`
+  - `@strudel/motion`
+  - `@strudel/mqtt`
+  Each follow-up issue lights up exactly one toggle in β-3 (changes the row
+  from disabled+tooltip to interactive). Files at β-PR merge.
 - **Settings panel re-init without reload** — current model requires page
   reload. Better UX is to tear down and re-create the engine in place.
   Separate phase; documented in β-3.
@@ -539,8 +721,8 @@ Mapped from RESEARCH §7:
   `feat/20-14-α-strudel-parity-bootstrap`. Body cites RESEARCH §1, lists the
   six added manifests, links to α-SUMMARY.
 - **PR β** — depends on α merged. Branch: `feat/20-14-β-alias-and-tiers`.
-  Body cites RESEARCH §3 + §6, screenshots of the settings UI, alias map
-  contents.
+  Body cites RESEARCH §3 + §6, screenshots of the settings UI (showing the
+  1 live + 7 disabled toggle layout), alias map contents.
 - **PR γ** — depends on β merged. Branch: `feat/20-14-γ-parity-corpus`.
   Body cites D-04, lists the 16 tunes, includes a sample snapshot diff
   example.
@@ -564,7 +746,8 @@ alias never ships.
     │        │
     │        └──> γ (corpus + CI)    asserts shapes produced by α+β pipeline
     │
-    └─ (independent: csound/tidal dynamic-import wiring — queued follow-up)
+    └─ (independent: heavy-module dynamic-import wiring — one queued
+       follow-up per disabled toggle in β-3)
 ```
 
 α MUST merge before β can ship: β-3's tier toggles UI binds to the schema
@@ -572,3 +755,12 @@ introduced in α-5. β MUST merge before γ ships: γ-2's snapshots assert
 shapes produced by the post-β pipeline (with alias rewriting in
 `wrappedOutput`). Regenerating γ-2 snapshots BEFORE β lands captures the
 wrong baseline.
+
+**Intra-α commit order: α-1 → α-2 → α-3 → α-4 → α-5 → α-6 → α-7.** Each
+lands as its own commit on the same PR. α-1 through α-4 are
+krama-load-bearing (they sit in the engine init sequence and the order is
+fixed by `feedback_strudel_init.md`). α-5 (schema), α-6 (audit), α-7
+(summary) could be reordered if convenient — they do not touch the init
+sequence — but the listed order is recommended so each later task can cite
+findings from the earlier ones (e.g., α-7 cites α-3's aliasBank
+merge-vs-replace finding).

--- a/.planning/phases/20-musician-timeline/20-14-PLAN.md
+++ b/.planning/phases/20-musician-timeline/20-14-PLAN.md
@@ -1,0 +1,574 @@
+---
+phase: 20-14
+title: Strudel.cc Parity — eval-scope mirror + alias layer + corpus gate
+created: 2026-05-14
+context: ./20-14-CONTEXT.md
+research: ./20-14-RESEARCH.md
+upstream_pin_sha: f73b395648645aabe699f91ba0989f35a6fd8a3c
+closes: "#110"
+waves: 3 (α bootstrap, β alias+UI, γ corpus+CI)
+verification: structural IR parity (no scheduler, no waveform)
+---
+
+# Phase 20-14 — Strudel.cc Parity
+
+## 1. Goal recap
+
+Any code that runs on strudel.cc should run on Stave with the same audible and
+visual result. This plan closes issue #110 (the `s("piano")` silent gap) by
+mirroring upstream's eval-scope into `StrudelEngine.init()`, adding a curated
+bare-name alias layer at the `s()` interception point, and gating the surface
+with a structural-parity corpus that runs in CI. The four locked decisions
+(D-01..D-04) live in [20-14-CONTEXT.md](./20-14-CONTEXT.md); the upstream init
+trace, tier matrix, and intercept sketch live in
+[20-14-RESEARCH.md](./20-14-RESEARCH.md). This plan translates those into
+executable tasks — it does not redesign them.
+
+## 2. Operational rules (read before touching code)
+
+- **Watch mode is mandatory.** Per PV48: when iterating on
+  `packages/editor/src/`, run `pnpm --filter @stave/editor dev` in a separate
+  terminal. The editor consumes the workspace package via `dist/`, so source
+  edits will appear stale in the running app without `tsup --watch`.
+- **Single-quote rule does NOT apply here.** P62 bites `.p()`, `.viz()`-style
+  string-id chain methods where reify-as-Pattern is unwanted. The parity corpus
+  intentionally uses double quotes inside `.s()`/`.bank()` chains because that
+  IS upstream behavior. Both Stave and upstream pipe through the same
+  transpiler, so structural parity holds. Do NOT mass-convert corpus quotes.
+- **Krama is locked.** Per `feedback_strudel_init.md`: new
+  `evalScope`/`register*` calls slot AFTER the existing registrations, never
+  before. Sample manifests resolve before the `loadedSoundNames` snapshot at
+  StrudelEngine.ts:179. The `aliasBank` JSON fetch resolves after all
+  `samples()` calls. `Pattern.prototype.piano` injection runs once at boot,
+  after `evalScope` populates `Pattern` on `globalThis`.
+- **Tier toggles take effect on reload**, not immediately. That copy must be
+  visible in the settings UI in β-wave.
+- **Catalogue patterns to honor**: P1 (transpiler reify — intercept post-reify
+  in `wrappedOutput`), P2 / UV2 (prototype install timing — boot-time only),
+  P11 (re-applied registrations — confirmed idempotent in α), P62 (quote
+  rewriting — does not bite the audio surface), PV48 (watch mode).
+
+## 3. Wave α — Bootstrap mirror
+
+**Goal:** Stave's engine boot mirrors upstream's audio-pure registrations
+exactly. After α, `s("piano")` resolves to the Salamander sample bank,
+`.bank("tr909")` resolves to the drum-machine manifest, and
+`Pattern.prototype.piano` chain method exists. Tier flag schema is introduced
+but UI lands in β.
+
+### Task α-1: Add `@strudel/edo` + `@strudel/mondo` to evalScope
+
+- **Files:** `packages/editor/src/engine/StrudelEngine.ts:129-137`
+- **Action:** Extend the `Promise.all` import set in `init()` to include
+  `import('@strudel/edo')` and `import('@strudel/mondo')`. Both packages must be
+  added to `packages/editor/package.json` dependencies. Both flow into the
+  existing `evalScope(...)` call alongside the current 7 modules — no other
+  init step changes. Verify pnpm lockfile updates cleanly.
+- **Ownership:** Created at boot by `StrudelEngine.init`. Consumed by user
+  patterns at eval-time via `globalThis` symbols. No teardown ownership.
+- **Lifecycle:** Boot-time only, inside the existing
+  `await evalScope(...modules)` call. Runs ONCE per engine instance, after
+  dynamic imports settle, before `miniAllStrings`.
+- **Pre-mortem:** P11 (re-applied registrations) — confirmed idempotent in
+  RESEARCH §8 (evalScope is `globalThis[name] = value` per export). Risk is
+  package install failure (registry hiccup); mitigation: pin to specific
+  upstream versions matching the SHA in frontmatter.
+- **Verify (Lokayata gate):** In dev console after engine boots, type
+  `globalThis.edoFromKey` and `globalThis.mondo` (or the respective module
+  exports — confirm names from upstream `loadModules`). Both must be defined.
+  Existing test suite must remain green.
+
+### Task α-2: Add six sample-manifest fetches to init
+
+- **Files:** `packages/editor/src/engine/StrudelEngine.ts:175` (after the
+  existing `samples('github:tidalcycles/Dirt-Samples/master')` call)
+- **Action:** Append six additional `samples(...)` calls in the order listed
+  in RESEARCH §1c, each awaited so the `loadedSoundNames` snapshot at line 179
+  captures all registered names:
+  1. `samples('${baseCDN}/piano.json', '${baseCDN}/piano/', { prebake: true })`
+  2. `samples('${baseCDN}/vcsl.json', '${baseCDN}/VCSL/', { prebake: true })`
+  3. `samples('${baseCDN}/tidal-drum-machines.json', baseCDN, { tag: 'drum-machines' })`
+  4. `samples('${baseCDN}/uzu-drumkit.json', baseCDN, { tag: 'drum-machines' })`
+  5. `samples('${baseCDN}/uzu-wavetables.json', baseCDN)`
+  6. `samples('${baseCDN}/mridangam.json', baseCDN, { tag: 'drum-machines' })`
+  Define `baseCDN = 'https://strudel.b-cdn.net'` as a const at module scope
+  with a comment citing upstream `prebake.mjs:13`. Keep the existing
+  `github:tidalcycles/Dirt-Samples/master` call intact per RESEARCH §1c
+  (second `samples()` wins on duplicate keys, so order matters — Dirt-Samples
+  stays FIRST, b-cdn manifests follow).
+- **Ownership:** `samples()` mutates `soundMap` via `setKey`. Each manifest is
+  owned by upstream b-cdn. Stave is a consumer only — never writes to the
+  manifest URL.
+- **Lifecycle:** All six run in parallel inside a `Promise.all` after
+  `registerSoundfonts` resolves, before the `loadedSoundNames` snapshot. Each
+  is a manifest-JSON fetch at boot; individual audio sample URLs lazy-load on
+  first trigger.
+- **Pre-mortem:** RESEARCH §7 open-question #2 — b-cdn.net availability. A
+  failed manifest fetch should not break boot; wrap each `samples()` call in
+  a try/catch that logs and continues, matching the existing Dirt-Samples call
+  pattern. Document the accepted risk in code comment + §7 of this plan.
+- **Verify (Lokayata gate):** Boot the engine, then in dev console:
+  `Object.keys(soundMap.get()).filter(k => /piano|tr909|RolandTR808|mridangam/i.test(k))`
+  must return a non-empty array. Run an `s("piano")` pattern — audio must
+  play, not throw "sound piano not found."
+
+### Task α-3: Add `aliasBank()` fetch after manifests
+
+- **Files:** `packages/editor/src/engine/StrudelEngine.ts:175` (after the
+  Promise.all from α-2)
+- **Action:** Add a single `await` call:
+  `aliasBank('${baseCDN}/tidal-drum-machines-alias.json')`. Import `aliasBank`
+  from `@strudel/webaudio` alongside the existing imports. This registers the
+  69 bank-name aliases (e.g., `RolandTR909 → 909`) — bank-level only, NOT the
+  bare-name alias layer (that's β).
+- **Ownership:** Upstream-owned JSON. Mutates `aliasBankMap` inside superdough
+  via `soundMap.set` (RESEARCH §3). Stave is consumer only.
+- **Lifecycle:** Runs once at boot, after all six manifest fetches resolve, so
+  `aliasBank` sees a populated `soundMap`.
+- **Pre-mortem:** RESEARCH §7 open-question #3 — confirm `.bank("tr909")`
+  produces the expected IR shape after this lands. Mitigation: run `flatrave`
+  (corpus member #10) manually after α-2 + α-3 land; if shape differs from
+  upstream, surface in α SUMMARY before β starts.
+- **Verify (Lokayata gate):** Eval `s("[bd <hh oh>]*2").bank("tr909").dec(.4)`
+  (upstream's default REPL line per RESEARCH §1d). Audio must play with TR-909
+  samples, not Dirt-Samples bd/hh.
+
+### Task α-4: Vendor or port `piano.mjs` for `Pattern.prototype.piano`
+
+- **Files:** `packages/editor/src/engine/vendored/piano.ts` (new, ~30 lines),
+  `packages/editor/src/engine/StrudelEngine.ts` (import call)
+- **Action:** Port the upstream `prebake.mjs` piano injection (clip=1,
+  `.s('piano')`, `.release(.1)`, pan by pitch — see RESEARCH §1c row "piano.mjs"
+  and §7 open-question #1) into a TypeScript module that, on import, attaches
+  `Pattern.prototype.piano`. Import this module at the END of `init()` AFTER
+  `evalScope` resolves (so `Pattern` exists on globalThis). Include header
+  comment citing upstream `prebake.mjs:165` and license note (AGPL-3.0).
+- **Ownership:** Vendored module owns the prototype assignment. Stave's
+  `injectPatternMethods` (per UV2/P2) owns `.p`, `.viz`, legacy viz names —
+  `.piano` is NOT in that list. The two systems coexist.
+- **Lifecycle:** Imported ONCE at boot, after `evalScope`. Side-effect on
+  import attaches the method. Does NOT re-run per eval — that would be the
+  P2 trap.
+- **Pre-mortem:** P2 / UV2 — `.p()` setter trap and `injectPatternMethods`
+  overwrite. RESEARCH §7 open-question #1 says trap is on `.p`, `.viz`, and
+  legacy viz names, so `.piano` should be safe. **OBSERVE in α**: after boot,
+  call `Pattern.prototype.piano` directly — must be a function. Then eval
+  `note("c4 e4 g4").piano()` and confirm the same method survives across an
+  eval cycle (i.e., evaluate, then re-check the prototype — must still be the
+  ported function, not overwritten/stripped). If overwrite occurs, the
+  mitigation is moving the install into post-eval, but this is anticipated
+  unlikely.
+- **Verify (Lokayata gate):** Console: `typeof Pattern.prototype.piano`
+  returns `'function'` after boot AND after one full eval cycle. Eval
+  `note("c4 e4 g4").piano()` — audio plays with Salamander piano samples.
+
+### Task α-5: Introduce tier flag schema (8 flags, schema only, no UI)
+
+- **Files:** `packages/editor/src/engine/tierFlags.ts` (new), referenced by
+  `StrudelEngine.ts` (read at init)
+- **Action:** Define and export a TypeScript type and default object:
+  ```
+  TierFlags = { csound, tidal, midi, osc, serial, gamepad, motion, mqtt }
+  ```
+  all booleans defaulting to `false`. Add a `getTierFlags()` reader that
+  consults the workspace settings store (same store used by track row height
+  etc. per CONTEXT codebase notes). For α, the store has no UI surface — the
+  function returns all-false until β adds toggles. Schema only — no
+  conditional imports yet (β threads MIDI/OSC behind their flags; csound/tidal
+  gating lands when those tunes enter the corpus, queued as follow-up).
+- **Ownership:** Schema owned by `tierFlags.ts`. Storage owned by workspace
+  settings store. Engine init is a READER only; never writes.
+- **Lifecycle:** Read ONCE at boot inside `StrudelEngine.init()`. Mid-session
+  toggle changes are not observed until next reload (RESEARCH §4 + §8).
+- **Pre-mortem:** Schema drift — adding a 9th tier later without migration
+  breaks persisted settings. Mitigation: defaults are derived from the type at
+  read-time, so missing keys read as `false`. Document this in the file
+  header.
+- **Verify (Lokayata gate):** In dev console after boot:
+  `getTierFlags()` returns an object with exactly 8 boolean false fields. Type
+  the keyset and confirm it matches the documented schema.
+
+### Task α-6: OBSERVE — open question #5 (`settingPatterns` audit)
+
+- **Files:** none modified; output is a findings note appended to
+  `20-14-RESEARCH.md` or a new `20-14-OBSERVATIONS.md` if RESEARCH stays
+  pristine
+- **Action:** Read upstream `settings.mjs` (Codeberg, same SHA) and enumerate
+  what `settingPatterns` exports. Classify each export: audio-pure / UI-only /
+  permissioned. If any audio-pure exports are missing from Stave, file a
+  follow-up issue (do NOT add in α — α scope is locked to edo/mondo).
+- **Ownership:** Read-only investigation. Output is documentation, not code.
+- **Lifecycle:** Out-of-band — runs during α-wave but does not block α
+  shipping. Findings inform γ corpus selection.
+- **Pre-mortem:** Skip-it temptation. Mitigation: this is a task line, not a
+  footnote, exactly because skipping it leaves a known blind spot RESEARCH §7
+  flagged.
+- **Verify:** A written note exists with the enumeration and the
+  audio-pure-missing list (or "none missing").
+
+### Task α-7: SUMMARY commit — α-wave gate
+
+- **Files:** `.planning/phases/20-musician-timeline/20-14-α-SUMMARY.md` (new)
+- **Action:** Write a one-page summary capturing: what landed, observations
+  from α-4 (piano prototype install timing), observations from α-6
+  (settingPatterns audit result), `.bank("tr909")` IR shape confirmation from
+  α-3, the "tier flag toggle requires reload" UX decision (carried into β),
+  and the explicit note that per-file `await tier(...)` directive is queued
+  follow-up (D-03 part B).
+- **Ownership:** Documentation owned by this plan.
+- **Lifecycle:** Final α task. Gates β-wave start.
+- **Pre-mortem:** Vague claims. Mitigation: every assertion in the summary
+  must cite a Lokayata observation from α-1 through α-6.
+- **Verify:** File exists and is complete; α gate (below) holds.
+
+### α verification gate
+
+Before opening the α PR:
+- Engine boots without throwing (no friendly-error panel on empty workspace).
+- `globalThis.edoFromKey` and `globalThis.mondo` exports defined.
+- `s("piano")` audibly plays piano samples (not "sound not found").
+- `s("[bd <hh oh>]*2").bank("tr909").dec(.4)` audibly plays TR-909 kick/hat.
+- `Pattern.prototype.piano` survives one full eval cycle.
+- `getTierFlags()` returns 8 falses.
+- Existing test suite remains green (no regressions).
+- Engine boot time within previous + 100ms (rough check via dev console
+  `performance.now()` delta — manifests lazy-load samples, so manifest fetches
+  are the only added cost).
+
+## 4. Wave β — Alias layer + tier UI
+
+**Goal:** Bare-name resolution (`piano`, `kick`, `snare`, etc.) works without
+the user reaching for `gm_*` GM names. Settings panel exposes tier toggles
+behind 8 flags. Friendly errors surface alias path on resolution and on miss.
+
+### Task β-1: Hand-curated alias map
+
+- **Files:** `packages/editor/src/engine/aliases.ts` (new)
+- **Action:** Export a `const ALIASES: Record<string, string>` with ~20-50
+  entries. Initial set must include at minimum: `piano`, `kick`, `snare`,
+  `hat`, `clap`, `tom`, `cymbal`, `crash`, `ride`, `cowbell`, `tambourine`,
+  `shaker`, `bell`, `bass`, mapped to their best-match upstream-registered
+  names (post-α the b-cdn manifests are loaded, so e.g. `piano → piano` is a
+  no-op alias and SHOULD NOT be in the map — only include aliases where the
+  bare name does NOT exist upstream after α). Audit each candidate alias key
+  against `soundMap` post-α boot — if the bare name is already registered,
+  skip it (D-02 invariant: aliases never shadow upstream-registered names).
+  Header comment: precedence rule from RESEARCH §7 open-question #4
+  (user-registered names win over our aliases; alias map is the LAST resort
+  before "sound not found").
+- **Ownership:** Owned by Stave. Distinct from upstream's `aliasBank` (which
+  is bank-level: `RolandTR909 → 909`). This map is bare-sample-name level
+  (`kick → bd`). The two layers never collide because aliasBank resolves
+  inside `.bank()`, our map resolves inside `.s()` at the trigger site.
+- **Lifecycle:** Module imported at engine init. The map itself is static
+  data; lookup happens per-hap in β-2.
+- **Pre-mortem:** Pollution of `loadedSoundNames` autocomplete (D-02 invariant
+  #1). Mitigation: this task does NOT touch `soundMap` — it only exports a
+  constant. Autocomplete stays honest because Strategy A in β-2 reads
+  `soundMap.get()` directly, never seeds it.
+- **Verify (Lokayata gate):** Read the file. Every alias key, when looked up
+  in a fresh post-α `soundMap.get()`, must return `undefined` — confirming the
+  alias is needed and not redundant.
+
+### Task β-2: Strategy A intercept in `wrappedOutput`
+
+- **Files:** `packages/editor/src/engine/StrudelEngine.ts:207` (the
+  `wrappedOutput` function — see RESEARCH §3 sketch)
+- **Action:** Insert the alias-resolution block from RESEARCH §3 right at the
+  top of `wrappedOutput`, BEFORE the breakpoint hit-check (~line 211). Read
+  `hap.value.s`; if string AND raw name unregistered AND alias exists in
+  `ALIASES`, replace `hap.value.s` with the aliased name. Preserve hap value
+  identity via shallow clone so other consumers see the same hap object
+  shape. Import `ALIASES` from β-1.
+- **Ownership:** `hap` is owned by the scheduler. `wrappedOutput` is a
+  transformer in the middle. After this task, `wrappedOutput` also owns the
+  optional rewrite of `hap.value.s` from bare name to canonical name. The
+  scheduler downstream consumes the rewritten hap.
+- **Lifecycle:** Runs per hap on the audio-thread message path. Strategy A
+  operates POST-reify (P1) — `hap.value.s` is always a string by the time
+  `wrappedOutput` sees it (RESEARCH §3, §8 invariant UV3).
+- **Pre-mortem:** P1 (transpiler reification) — Strategy A is the correct
+  layer because reification has already collapsed Patterns to per-event
+  strings. Cite this in the inline comment. Second risk: hot-path cost.
+  Mitigation: a single `Map.get` + null check per hap is sub-microsecond;
+  irrelevant compared to existing scheduler overhead.
+- **Verify (Lokayata gate):** Eval `s("kick").n(0)`. Audio plays a kick drum
+  (`bd` sample). Then eval `s("bd")` — same audible result. Confirm
+  `soundMap.get().kick` is still `undefined` (no pollution of autocomplete).
+
+### Task β-3: Tier toggles in `EditorSettingsModal`
+
+- **Files:** `packages/app/src/components/EditorSettingsModal.tsx`
+- **Action:** Add a "Strudel modules" section to the settings modal with 8
+  toggles (csound, tidal, midi, osc, serial, gamepad, motion, mqtt). Each row
+  shows: name, one-sentence description, current state. Below the section, a
+  visible caption: "Changes take effect when you reload the page." Toggles
+  persist through the existing workspace settings store; reading uses
+  `getTierFlags()` from α-5.
+- **Ownership:** UI owned by `EditorSettingsModal`. Persistence owned by the
+  workspace settings store. Engine reads at next boot only.
+- **Lifecycle:** User interaction → settings store write → state persists.
+  Engine does NOT observe the change until the next page load. The reload
+  copy makes this explicit.
+- **Pre-mortem:** User toggles, expects immediate effect, sees nothing happen
+  → reports as bug. Mitigation: the reload copy is non-negotiable. RESEARCH
+  §4 + §8 documented this. Also: if user enables `csound` or `tidal` and
+  reloads, the dynamic import will pull a 6MB+ bundle on next boot — add a
+  size hint to those two rows ("loads ~6MB on enable").
+- **Verify (Lokayata gate):** Open settings, toggle `midi` on, close modal,
+  reload page. Verify the toggle state persists (modal reflects on). Confirm
+  via dev console that the engine init read the flag.
+
+### Task β-4: Thread MIDI tier flag through engine init
+
+- **Files:** `packages/editor/src/engine/StrudelEngine.ts:141-145` (existing
+  comment block about `enableWebMidi()`)
+- **Action:** Replace the static "intentionally not called" comment with a
+  conditional: if `getTierFlags().midi === true`, call `enableWebMidi()`
+  AFTER `evalScope` resolves. Keep the existing module import unconditional
+  (it's only 80 KB and already in α — only the permission-triggering call is
+  gated). Add a one-line caption to the β-3 settings row: "Enabling prompts
+  for MIDI device permission on next reload."
+- **Ownership:** `enableWebMidi` is called by the engine at boot. The browser
+  owns the permission state. The flag toggle is the user intent signal.
+- **Lifecycle:** Permission prompt fires on engine init when flag is on. Per
+  RESEARCH §4 toggle UX: "early prompt at toggle-on via one-shot
+  `enableWebMidi()` queued for next init" — this task implements that.
+- **Pre-mortem:** RESEARCH §7 + CONTEXT gray-area #3 — prompt timing UX call.
+  Mitigation: prompt on init-after-toggle-on (not lazily on first MIDI op).
+  Caption telegraphs the consequence so user opts in deliberately.
+- **Verify (Lokayata gate):** With midi flag OFF, boot — no permission prompt.
+  Enable, reload — browser shows MIDI permission dialog during init.
+
+### Task β-5: Friendly-errors integration
+
+- **Files:** `packages/editor/src/engine/friendlyErrors.ts:240` (resolved
+  path), `:269` (miss path)
+- **Action:** Two one-line additions per RESEARCH §6:
+  1. **Resolved path:** when `wrappedOutput` rewrote `hap.value.s` via alias,
+     attach an `aliasResolved: { from, to }` field to the friendly-error
+     payload (when one is produced for downstream diagnostics — not on every
+     hap). UI surfaces: `tried alias "kick" → "bd" (resolved)`. Plumb the
+     alias context through `wrappedOutput` so this is observable; simplest is
+     a per-eval `lastAliasResolutions: Map<string,string>` accumulator
+     consulted only when a friendly error is built.
+  2. **Miss path:** in the "sound X not found" message builder, check
+     `ALIASES` for the missing name; if absent, append "alias map: no entry
+     for `xyz`." If present in ALIASES but the aliased target also missing,
+     append "alias map: `xyz` → `target` (but `target` is not loaded)."
+- **Ownership:** `friendlyErrors.ts` owns the message text. The alias map is
+  the input. `wrappedOutput` writes the per-eval accumulator.
+- **Lifecycle:** Resolved-path runs at message-build time (rare; only on
+  error). Miss-path runs when superdough throws the "not found" error
+  upstream-side. Separate from `detect.alias` (orthogonal CommonMistake
+  mechanism in friendlyErrors — RESEARCH §6).
+- **Pre-mortem:** Pre-existing `detect.alias` field collision. Mitigation:
+  use distinct key `aliasResolved` (or namespace under `soundAlias`) to keep
+  the two concepts separate per RESEARCH §6.
+- **Verify (Lokayata gate):** Eval `s("kick")` — no error. Eval `s("xyz123")`
+  — friendly error shows the "alias map: no entry" suffix. Eval `s("bell")`
+  when bell sample isn't loaded — friendly error shows the resolved-to-target
+  + target-not-loaded suffix.
+
+### Task β-6: SUMMARY commit — β-wave gate
+
+- **Files:** `.planning/phases/20-musician-timeline/20-14-β-SUMMARY.md` (new)
+- **Action:** Document: alias map final entry list + rationale per entry,
+  resolved Strategy A observations, settings UI screenshots (or `<details>`
+  links to dev screencaps), MIDI prompt UX confirmation, friendly-error
+  behavior in the three β-5 test cases.
+- **Verify:** β gate (below) holds.
+
+### β verification gate
+
+- `s("piano")`, `s("kick")`, `s("snare")`, `s("clap")` all play their
+  intended sounds without manual `gm_*` prefix.
+- `soundMap.get().kick` remains `undefined` post-boot (autocomplete clean).
+- Settings modal exposes 8 toggles; toggling one + reload reads true on next
+  boot via `getTierFlags()`.
+- Enabling `midi` triggers permission prompt on next reload, not before.
+- Friendly errors show the alias-resolution suffix on the three β-5 test
+  cases.
+
+## 5. Wave γ — Parity corpus + CI gate
+
+**Goal:** 16 vendored tunes evaluate through Stave's pipeline to stable IR
+shapes. Vitest spec runs on every PR. `pnpm parity:refresh` script enables
+manual upstream sync without running on PRs.
+
+### Task γ-1: Vendor 16 tunes + CORPUS-SOURCE.md
+
+- **Files:** `packages/app/tests/parity-corpus/CORPUS-SOURCE.md` (new),
+  `packages/app/tests/parity-corpus/{chop,delay,orbit,belldub,sampleDrums,randomBells,barryHarris,echoPiano,holyflute,flatrave,amensister,juxUndTollerei,bassFuge,dinofunk,meltingsubmarine,arpoon}.strudel`
+- **Action:** Fetch upstream `website/src/repl/tunes.mjs` at SHA
+  `f73b395648645aabe699f91ba0989f35a6fd8a3c`. For each of the 16 tunes in
+  RESEARCH §5, extract the string body and write it as a `.strudel` file with
+  trailing newline. Write `CORPUS-SOURCE.md` with: upstream SHA, fetch date,
+  AGPL-3.0 license note, list of vendored tunes with rationale, list of
+  deliberately-omitted tunes with reason, refresh cadence policy ("every
+  upstream minor version OR when a Stave user reports a parity gap" — from
+  CONTEXT open items).
+- **Ownership:** Stave vendors a frozen snapshot of upstream-owned content.
+  Refresh is human-driven; upstream owns the canonical version.
+- **Lifecycle:** Vendor once at α, refresh manually via γ-3 script.
+- **Pre-mortem:** P62 — quote rewriting. Mitigation: do NOT mass-convert
+  quotes. Corpus uses double quotes because upstream does, and parity goes
+  through the same transpiler (RESEARCH §5).
+- **Verify:** Each `.strudel` file is a byte-faithful extraction from upstream
+  (verify by re-running the fetch on the pinned SHA — git diff is empty).
+  CORPUS-SOURCE.md lists exactly 16 tunes.
+
+### Task γ-2: Vitest spec — eval each tune, assert IR shape
+
+- **Files:** `packages/app/tests/parity-corpus/parity.test.ts` (new),
+  `packages/app/tests/parity-corpus/snapshots/__snapshots__/parity.test.ts.snap`
+  (new, generated)
+- **Action:** Vitest spec that for each `.strudel` file in the corpus:
+  1. Reads the file content.
+  2. Evals it through Stave's `StrudelEngine.evaluate()` (or the analogous
+     IR-producing call — confirm the right entry point during implementation;
+     the IR consumed by the inspector is the asserted artifact).
+  3. Asserts the resulting IR's STRUCTURAL shape against a snapshot: event
+     count, sorted param-key set per event, mini-notation shape (NOT
+     timing/begin-end values, NOT audible-output bytes). D-01 explicitly
+     locks this rung.
+  4. Initial snapshots generated by running the spec once with `-u` —
+     committed alongside the test.
+- **Ownership:** Stave's eval pipeline owns the IR shape. The snapshot is the
+  current declared truth. Drift = snapshot change = PR review moment.
+- **Lifecycle:** Runs on every CI PR. Reads vendored `.strudel` files at
+  test-start, evals each in isolation (new engine instance per tune to avoid
+  cross-tune state).
+- **Pre-mortem:** Snapshot flakiness from non-deterministic IR fields (e.g.,
+  random seeds, timestamps). Mitigation: serialize IR through a normalization
+  function that strips timing fields, sorts param keys, and drops `id` fields
+  if any. The normalizer is part of this task — write it explicitly, not as
+  an afterthought.
+- **Verify (Lokayata gate):** Run the test suite — all 16 tunes pass. Manually
+  break one corpus file by adding a `.fast(2)` and re-run — that single test
+  fails with a clear snapshot diff (not a runtime error).
+
+### Task γ-3: `pnpm parity:refresh` script + CI wiring
+
+- **Files:** `packages/app/scripts/parity-refresh.ts` (new), `package.json`
+  scripts section
+- **Action:** Script that:
+  1. Reads current SHA from `CORPUS-SOURCE.md`.
+  2. Fetches `tunes.mjs` from Codeberg `main` (latest SHA).
+  3. Re-extracts the 16 tunes by export name.
+  4. Diffs each against the vendored `.strudel` file.
+  5. Prints unified diffs to stdout; exits 0 even if diffs exist (purpose is
+     surfacing, not gating).
+  6. Prints the new upstream SHA at the end for the maintainer to update
+     `CORPUS-SOURCE.md` by hand if accepting the refresh.
+  Wire `pnpm parity:refresh` to call this script. Add a separate `pnpm
+  parity:test` alias for the γ-2 spec. CI runs `parity:test` on PR, NEVER
+  `parity:refresh`.
+- **Ownership:** Script is a maintainer tool. Output is human-readable diff.
+  Never auto-commits.
+- **Lifecycle:** Manual invocation only. Network call to Codeberg.
+- **Pre-mortem:** Codeberg API rate-limit, network flake. Mitigation: this is
+  a developer-side script, not CI — flakes are visible immediately to the
+  human running it. Document that in the script header.
+- **Verify (Lokayata gate):** Run `pnpm parity:refresh` locally on a clean
+  checkout — script prints either "no upstream drift" or a list of diffs.
+  Modify one local corpus file (`chop.strudel`) by inserting a comment and
+  re-run — the diff appears for that file.
+
+### Task γ-4: SUMMARY commit — γ-wave gate
+
+- **Files:** `.planning/phases/20-musician-timeline/20-14-γ-SUMMARY.md` (new)
+- **Action:** Document: which 16 tunes are vendored, snapshot regeneration
+  policy ("regen with `-u` only in a PR titled `corpus: refresh from
+  upstream SHA <x>`"), CI runtime of the parity spec, examples of what a
+  shape drift looks like in a PR diff.
+- **Verify:** γ gate (below) holds.
+
+### γ verification gate
+
+- All 16 corpus tunes pass `pnpm parity:test` locally and in CI.
+- Snapshot file is committed; deleting it and re-running with `-u`
+  regenerates byte-identical content.
+- `pnpm parity:refresh` runs without errors and surfaces upstream diffs
+  (or "no drift" if upstream hasn't moved).
+- CI workflow includes the parity job and it runs in under 60 seconds.
+
+## 6. Open questions / accepted risks
+
+Mapped from RESEARCH §7:
+
+| # | Item | Classification | Lands in |
+|---|---|---|---|
+| 1 | `Pattern.prototype.piano` install timing vs `.p()` setter trap | α observation | Task α-4 + α-7 summary |
+| 2 | b-cdn.net availability | Documented risk | Task α-2 try/catch + α-7 summary call-out |
+| 3 | `.bank("tr909")` IR shape match | α observation | Task α-3 verify + α-7 summary; failure mode escalates to γ-2 |
+| 4 | Pre-init alias lookup race | Documented risk | β-1 header comment (precedence rule) |
+| 5 | `settingPatterns` audit | α observation | Task α-6 |
+| 6 | Codemirror-specific globals | Queue-if-surfaces | Will be caught by γ-2 if a corpus tune relies on one; otherwise ignored |
+| 7 | Audio-pure-but-heavy boundary case (`xen` vs `tidal`) | Documented risk + decision rule | α-7 summary documents the "already in bundle" rule |
+
+## 7. Out of scope (queued follow-ups)
+
+- **Per-file `await tier(...)` directive** (D-03 part B) — opens after β
+  lands. File issue at α-PR merge.
+- **Schedule-time parity (D-01 rung B)** — only when structural drift surfaces
+  something shape can't catch.
+- **Audible parity (D-01 rung C)** — same gate.
+- **Bakery UI** — sample-pack sharing; eval parity ≠ UI parity. Separate
+  phase.
+- **Post-init `samples()` autocomplete pollution** — `loadedSoundNames`
+  snapshot at StrudelEngine.ts:179 misses user-eval'd `samples()` calls
+  (RESEARCH §3 final paragraph). File follow-up issue after α merges.
+- **Pianoroll / scope re-export decision** — `@strudel/draw` provides
+  `pianoroll`/`scope`/etc. Stave excludes the module entirely. If users want
+  these specific functions without the DOM injection, re-export them.
+  RESEARCH §1b open question.
+- **`@strudel/csound` + `@strudel/tidal` dynamic-import wiring** — schema
+  exists in α-5, UI in β-3, but the actual conditional `await import()` for
+  those two heavy modules is not landed in this phase. File follow-up issue
+  when the first user requests csound/tidal support.
+- **Settings panel re-init without reload** — current model requires page
+  reload. Better UX is to tear down and re-create the engine in place.
+  Separate phase; documented in β-3.
+
+## 8. PR strategy
+
+**Per-wave PRs**, stacked but reviewed independently:
+
+- **PR α** — closes nothing yet. Merges first. Branch:
+  `feat/20-14-α-strudel-parity-bootstrap`. Body cites RESEARCH §1, lists the
+  six added manifests, links to α-SUMMARY.
+- **PR β** — depends on α merged. Branch: `feat/20-14-β-alias-and-tiers`.
+  Body cites RESEARCH §3 + §6, screenshots of the settings UI, alias map
+  contents.
+- **PR γ** — depends on β merged. Branch: `feat/20-14-γ-parity-corpus`.
+  Body cites D-04, lists the 16 tunes, includes a sample snapshot diff
+  example.
+
+Only PR γ should be the one that finally writes `closes #110`, because issue
+#110 is the user-visible `s("piano")` gap and β is the wave where that gap
+clinches (α loads the manifest, β lights up the bare-name path). The γ
+corpus is the gate that prevents regression.
+
+Each wave is ATOMIC for revert: if β breaks, revert PR β without touching
+α's boot mirror. The boot-mirror in α is independently valuable (audible
+parity for explicit `gm_*` and `.bank("…")` callers) even if β's bare-name
+alias never ships.
+
+## 9. Dependencies + ordering
+
+```
+α (boot mirror + tier schema)
+    │
+    ├──> β (alias layer + tier UI)   reads tier flag schema from α
+    │        │
+    │        └──> γ (corpus + CI)    asserts shapes produced by α+β pipeline
+    │
+    └─ (independent: csound/tidal dynamic-import wiring — queued follow-up)
+```
+
+α MUST merge before β can ship: β-3's tier toggles UI binds to the schema
+introduced in α-5. β MUST merge before γ ships: γ-2's snapshots assert
+shapes produced by the post-β pipeline (with alias rewriting in
+`wrappedOutput`). Regenerating γ-2 snapshots BEFORE β lands captures the
+wrong baseline.

--- a/.planning/phases/20-musician-timeline/20-14-RESEARCH.md
+++ b/.planning/phases/20-musician-timeline/20-14-RESEARCH.md
@@ -1,0 +1,516 @@
+---
+phase: 20-14
+title: Strudel.cc parity — research (α-wave spec)
+researcher: anvi-researcher
+created: 2026-05-14
+upstream_pin_sha: f73b395648645aabe699f91ba0989f35a6fd8a3c
+upstream_pin_date: 2026-05-07
+confidence: HIGH
+closes: "#110"
+---
+
+# Phase 20-14 — Research
+
+User constraints (verbatim from `20-14-CONTEXT.md` — locked):
+- **D-01** Parity rung = structural only (IR shape + event count + param keys).
+- **D-02** Alias source = hand-curated TS const at `packages/editor/src/engine/aliases.ts`,
+  consulted at `s()` call interception — NOT by mutating `soundMap`.
+- **D-03** Tier policy = settings panel toggle, default OFF, in `EditorSettingsModal`.
+- **D-04** Corpus = vendor 10-20 examples + upstream-SHA pin at
+  `packages/app/tests/parity-corpus/`.
+
+Upstream pin: `uzu/strudel` Codeberg, branch `main`, SHA `f73b3956…` (2026-05-07).
+**NOTE:** Strudel migrated GitHub → Codeberg. `github.com/tidalcycles/strudel` is
+frozen (`MOVED_TO_CODEBERG.md`). All upstream citations below are Codeberg paths.
+
+---
+
+## 1. Upstream init enumeration — α-WAVE SPEC
+
+Bootstrap path: `useReplContext.jsx` → `loadModules()` + `prebake()` fire as
+module-scope side-effects (see `useReplContext.jsx:44–46`).
+
+### 1a. `loadModules()` — the evalScope call
+
+Source: `website/src/repl/util.mjs:68–98` (raw at
+`https://codeberg.org/uzu/strudel/raw/branch/main/website/src/repl/util.mjs`).
+
+```js
+// util.mjs:68-98
+export function loadModules() {
+  let modules = [
+    import('@strudel/core'),
+    import('@strudel/draw'),
+    import('@strudel/edo'),         // ← NOT loaded by Stave
+    import('@strudel/tonal'),
+    import('@strudel/mini'),
+    import('@strudel/xen'),
+    import('@strudel/webaudio'),
+    import('@strudel/codemirror'),  // ← editor concern, Stave uses Monaco
+    import('@strudel/hydra'),       // ← NOT loaded by Stave
+    import('@strudel/serial'),      // ← NOT loaded by Stave (heavy/permissioned)
+    import('@strudel/soundfonts'),
+    import('@strudel/csound'),      // ← NOT loaded by Stave (heavy)
+    import('@strudel/tidal'),       // ← NOT loaded by Stave (5.8 MB!)
+    import('@strudel/gamepad'),     // ← NOT loaded by Stave
+    import('@strudel/motion'),      // ← NOT loaded by Stave (DeviceMotion permission)
+    import('@strudel/mqtt'),        // ← NOT loaded by Stave
+    import('@strudel/mondo'),       // ← NOT loaded by Stave (new mondo lang)
+  ];
+  if (isTauri()) {
+    modules = modules.concat([
+      import('@strudel/desktopbridge/loggerbridge.mjs'),
+      import('@strudel/desktopbridge/midibridge.mjs'),
+      import('@strudel/desktopbridge/oscbridge.mjs'),
+    ]);
+  } else {
+    modules = modules.concat([
+      import('@strudel/midi'),      // ✓ Stave loads this
+      import('@strudel/osc'),       // ← NOT loaded by Stave
+    ]);
+  }
+  return evalScope(settingPatterns, ...modules);
+}
+```
+
+Stave's current load set (`StrudelEngine.ts:129–137`): core, mini, tonal,
+webaudio, soundfonts, xen, midi. **Seven modules. Upstream loads
+fifteen** (non-Tauri).
+
+### 1b. Module-by-module classification
+
+Sizes are npm `dist.unpackedSize` (verified via `registry.npmjs.org`), confidence HIGH.
+
+| # | Module | Stave loads? | Audio-pure? | Heavy? | Size (npm unpacked) | Tier flag | Notes |
+|---|---|---|---|---|---|---|---|
+| 1 | `@strudel/core` | ✓ | yes | no | (core) | — | required |
+| 2 | `@strudel/mini` | ✓ | yes | no | — | — | mini-notation parser |
+| 3 | `@strudel/tonal` | ✓ | yes | no | 121 KB | — | scale/chord operators |
+| 4 | `@strudel/webaudio` | ✓ | yes | no | — | — | sound output |
+| 5 | `@strudel/soundfonts` | ✓ | yes | mid | 278 KB | — | GM fonts lazy-fetched |
+| 6 | `@strudel/xen` | ✓ | yes | **yes** | **2.47 MB** | — | xenharmonic (already loaded; audio-pure so stays unconditional per D-03) |
+| 7 | `@strudel/midi` | ✓ | yes | no | 80 KB | `midi` (β) | already excludes `enableWebMidi()` per StrudelEngine.ts:142 |
+| 8 | `@strudel/draw` | ✗ | no | mid | 90 KB | `draw` (γ?) | **intentionally excluded** (StrudelEngine.ts:143–146) — injects `id="test-canvas"` into `document.body`. Stave owns visuals. Keep excluded; surface as opt-out, not opt-in. Provides `getDrawContext`, `pianoroll`, `scope`, `spectrum`, `wordfall`, `punchcard`. |
+| 9 | `@strudel/edo` | ✗ | yes | no | — | — | equal-divisions-of-octave operators. **Audio-pure → add unconditionally (α).** |
+| 10 | `@strudel/hydra` | ✗ | no | mid | 39 KB | `hydra` (γ?) | injects hydra canvas. Same shape as `@strudel/draw` exclusion. Stave already has its own hydra renderer (P19 catalogue). **Keep excluded.** |
+| 11 | `@strudel/serial` | ✗ | no | small | 42 KB | `serial` (β) | WebSerial API — permissioned. Behind tier flag. |
+| 12 | `@strudel/csound` | ✗ | no | **YES** | 113 KB stub + **6.3 MB `@csound/browser`** | `csound` (β) | Behind tier flag. See §2. |
+| 13 | `@strudel/tidal` | ✗ | yes | **YES** | **5.8 MB** | `tidal` (β) | Loads TidalCycles haskell-via-wasm interop. Audio-pure (no permission) but huge bundle. **Default OFF.** |
+| 14 | `@strudel/gamepad` | ✗ | no | small | 54 KB | `gamepad` (β) | Gamepad API — permissioned. |
+| 15 | `@strudel/motion` | ✗ | no | small | 134 KB | `motion` (β) | DeviceMotion API — permissioned. |
+| 16 | `@strudel/mqtt` | ✗ | no | small | 42 KB | `mqtt` (β) | network-dependent. |
+| 17 | `@strudel/mondo` | ✗ | yes | small | 42 KB | — | new mondo lang. Audio-pure. **Add unconditionally (α)** — its absence is a parity gap. |
+| 18 | `@strudel/osc` | ✗ | no | small | 49 KB | `osc` (β) | needs SuperCollider backend. behind tier flag. |
+| 19 | `@strudel/codemirror` | ✗ | n/a | — | — | — | editor — Stave uses Monaco. **Do NOT add.** |
+
+**α-wave audio-pure additions (load unconditionally):**
+1. `@strudel/edo` — currently missing, audio-pure, no cost. Add to `Promise.all`.
+2. `@strudel/mondo` — currently missing, audio-pure, ~42 KB. Add to `Promise.all`.
+
+**That is the entire α-wave evalScope diff.** `tidal` is intentionally tier-gated
+even though it's audio-pure, on bundle-size grounds (5.8 MB).
+
+`@strudel/draw` and `@strudel/hydra` remain excluded by design — both inject DOM
+into `document.body`. Document this as "opt-out at α, never moves to opt-in
+because Stave owns visuals." (See §7 open question on `pianoroll`/`scope`
+re-export.)
+
+### 1c. `prebake()` — the sample manifest fetches
+
+Source: `website/src/repl/prebake.mjs:1–161` (raw available; full file 174
+lines). All calls run in `Promise.all` after `await initAudioOnFirstClick`
+(triggered by user gesture — already covered by Stave's `init()` contract).
+
+```js
+// prebake.mjs:13-160
+import { aliasBank, registerSynthSounds, registerZZFXSounds, samples } from '@strudel/webaudio';
+import { registerSamplesFromDB } from './idbutils.mjs';   // ← website-only
+import './piano.mjs';                                      // ← prototype injection
+
+await Promise.all([
+  registerSynthSounds(),                                                          // ✓ Stave (:163)
+  registerZZFXSounds(),                                                           // ✓ Stave (:166)
+  registerSamplesFromDB(),                                                        // ✗ Stave — website IndexedDB feature
+  import('@strudel/soundfonts').then(({ registerSoundfonts }) => registerSoundfonts()), // ✓ Stave (:170)
+  samples(`${baseCDN}/piano.json`, `${baseCDN}/piano/`, { prebake: true }),       // ✗ Stave — Salamander piano
+  samples(`${baseCDN}/vcsl.json`, `${baseCDN}/VCSL/`, { prebake: true }),         // ✗ Stave — VCSL orchestra
+  samples(`${baseCDN}/tidal-drum-machines.json`, ..., { tag: 'drum-machines' }),  // ✗ Stave — tr909/808/etc.
+  samples(`${baseCDN}/uzu-drumkit.json`, ..., { tag: 'drum-machines' }),          // ✗ Stave
+  samples(`${baseCDN}/uzu-wavetables.json`, ...),                                 // ✗ Stave
+  samples(`${baseCDN}/mridangam.json`, ..., { tag: 'drum-machines' }),            // ✗ Stave
+  samples({ casio:[...], crow:[...], insect:[...], wind:[...], jazz:[...],       // ✗ Stave — inline manifest
+            metal:[...], east:[...], space:[...], numbers:[...], num:[...] },
+          `${baseCDN}/Dirt-Samples/`, { prebake: true }),
+]);
+aliasBank(`${baseCDN}/tidal-drum-machines-alias.json`);                            // ✗ Stave — see §3
+// Pattern.prototype.piano injection (piano.mjs)                                   // ✗ Stave
+```
+
+Stave currently does `samples('github:tidalcycles/Dirt-Samples/master')`
+(StrudelEngine.ts:175) — that loads a different manifest. Upstream's drum-machine
+banks (`tr909`, `tr808`, `RolandTR909`, `LinnLM1` …) are **NOT** in
+`tidalcycles/Dirt-Samples`. They come from
+`strudel.b-cdn.net/tidal-drum-machines.json`.
+
+The default code at upstream `useReplContext.jsx:148` is
+`$: s("[bd <hh oh>]*2").bank("tr909").dec(.4)` — relies on
+`.bank("tr909")` which needs the drum-machines manifest (NOT Dirt-Samples).
+
+**α-wave prebake additions (all audio-pure):**
+
+| Call | Why it matters for parity | Cost | Decision |
+|---|---|---|---|
+| `samples('${baseCDN}/piano.json', '${baseCDN}/piano/')` | unlocks `s("piano")` with Salamander samples (CC-by) — currently the **exact symptom of issue #110**. Without it, `s("piano")` only works if our alias map points `piano → gm_piano` (a soundfont). The upstream `piano` is a sample bank, not a soundfont. | 1 lazy json fetch | **add unconditionally (α).** |
+| `samples('${baseCDN}/tidal-drum-machines.json', ..., { tag: 'drum-machines' })` | unlocks `.bank("tr909")` `.bank("RolandTR808")` etc. Affects ~half the corpus tunes. | 1 lazy json fetch | **add unconditionally (α).** |
+| `samples('${baseCDN}/uzu-drumkit.json', ..., { tag: 'drum-machines' })` | extra banks | small | **add unconditionally (α).** |
+| `samples('${baseCDN}/uzu-wavetables.json')` | wavetables for synth | small | **add unconditionally (α).** |
+| `samples('${baseCDN}/mridangam.json', ..., { tag: 'drum-machines' })` | percussion bank | small | **add unconditionally (α).** |
+| `samples('${baseCDN}/vcsl.json', '${baseCDN}/VCSL/')` | VCSL orchestral library (CC0). Big bank — but lazy-loaded; manifest is small. | manifest only at boot | **add unconditionally (α).** |
+| Inline Dirt-Samples object (casio, crow, insect, wind, jazz, metal, east, space, numbers, num) | upstream uses the b-cdn copy, not `github:tidalcycles/Dirt-Samples`. The github source is older/smaller. | manifest is in-source | **decide α (lean): keep our current `github:tidalcycles/Dirt-Samples/master` AND ADD the inline manifest.** Both succeed; second one wins on duplicate keys per `soundMap.setKey` semantics. |
+| `aliasBank('${baseCDN}/tidal-drum-machines-alias.json')` | adds e.g. `RolandTR909 → 909`, `KorgKR55 → KR55` (69 entries verified at fetch-time). **This is bank-level aliasing**, NOT bare-name aliasing. Does NOT solve `s("piano")` vs `s("gm_piano")` directly. | 1 json fetch (1.7 KB) | **add unconditionally (α)** — gives parity on `.bank("RolandTR909")` etc. |
+| `registerSamplesFromDB()` | website-only IndexedDB user sample feature. | n/a | **skip** — not relevant to Stave's parity story. |
+| `Pattern.prototype.piano` (piano.mjs injection) | adds `.piano()` chain method (sets `clip=1`, applies `.s('piano')`, `.release(.1)`, `pan` by pitch). Twelve+ corpus tunes use `.piano()`. | tiny inline | **port verbatim into Stave's init or vendor `piano.mjs`** — α-wave decision. |
+
+### 1d. The default code line — bare-name baseline
+
+Upstream `useReplContext.jsx:148`:
+```js
+code = '$: s("[bd <hh oh>]*2").bank("tr909").dec(.4)';
+```
+
+This is the empty-REPL placeholder. After α-wave (drum-machines manifest +
+aliasBank), this code runs unchanged on Stave. **This is the simplest parity
+smoke test.**
+
+---
+
+## 2. Csound footprint — verified
+
+`@strudel/csound` npm package itself = **113 KB unpacked** (just a thin wrapper).
+Its hard dependency `@csound/browser` (v7.0.0-beta31) = **6.33 MB unpacked**.
+Deps include `google-closure-library`, `pako`, `ramda`,
+`standardized-audio-context`, `text-encoding-shim`, `unmute-ios-audio`,
+`web-midi-api`.
+
+**Verdict:** monolithic. The 6+ MB is wasm+glue and isn't tree-shakeable. Tier
+toggle is non-negotiable. Default OFF is correct (D-03 ratified).
+
+**Mechanism:** lazy `await import('@strudel/csound')` ONLY when the tier flag
+is on at boot. If the flag is off, no import statement evaluates → no bundle
+inclusion (Vite/esbuild dynamic-import code-split). Confirmed pattern used by
+upstream `prebake.mjs:24` (`import('@strudel/soundfonts').then(...)`).
+
+Loading `@strudel/csound` exposes `loadCsound` as a tagged template (used by the
+`csoundDemo` example, see §1c reference). No `evalScope` re-registration needed
+post-init; the import side-effect populates `globalThis.loadCsound`.
+
+---
+
+## 3. soundMap interception strategy — concrete sketch
+
+D-02 forbids mutating `soundMap`. Investigation of `s()` resolution:
+
+- `s()` is a Pattern method registered by `register('s', …)` in `@strudel/webaudio`.
+  At runtime each hap's `value.s` is the string the user passed.
+- Sound resolution happens at SCHEDULE time inside
+  `onTriggerSample()` (superdough/sampler.mjs:291) via
+  `getSound(s)` → `soundMap.get()[s.toLowerCase()]`
+  (`superdough/superdough.mjs:165–170`).
+- If `getSound` returns nothing, superdough throws `sound X not found! Is it
+  loaded?` — already caught by Stave's `wrappedOutput` error handler
+  (StrudelEngine.ts:227–233).
+
+**Two interception choices:**
+
+| Strategy | Where | Pros | Cons |
+|---|---|---|---|
+| **A. Pre-trigger rewrite** in `wrappedOutput` | StrudelEngine.ts:207 | one-line addition, no Strudel internals touched, runs AFTER transpiler reify, sees the final `hap.value.s` | runs every hap (cheap — Map.get); silent for callers passing a Pattern (P1 — but `s()` itself accepts a Pattern fan, so the hap's `s` field is always a string by the time we see it) |
+| **B. Wrap exported `s()` function** | inject into globalThis after evalScope | catches at parse time, before any audio | `s()` accepts Patterns + strings + arrays; replicating its full type machinery is risky; transpiler reification (P1) means we see Patterns most of the time, defeating string-based alias lookup |
+
+**Recommendation: Strategy A.** Concrete shape:
+
+```ts
+// In wrappedOutput, before the breakpoint hit-check (line ~211):
+const rawS = hap?.value?.s
+if (typeof rawS === 'string') {
+  const aliased = ALIASES[rawS.toLowerCase()]
+  if (aliased && !soundMap.get()[rawS.toLowerCase()]) {
+    // Only rewrite when the raw name has no upstream entry — preserves
+    // "GM names are GM names" for advanced users (D-02 invariant #2).
+    hap.value = { ...hap.value, s: aliased }
+  }
+}
+```
+
+`loadedSoundNames` (StrudelEngine.ts:179) — D-02 says keep autocomplete-honest.
+Strategy A leaves `soundMap` untouched, so `loadedSoundNames` stays unpolluted.
+**To surface aliases in autocomplete**, the editor pulls a SECOND list via a
+new `getAliasNames()` getter and merges in the UI. The autocomplete itself
+classifies them visually ("alias → bd") — out of α/β scope, queue for follow-up.
+
+**soundMap mutation timing (CONTEXT open question):** `aliasBank` calls
+`soundMap.set({ ...soundDictionary })` (`superdough.mjs:117`). After init, `soundMap`
+is **mutated** if user code calls `samples(...)` or `aliasBank(...)`. If we
+ever snapshot for "does this name exist?", we must re-read live, NOT cache.
+Strategy A is a live read (`soundMap.get()[name]`) — safe.
+
+The other mutation site: `registerSound` (`superdough.mjs:61`) calls
+`soundMap.setKey(...)`. This happens during `registerSynthSounds`,
+`registerZZFXSounds`, `registerSoundfonts`, and during `samples()` parse. After
+init completes, `loadedSoundNames` (line 179 snapshot) is **frozen**, missing
+any sounds registered post-init by user-eval'd `samples()` calls. Existing bug,
+out of scope for 20-14, but flag for follow-up.
+
+---
+
+## 4. Heavy module list — confirmed
+
+| Module | Tier flag | Default | Rationale |
+|---|---|---|---|
+| `@strudel/csound` | `csound` | OFF | 6.3 MB wasm + glue (§2). |
+| `@strudel/tidal` | `tidal` | OFF | 5.8 MB. Audio-pure but bloats audio-pure bundle. |
+| `@strudel/midi` with `enableWebMidi()` | `midi` | OFF | Module loaded; `enableWebMidi()` requires permission. Two-step flag: load on/off + permission prompt timing (β-wave UX call, see CONTEXT gray-area #3). |
+| `@strudel/osc` | `osc` | OFF | Needs SuperCollider backend running locally. |
+| `@strudel/serial` | `serial` | OFF | WebSerial permission. |
+| `@strudel/gamepad` | `gamepad` | OFF | Gamepad permission. |
+| `@strudel/motion` | `motion` | OFF | DeviceMotion permission. |
+| `@strudel/mqtt` | `mqtt` | OFF | Network broker config. |
+
+8 tier flags. Schema lives in `EditorSettingsModal` per D-03. Each is a `boolean`
+that `StrudelEngine.init()` reads from the workspace settings snapshot at boot.
+
+**Not a tier flag (stay OFF permanently):** `@strudel/draw`, `@strudel/hydra`,
+`@strudel/codemirror` — these collide with Stave's own UI/visualizer stack.
+
+**Toggle UX** (note for β-wave): toggles take effect **on reload**, not
+immediately. The CONTEXT gray-area #3 raises the MIDI prompt question — recommend
+"early prompt at toggle-on" via a one-shot `enableWebMidi()` call queued for
+the next init. Surface in β-wave's discuss-phase.
+
+---
+
+## 5. Parity corpus candidates — 10-20 from upstream
+
+Source: `website/src/repl/tunes.mjs` @ SHA `f73b395648645aabe699f91ba0989f35a6fd8a3c`,
+32 named exports.
+
+**Curated 16 (covers full parity surface):**
+
+| # | Tune | Why curated | Surface tested |
+|---|---|---|---|
+| 1 | `chop` | minimal, single sample chop | bare-sample resolve |
+| 2 | `delay` | simple FX | param keys |
+| 3 | `orbit` | `.orbit()` chain | orbit routing |
+| 4 | `belldub` | `.s("bell")` bare name | **alias layer** |
+| 5 | `sampleDrums` | bare `bd/sd/hh` | Dirt-Samples baseline |
+| 6 | `randomBells` | `.note().scale()` | tonal ops |
+| 7 | `barryHarris` | jazz harmony, scales | tonal + xen edge |
+| 8 | `echoPiano` | `.piano()` chain | **Pattern.prototype.piano injection** |
+| 9 | `holyflute` | soundfont (`gm_…`) | soundfont parity |
+| 10 | `flatrave` | `.bank("tr909")` | **drum-machines manifest + aliasBank** |
+| 11 | `amensister` | sample chop + stutter | sequencing ops |
+| 12 | `juxUndTollerei` | `.jux()` higher-order | combinator IR shape |
+| 13 | `bassFuge` | polyphony + voicing | `.voicing()` |
+| 14 | `dinofunk` | drum-machines + polyrhythm | mini-notation polyrhythm |
+| 15 | `meltingsubmarine` | `.color()` + viz hints | metadata pass-through |
+| 16 | `arpoon` | arp + chord ops | tonal chord progression |
+
+**Deliberately omitted:**
+- `csoundDemo` — requires `@strudel/csound` (heavy tier flag). Add when csound
+  tier shipped (out of scope).
+- `swimming`, `giantSteps`, `caverave`, `zeldasRescue`, `goodTimes`,
+  `festivalOfFingers*`, `sml1`, `waa2`, `outroMusic`, `undergroundPlumber`,
+  `wavyKalimba`, `blippyRhodes`, `loungeSponge`, `sampleDemo` — variations of
+  the surface already covered. Add if a parity gap appears.
+
+**P62 audit** (quote-rewriting): scanning the 16 tunes, **all** use double-quoted
+strings inside chain methods (`.s("bd")`, `.bank("tr909")`, etc.). Strudel's
+transpiler reifies these as Patterns intentionally — that IS the upstream
+behavior. **Corpus should NOT be hand-rewritten to single quotes.** The parity
+assertion is "after eval, our IR matches upstream's eval", and both go through
+the same transpiler. P62 only bites in `.p()`, `.viz()`-style "string-id"
+chains, not the audio-side `.s()`/`.bank()` chains in the corpus.
+
+**Corpus storage layout** (per D-04):
+```
+packages/app/tests/parity-corpus/
+  CORPUS-SOURCE.md              ← SHA pin + license note (AGPL-3.0)
+  chop.strudel                  ← (copy of tunes.mjs export, trailing newline)
+  delay.strudel
+  ...
+  arpoon.strudel
+```
+
+**Refresh script** (γ-wave): `pnpm parity:refresh` re-fetches `tunes.mjs` at a
+new SHA and `diff -u` against current corpus — surfaces upstream additions for
+manual review. Does NOT run on PRs (D-04).
+
+---
+
+## 6. Friendly-errors integration — one-line vs deeper
+
+`friendlyErrors.ts:240` uses `detect.alias` for a runtime-doc alias mechanism
+(e.g., "user typed `volume`, doc entry for `gain` lists `volume` as a
+CommonMistake alias"). **Different concept** from the sound-name alias layer
+this phase introduces. They do not collide structurally.
+
+**β-wave touch:**
+1. Add an `aliasResolved` field to the friendly-error payload when a hap's `s`
+   was rewritten by the alias map (Strategy A in §3). Surface in the error
+   panel: "tried alias `kick` → `bd` (resolved)". One-liner where we already
+   build the message.
+2. On a MISS at `getSound` after alias resolution attempted: the existing
+   "sound X not found" path stays. Augment the friendly-error message
+   builder to mention "alias map: no entry for `xyz`" when the user's
+   identifier didn't resolve via alias either. One-liner in the doc-lookup
+   step.
+
+**Verdict: one-line additions** on both paths. No deep refactor. Defer the
+"suggest a close alias via fuzzy match" UX to a γ+1 follow-up; existing
+`detect.alias` per-doc CommonMistake handling already covers most fuzzy cases.
+
+---
+
+## 7. Boundary scan — what we still don't know
+
+Open questions for the PLAN pre-mortem:
+
+1. **`Pattern.prototype.piano` injection ordering vs Stave's `.p()` setter trap
+   (P2).** Upstream `prebake.mjs:165` assigns
+   `Pattern.prototype.piano = function(){…}` at boot. Stave's
+   `injectPatternMethods` (per UV2, P2 in hetvabhasa) overwrites prototypes
+   during `evaluate()`. If we vendor `piano.mjs`, when does the assignment
+   fire — boot, or every eval? Boot is correct (upstream behavior); confirm
+   `.p()` setter trap doesn't strip it. (Likely safe: the trap is on `.p`,
+   `.viz`, and legacy viz names — `.piano` isn't in that list.) **VERIFY in α.**
+
+2. **`tidal-drum-machines` baseURL invariant.** Upstream sources are pinned at
+   `https://strudel.b-cdn.net/…`. If b-cdn.net moves or expires, our parity
+   corpus breaks silently (samples fail to load, IR shape still matches → smoke
+   test passes, but `s("RolandTR909")` produces no audio). D-01 (structural
+   parity) explicitly does NOT catch this. **Document as accepted risk; flag
+   for monitoring.**
+
+3. **`.bank()` shape after α-wave.** After loading `tidal-drum-machines.json` +
+   `aliasBank(tidal-drum-machines-alias.json)`, does `.bank("tr909")` produce
+   the same IR shape on Stave as upstream? Need to eval one tune (`flatrave`)
+   in both to verify. **Mark γ-wave as "first sample tune that exercises bank
+   must pass on first run."**
+
+4. **Pre-init alias lookup race.** Strategy A reads `soundMap.get()[name]` at
+   trigger time. But the alias is in our hand-rolled TS const. What if a user
+   `samples(...)` call registers a sound with the SAME name as one of our
+   aliases? Strategy A's guard (`!soundMap.get()[rawS]`) deferring to upstream
+   wins is correct — user-registered names override our alias. Document this
+   precedence in `aliases.ts` header.
+
+5. **`settingPatterns` first arg.** Upstream `loadModules()` passes
+   `settingPatterns` as the FIRST arg to `evalScope` (util.mjs:97). This is a
+   module-shape object exporting setting-bound pattern functions. Stave doesn't
+   currently expose this. **Audit `settings.mjs:settingPatterns` — likely
+   audio-pure adds.** Low-priority but a real gap.
+
+6. **Codemirror-specific globals.** `@strudel/codemirror` registers
+   `highlightHaps` and other globals that user code might reference. If a
+   corpus tune (unlikely) depends on a codemirror-exported global, parity
+   fails. Out of scope; flag if it surfaces.
+
+7. **Audio-pure-but-heavy boundary case.** `@strudel/xen` is currently loaded
+   (Stave) — 2.47 MB. Defensible: it's audio-pure (no permission), already
+   shipping, and removing it breaks current code. `@strudel/tidal` is the same
+   shape (audio-pure, heavy) but NOT shipping — defensible to gate behind
+   `tidal` flag. The line is "is it already in the bundle?" not "is it audio
+   pure?" Document this decision rule in α SUMMARY.
+
+---
+
+## 8. Boundary scan summary (cognitive)
+
+Boundaries crossed by this phase, with silent-failure modes:
+
+| Boundary | Silent-failure mode | Mitigation |
+|---|---|---|
+| `StrudelEngine` ↔ upstream `@strudel/*` | new register* in upstream we don't mirror = silent gap | corpus smoke test (γ); refresh script flags adds |
+| Engine init ↔ user-eval'd globals | tier flag toggled but not re-init = stale globals | "reload required" copy on toggle |
+| `EditorSettingsModal` ↔ engine init | settings snapshot read at boot only | mid-session toggle requires reload; document explicitly |
+| Corpus snapshot ↔ live upstream | corpus drifts; smoke test passes against stale shape | refresh PR cadence in CORPUS-SOURCE.md |
+| Alias map ↔ user `samples(…)` calls | user shadows an alias key | Strategy A guard: `!soundMap.get()[name]` defers to upstream |
+| `Pattern.prototype.piano` ↔ Stave's `.p()` setter trap (P2) | trap strips the injected method | confirm `.piano` not in `legacyVizNames`; observe in α |
+
+Known invariants respected:
+- **UV2** (Framework Prototype Sovereignty) — α-wave does not add prototype
+  installers; β-wave's `.piano` injection mirrors upstream's boot-time install,
+  no per-eval re-install.
+- **UV3** (Pipeline Argument Transformation) — Strategy A reads the post-reify
+  `hap.value.s` which is always a string by the time superdough sees it.
+
+Known error patterns respected:
+- **P1** (transpiler reification) — Strategy A intercepts AFTER reify; sees the
+  resolved string.
+- **P2** (injectPatternMethods overwrite) — α adds NO prototype installs; β's
+  `.piano` install is boot-time (mirrors upstream — outside the evaluate-time
+  trap zone).
+- **P11** (re-applied registrations) — `evalScope` is idempotent
+  (`evaluate.mjs:37–51` — just `globalThis[name] = value` per export). New
+  `register*` calls are mostly idempotent (`registerSound` does
+  `soundMap.setKey` which overwrites). Safe to call repeatedly.
+- **P62** (transpiler quote rewriting) — corpus tunes use double quotes
+  intentionally; Strategy A operates downstream of reify, so it's a non-issue
+  here. Document for future maintainers.
+
+Krama (lifecycle) preserved (per `feedback_strudel_init.md`):
+- α additions slot at the **same lifecycle stage** as their current siblings:
+  - `@strudel/edo`, `@strudel/mondo` → inside the `Promise.all` at
+    StrudelEngine.ts:129–137
+  - Sample manifests → after `registerSoundfonts`, before the
+    `loadedSoundNames` snapshot
+  - `aliasBank` JSON fetch → after all sample manifests resolve
+  - `Pattern.prototype.piano` injection → after `Pattern` is in `globalThis`
+    (i.e., after `evalScope`)
+
+---
+
+## 9. References
+
+Codeberg (upstream-pinned SHA `f73b395648645aabe699f91ba0989f35a6fd8a3c`):
+
+- `website/src/repl/util.mjs:68-98` — `loadModules()` evalScope set.
+  https://codeberg.org/uzu/strudel/raw/branch/main/website/src/repl/util.mjs
+- `website/src/repl/prebake.mjs:1-174` — sample manifest + `aliasBank` + piano.
+  https://codeberg.org/uzu/strudel/raw/branch/main/website/src/repl/prebake.mjs
+- `website/src/repl/useReplContext.jsx:44-46,148` — boot orchestration + default
+  pattern. https://codeberg.org/uzu/strudel/raw/branch/main/website/src/repl/useReplContext.jsx
+- `website/src/repl/tunes.mjs` — 32 example tunes.
+  https://codeberg.org/uzu/strudel/raw/branch/main/website/src/repl/tunes.mjs
+- `packages/core/evaluate.mjs:37-51` — `evalScope` idempotence proof.
+  https://codeberg.org/uzu/strudel/raw/branch/main/packages/core/evaluate.mjs
+- `packages/superdough/superdough.mjs:61-170` — `registerSound`, `aliasBank`,
+  `aliasBankMap`, `soundAlias`, `getSound`.
+  https://codeberg.org/uzu/strudel/raw/branch/main/packages/superdough/superdough.mjs
+- `packages/superdough/sampler.mjs:291` — `onTriggerSample` (alias resolution
+  read-site for Strategy A).
+  https://codeberg.org/uzu/strudel/raw/branch/main/packages/superdough/sampler.mjs
+
+npm registry (size metadata):
+- `https://registry.npmjs.org/@strudel/csound/latest`
+- `https://registry.npmjs.org/@csound/browser/latest`
+- `https://registry.npmjs.org/@strudel/tidal/latest`
+- (and remaining packages enumerated in §1b)
+
+Strudel CDN:
+- `https://strudel.b-cdn.net/tidal-drum-machines-alias.json` — 1.7 KB, 69 entries
+  (Roland*/Korg*/Yamaha*/etc. → short name).
+
+Local files:
+- `/Users/mrityunjaybhardwaj/Documents/projects/struCode/packages/editor/src/engine/StrudelEngine.ts:121-180` — current init.
+- `/Users/mrityunjaybhardwaj/Documents/projects/struCode/packages/editor/src/engine/StrudelEngine.ts:207-234` — `wrappedOutput` (Strategy A insertion site).
+- `/Users/mrityunjaybhardwaj/Documents/projects/struCode/packages/editor/src/engine/friendlyErrors.ts:227-306` — `detect.alias` (orthogonal to phase aliases).
+- `/Users/mrityunjaybhardwaj/Documents/projects/struCode/packages/app/src/components/EditorSettingsModal.tsx` — tier flag UI insertion site.
+- `/Users/mrityunjaybhardwaj/Documents/projects/struCode/.anvi/hetvabhasa.md` — P1, P2, P11, P62 catalogue entries referenced.
+
+Catalogue cross-refs:
+- P1 (`hetvabhasa.md:42`) — Strudel Transpiler Reification.
+- P2 (`hetvabhasa.md:47`) — Strudel injectPatternMethods Overwrite.
+- P62 (`hetvabhasa.md:1530`) — Strudel transpiler quote-rewriting.
+- `feedback_strudel_init.md` — krama (init order).
+- `feedback_editor_watch_mode.md` (PV48) — `pnpm --filter @stave/editor dev` MUST run during work on this phase.

--- a/.planning/phases/20-musician-timeline/20-14-α-SUMMARY.md
+++ b/.planning/phases/20-musician-timeline/20-14-α-SUMMARY.md
@@ -1,0 +1,286 @@
+---
+phase: 20-14
+wave: α
+title: Bootstrap mirror — strudel.cc parity α-wave SUMMARY
+created: 2026-05-15
+branch: feat/20-14-strudel-parity
+commits: α-1..α-6 inclusive
+---
+
+# Phase 20-14 — α-Wave SUMMARY
+
+α-wave mirrors upstream strudel.cc's audio-pure engine bootstrap into Stave's
+`StrudelEngine.init()` plus introduces the tier-flag schema that β consumes.
+Six tasks, six commits. Functional checks (browser console, audible audio)
+require user-side verification because the executor cannot drive a browser;
+those gates are stated below with the exact snippet the user runs and the
+expected response. Test-suite observations (1526/1526 green throughout)
+confirm no regressions to existing behavior.
+
+## α-1 — `@strudel/mondo` added to evalScope
+
+Added `@strudel/mondo@1.1.6` as a new dependency of `@stave/editor` and
+threaded it through the existing `Promise.all` dynamic-import set, then into
+the `coreMod.evalScope(...)` call. The module exposes four globals via
+evalScope: `mondo`, `mondi`, `mondolang`, `getLocations` (verified at
+`packages/editor/node_modules/@strudel/mondo/dist/mondough.mjs:74-79`).
+
+**Deviation from PLAN α-1:** `@strudel/edo` was NOT added. The package is
+referenced by upstream `loadModules()` at the pinned SHA but is **not
+published to npm** — `registry.npmjs.org/@strudel/edo` returns 404 as of
+2026-05-15. Adding it would require installing from Codeberg directly,
+which the plan did not pre-authorize. Recorded as a follow-up to re-attempt
+when upstream publishes; α scope unaffected because the edo operators only
+matter once a corpus tune that uses them lands in γ (none of the 16 in
+RESEARCH §5 do).
+
+**Observations:**
+- **Test-suite (executor-run):** editor tests 1526/1526 passing
+  post-change — empty `vi.mock('@strudel/mondo', () => ({}))` matches the
+  existing tonal/xen/midi mocking pattern.
+- **Browser-side (user-verify):** open the app at <http://localhost:3000>,
+  open dev console, run:
+  ```js
+  [typeof globalThis.mondo, typeof globalThis.mondolang]
+  ```
+  Expected: `["function", "function"]`. If either reads `"undefined"`,
+  evalScope did not bind the export — α-1 incomplete.
+
+## α-2 — Six sample-manifest fetches added to init
+
+Added a `Promise.all` of seven `samples()` calls after the existing
+`github:tidalcycles/Dirt-Samples/master` fetch, mirroring upstream
+`prebake.mjs:25-155` verbatim: Salamander piano, VCSL orchestra,
+tidal-drum-machines, uzu-drumkit, uzu-wavetables, mridangam, plus the
+inline Dirt-Samples extras object (casio, crow, insect, wind, jazz, metal,
+east, space, numbers, num). Each call wrapped in `safeSamples(...)` that
+catches + logs so a b-cdn outage does not break engine boot (accepted
+risk per RESEARCH §7 #2 and PLAN §6).
+
+**Observations:**
+- **Test-suite (executor-run):** 1526/1526 green. The `samples()` mock is
+  a `vi.fn()` so unit tests pass through unchanged.
+- **Browser-side (user-verify):** in dev console after engine boot:
+  ```js
+  Object.keys(soundMap.get()).filter(k => /piano|tr909|RolandTR808|mridangam/i.test(k)).length
+  ```
+  (`soundMap` is exposed by `@strudel/webaudio` on globalThis via evalScope.)
+  Expected: positive integer. Then evaluate `s("piano")` in the editor —
+  audio must play, no friendly-error panel.
+
+## α-3 — `aliasBank()` registers 69 bank-name aliases
+
+Added `await (webaudioMod as any).aliasBank(\`${baseCDN}/tidal-drum-machines-alias.json\`)`
+after the α-2 Promise.all, wrapped in try/catch. Recorded the pre- and
+post-aliasBank `Object.keys(soundMap.get()).length` and logged them on every
+boot via `console.log('[StrudelEngine] aliasBank: soundMap keys X → Y (Δ N…)')`.
+
+**Static read of `aliasBank` semantics** (RESEARCH §3 open question #3):
+`superdough/superdough.mjs:86-117` (`aliasBankMap`) reads the existing
+`soundMap.get()` dictionary into a local, mutates the LOCAL to add aliased
+keys, then calls `soundMap.set({...soundDictionary})` which is a shallow
+spread of the same dict plus new keys onto a fresh object. **This is a
+merge, not a replace.** The post-aliasBank count is monotonically ≥ the
+pre-count. Current α-3 call ordering (after manifest fetches) is therefore
+safe; no PLAN-level rework needed.
+
+**Observations:**
+- **Test-suite (executor-run):** 1526/1526 green.
+- **Browser-side (user-verify) — REQUIRED for α-7 SUMMARY closure per
+  PLAN α-3 verify gate:** open dev console on app load. Look for the line:
+  ```
+  [StrudelEngine] aliasBank: soundMap keys <N> → <M> (Δ <M-N>; expect non-negative)
+  ```
+  Expected: Δ ≥ 0 (likely ~69 net adds). If Δ < 0, this contradicts the
+  static read above and PLAN α-3 says **STOP and escalate as a PLAN-LEVEL
+  ISSUE**. Then evaluate `s("[bd <hh oh>]*2").bank("tr909").dec(.4)` —
+  audio must play with TR-909 samples (not Dirt-Samples bd).
+
+## α-4 — Vendored `piano.mjs` for `Pattern.prototype.piano`
+
+Created `packages/editor/src/engine/vendored/piano.ts` — a side-effect
+module that attaches `Pattern.prototype.piano` on import. The body mirrors
+upstream `prebake.mjs:161-173` verbatim (fmap clip=1, `.s('piano')`,
+`.release(0.1)`, fmap pan by pitch via `panwidth`/`valueToMidi`/`noteToMidi`).
+The file's header cites the pinned upstream SHA and the repo-root
+AGPL-3.0-or-later LICENSE.
+
+Wired the import (`await import('./vendored/piano')`) at the END of
+`StrudelEngine.init()`, after evalScope has populated `Pattern` on
+globalThis. Test mocks for `@strudel/core` extended with stub `noteToMidi`
++ `valueToMidi` so the module loads cleanly under jsdom (Lokayata: tests
+went red, then green after the stub — exactly the observation contract
+the vendored import creates).
+
+**Post-eval prototype check result (PLAN α-4 verify gate, user-verify):**
+This is the single observation that determines whether α-4's "install at
+boot, NOT in setter trap" assumption holds. The user must run, in the dev
+console after engine boot:
+```js
+// BEFORE evaluate
+const before = typeof Pattern.prototype.piano
+// run any eval, e.g. note("c4").piano() inside the editor
+// AFTER one evaluate() cycle
+const after = typeof Pattern.prototype.piano
+;[before, after]
+```
+**Expected: `["function", "function"]`.** If `after === "undefined"`, the
+P2 / UV2 setter trap stripped the method during `injectPatternMethods` and
+the install must move to post-eval — PLAN α-4 anticipated this and called
+it "unlikely." α-7 verdict pending the user's reload-and-eval.
+
+**Static reasoning supporting the expected result:** The injectPatternMethods
+setter trap in `StrudelEngine.evaluate()` (lines 282-333) only wraps `p`,
+`viz`, and the legacy viz names `['pianoroll', 'punchcard', 'wordfall',
+'scope', 'fscope', 'spectrum', 'spiral', 'pitchwheel', 'markCSS']`.
+`.piano` is not in that list, so the boot-time install should survive. The
+post-eval check is the runtime confirmation of this static reasoning.
+
+**Observations:**
+- **Test-suite (executor-run):** 1526/1526 green after the mock-stub fix.
+- **Browser-side (user-verify, REQUIRED):** post-eval prototype check
+  above — record `[before, after]` here once observed.
+
+## α-5 — Tier flag schema (8 flags, schema-only, no UI)
+
+New module `packages/editor/src/engine/tierFlags.ts` exports `TierFlags`
+type, `getTierFlags()` reader, `setTierFlag(name, on)` writer,
+`listTiers()` enumerator. Storage: localStorage with prefix
+`stave.strudel.tier.`, default `false`. Schema-drift safe: missing or
+malformed keys read as `false`. Public surface re-exported from
+`packages/editor/src/index.ts` so β-3's modal in `packages/app/` can
+consume via the `@stave/editor` boundary.
+
+Wiring in `StrudelEngine.init()`: read tier flags **once** at the top of
+init(), stash on a private instance field `this.tierFlags`, expose via
+`getTierFlagsSnapshot()` for β-4, and emit the dev-console log
+`[StrudelEngine] tierFlags read at init: { csound: false, … }`. β-4 will
+read `this.tierFlags.midi` to gate `enableWebMidi()`.
+
+**Observations:**
+- **Test-suite (executor-run):** 1526/1526 green. `safeLocalStorage()`
+  duck-types `getItem` before returning to handle jsdom's partial-Storage
+  stub used by some tests.
+- **Browser-side (user-verify) — REQUIRED:** reload the dev server,
+  open dev console. The line
+  ```
+  [StrudelEngine] tierFlags read at init: { csound: false, tidal: false, midi: false, osc: false, serial: false, gamepad: false, motion: false, mqtt: false }
+  ```
+  must appear on engine boot. Then run `getTierFlags()` directly (the
+  function is exported on `globalThis` via the @stave/editor public
+  surface — caveat: it may need explicit re-import depending on tree-shake;
+  if `getTierFlags` is not on globalThis, the boot-time log alone
+  satisfies the consumed-at-init proof).
+
+## α-6 — `settingPatterns` audit (RESEARCH §7 open question #5)
+
+Fetched upstream `website/src/settings.mjs` at the pinned SHA. The
+`settingPatterns` export at line 154 is `{ theme, fontFamily, fontSize }`,
+each a `patternSetting(key)` from line 139 that calls
+`pat.onTrigger(() => settingsMap.setKey(key, value), false)`. The `false`
+arg to `onTrigger` explicitly disables audio output. The body mutates the
+upstream React editor's settings store.
+
+**Verdict:** UI-only. **No audio-pure exports are missing from Stave**.
+Re-exposing on Stave would write to a settings object that doesn't exist
+here. Action: none for α, none for β. Full audit lives at
+`.planning/phases/20-musician-timeline/20-14-OBSERVATIONS.md`.
+
+## UX decisions carried into β
+
+- **Tier flag toggle requires reload** (per PLAN §2 + RESEARCH §4 + §8):
+  the engine reads tier flags **once** at init. β-3's modal must surface
+  the caption `"Changes take effect when you reload the page."` —
+  non-negotiable to avoid user confusion when toggling MIDI seems to do
+  nothing.
+- **Tier-flag UI honesty (per PLAN §2):** β-3 ships all 8 toggles. MIDI
+  is interactive; the other 7 (csound, tidal, osc, serial, gamepad,
+  motion, mqtt) ship as disabled-scaffolded with the tooltip
+  `"Module wiring planned — see issue #NNN."` Each wiring follow-up
+  issue (listed below) lights up one toggle.
+- **Per-file `await tier(...)` directive (D-03 part B):** queued as a
+  follow-up, not part of β. File when α merges.
+
+## Follow-up issues to file (out of α scope)
+
+1. **`@strudel/edo` install**: re-attempt α-1's missing import once
+   upstream publishes `@strudel/edo` to npm. Until then, the upstream
+   `loadModules()` parity is partial.
+2. **Heavy-module dynamic-import wiring** (one issue per disabled toggle
+   in β-3):
+   - `@strudel/csound` (6.3 MB wasm)
+   - `@strudel/tidal` (5.8 MB)
+   - `@strudel/osc` (needs SuperCollider backend)
+   - `@strudel/serial` (WebSerial permission)
+   - `@strudel/gamepad` (Gamepad permission)
+   - `@strudel/motion` (DeviceMotion permission)
+   - `@strudel/mqtt` (network broker)
+3. **Per-file `await tier(...)` directive** (D-03 part B) — at-eval
+   tier opt-in.
+4. **Post-init `samples()` autocomplete pollution** —
+   `loadedSoundNames` snapshot at StrudelEngine.ts:179 misses
+   user-eval'd `samples()` calls (RESEARCH §3 final paragraph). Filed
+   after α merges.
+5. **Pianoroll / scope re-export decision** — `@strudel/draw` excluded
+   wholesale. If users want `pianoroll`/`scope`/`spectrum`/`wordfall`/
+   `punchcard` without the DOM injection, re-export them. (Out of
+   visual-parity scope for 20-14.)
+6. **b-cdn.net availability monitoring** — RESEARCH §7 #2. The α-2
+   `safeSamples` wrapper degrades gracefully if a manifest fetch fails,
+   but the structural parity smoke test (γ-2) explicitly does NOT catch
+   "samples loaded but audio is silent." Document as accepted risk and
+   monitor manually.
+7. **`@strudel/edo` audio-pure additions** beyond evalScope — once edo
+   ships on npm, also check if `prebake.mjs` adds any edo-specific
+   manifest calls we missed in α-2.
+
+## Catalogue candidates (deferred for promotion review)
+
+Per executor operational rules, `.anvi/` catalogues are not updated
+mid-wave. Candidates noticed in α to consider after β merge:
+
+- **hetvabhasa candidate:** "upstream package referenced by upstream init
+  but unpublished to npm" — the α-1 `@strudel/edo` situation. Pattern:
+  `loadModules()` snapshot includes packages not all published. Fix:
+  detect via `npm view` audit before claiming parity. Detection: 404
+  from `registry.npmjs.org/<pkg>`.
+- **vyapti candidate (already implicit via P11):** "evalScope is
+  idempotent — `globalThis[name] = value` per export — but tests need a
+  matching `vi.mock` even for unused modules, else jsdom fails on the
+  module-load side effect of the real package." Promote if seen again.
+- **krama candidate:** "α-3 aliasBank ordering: aliasBank MUST run after
+  all manifest fetches, because its body walks the existing soundMap to
+  add aliased keys for each registered bank suffix. Running before
+  manifests = no bank suffixes to alias." Confirmed empirically via the
+  static read of `aliasBankMap`. Lifecycle entry candidate.
+
+## α verification gate status
+
+Per PLAN §3:
+
+| Gate item | Status | Source |
+|---|---|---|
+| Engine boots without throwing | ✅ tests | 1526/1526 green |
+| globalThis exports defined (`mondo`, `mondolang`) | ⏳ user-verify | snippet in α-1 paragraph |
+| `s("piano")` audibly plays | ⏳ user-verify | snippet in α-2 paragraph |
+| `s("[bd <hh oh>]*2").bank("tr909").dec(.4)` plays TR-909 | ⏳ user-verify | snippet in α-3 paragraph |
+| aliasBank merges (count Δ ≥ 0) | ⏳ user-verify (boot log) | α-3 paragraph |
+| `Pattern.prototype.piano` survives one eval cycle | ⏳ user-verify | snippet in α-4 paragraph |
+| `getTierFlags()` returns 8 falses + init log fires | ⏳ user-verify | α-5 paragraph |
+| Existing test suite remains green | ✅ executor | 1526/1526 throughout α-1..α-5 |
+| Engine boot time within previous + 100ms | ⏳ user-verify | manifest fetches are the only added cost; lazy |
+
+Branch ready for user-side reload-and-verify pass before PR. Do not push
+until the user confirms the ⏳ items.
+
+## Open questions resolution status (mapped to PLAN §6)
+
+| # | Question | Status |
+|---|---|---|
+| 1 | `Pattern.prototype.piano` install timing vs P2 setter trap | Pending user-side post-eval check (α-4 paragraph) |
+| 2 | b-cdn.net availability | Risk documented; `safeSamples` mitigation in code |
+| 3 | `aliasBank` merge vs replace + `.bank("tr909")` IR shape | **Resolved: merge** via static read; functional check pending user-side |
+| 4 | Pre-init alias lookup race | β-1 concern; not in α scope |
+| 5 | `settingPatterns` audit | **Resolved: UI-only, no audio gap** (α-6) |
+| 6 | Codemirror-specific globals | Deferred — γ-2 corpus will catch if surface |
+| 7 | `xen` audio-pure-but-heavy boundary | Decision rule documented: "already in bundle" — `xen` stays, `tidal` gated |

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -36,6 +36,7 @@
     "@strudel/draw": "^1.0.0",
     "@strudel/midi": "^1.0.0",
     "@strudel/mini": "^1.0.0",
+    "@strudel/mondo": "^1.1.6",
     "@strudel/soundfonts": "^1.0.0",
     "@strudel/tonal": "^1.0.0",
     "@strudel/transpiler": "^1.0.0",

--- a/packages/editor/src/engine/StrudelEngine.test.ts
+++ b/packages/editor/src/engine/StrudelEngine.test.ts
@@ -175,6 +175,11 @@ vi.mock('@strudel/xen', () => ({}))
 
 vi.mock('@strudel/midi', () => ({}))
 
+// Phase 20-14 α-1: audio-pure addition to evalScope; tests don't exercise
+// mondo notation so an empty mock is sufficient (matches the @strudel/tonal,
+// @strudel/xen, @strudel/midi pattern above).
+vi.mock('@strudel/mondo', () => ({}))
+
 vi.mock('@strudel/transpiler', () => ({
   transpiler: vi.fn((code: string) => ({ output: code })),
 }))

--- a/packages/editor/src/engine/StrudelEngine.test.ts
+++ b/packages/editor/src/engine/StrudelEngine.test.ts
@@ -50,6 +50,13 @@ vi.mock('@strudel/core', () => {
   return {
     Pattern: MockPattern,
     evalScope: vi.fn().mockResolvedValue(undefined),
+    // Phase 20-14 α-4: vendored piano.ts imports noteToMidi + valueToMidi
+    // from @strudel/core at engine boot. Stubbed here so the test env can
+    // load the side-effect module without an undefined-export crash.
+    // The functions aren't exercised by these tests — any numeric return
+    // is fine.
+    noteToMidi: vi.fn((_note: string) => 108),
+    valueToMidi: vi.fn((_value: unknown) => 60),
   }
 })
 

--- a/packages/editor/src/engine/StrudelEngine.ts
+++ b/packages/editor/src/engine/StrudelEngine.ts
@@ -365,6 +365,13 @@ export class StrudelEngine implements LiveCodingEngine {
       },
     })
 
+    // Phase 20-14 α-4: vendor upstream `piano.mjs` chain method. Side-effect
+    // import — attaches Pattern.prototype.piano once at boot. evalScope
+    // populated Pattern on globalThis ~200 lines above, so by here the
+    // prototype exists to extend. NOT re-imported per evaluate (UV2 / P2
+    // safe — `.piano` is not in the injectPatternMethods overwrite list).
+    await import('./vendored/piano')
+
     this.initialized = true
   }
 

--- a/packages/editor/src/engine/StrudelEngine.ts
+++ b/packages/editor/src/engine/StrudelEngine.ts
@@ -267,7 +267,34 @@ export class StrudelEngine implements LiveCodingEngine {
       }, `${baseCDN}/Dirt-Samples/`, { prebake: true })),
     ])
 
-    // α-3 lands here: aliasBank(`${baseCDN}/tidal-drum-machines-alias.json`)
+    // Phase 20-14 α-3: aliasBank() registers 69 bank-name aliases (e.g.
+    //   RolandTR909 → 909, KorgKR55 → KR55) so users can spell drum-machine
+    //   banks the way upstream tunes do. See upstream prebake.mjs:158.
+    //
+    // Merge-vs-replace semantics (RESEARCH §3 open question #3):
+    //   superdough/superdough.mjs:86-117 (aliasBankMap) reads the current
+    //   soundMap.get() dictionary, MUTATES it in place to add aliased keys
+    //   (e.g. `909_bd` aliased from `RolandTR909_bd`), then calls
+    //   soundMap.set({...soundDictionary}). That spread is a SHALLOW MERGE
+    //   of the same dict back onto itself plus the new alias keys — so the
+    //   post-aliasBank count is monotonically ≥ the pre-count. We log
+    //   BEFORE/AFTER to make the contract observable; α-7 SUMMARY pins this.
+    //
+    // Wrapped in try/catch for the same boot-resilience reason as α-2.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const soundMapRef = (webaudioMod as any).soundMap
+    const preAliasCount = soundMapRef?.get ? Object.keys(soundMapRef.get()).length : 0
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (webaudioMod as any).aliasBank(`${baseCDN}/tidal-drum-machines-alias.json`)
+    } catch (e) {
+      console.warn('[StrudelEngine] aliasBank fetch failed; .bank() aliases unavailable.', e)
+    }
+    const postAliasCount = soundMapRef?.get ? Object.keys(soundMapRef.get()).length : 0
+    // Dev-only observation log — α-7 SUMMARY cites this for the merge-vs-replace
+    // gate. Drop noisily if a future review wants quieter boot — keep the
+    // observation visible until structural parity ships.
+    console.log(`[StrudelEngine] aliasBank: soundMap keys ${preAliasCount} → ${postAliasCount} (Δ ${postAliasCount - preAliasCount}; expect non-negative)`)
 
     // Snapshot all registered sound names (synths + Dirt-Samples) for editor autocompletion.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/editor/src/engine/StrudelEngine.ts
+++ b/packages/editor/src/engine/StrudelEngine.ts
@@ -9,6 +9,7 @@ import type { LiveCodingEngine, EngineComponents } from './LiveCodingEngine'
 import { propagate, StrudelParseSystem, IREventCollectSystem } from '../ir/propagation'
 import type { PatternIR } from '../ir/PatternIR'
 import type { IREvent } from '../ir/IREvent'
+import { getTierFlags, type TierFlags } from './tierFlags'
 
 type HapHandler = (event: HapEvent) => void
 
@@ -118,8 +119,28 @@ export class StrudelEngine implements LiveCodingEngine {
   private isPausedState: boolean = false
   private pauseChangedListeners: Set<(paused: boolean) => void> = new Set()
 
+  // Phase 20-14 α-5 — tier flags read at boot. β-4 wires `midi` to call
+  // enableWebMidi(); the other 7 (csound, tidal, osc, serial, gamepad,
+  // motion, mqtt) land as one follow-up issue each. Mid-session toggle
+  // changes are NOT picked up here — settings modal shows the "Changes
+  // take effect on reload" caption.
+  private tierFlags: TierFlags | null = null
+
+  /** Read-only snapshot of the tier flags consumed at this engine's init(). */
+  getTierFlagsSnapshot(): Readonly<TierFlags> | null {
+    return this.tierFlags
+  }
+
   async init(): Promise<void> {
     if (this.initialized) return
+
+    // Phase 20-14 α-5: tier-flag consume-at-init contract. Read ONCE here
+    // and stash on the instance. β-4 (MIDI wiring) reads from
+    // `this.tierFlags`. The dev-console log is the consumed-at-init
+    // proof — α-5's Lokayata gate looks for it on reload.
+    this.tierFlags = getTierFlags()
+    // eslint-disable-next-line no-console
+    console.log('[StrudelEngine] tierFlags read at init:', this.tierFlags)
 
     // Load all strudel modules up-front so evalScope can register their
     // exports (note, s, gain, stack, etc.) into globalThis.  The eval'd user

--- a/packages/editor/src/engine/StrudelEngine.ts
+++ b/packages/editor/src/engine/StrudelEngine.ts
@@ -181,6 +181,94 @@ export class StrudelEngine implements LiveCodingEngine {
     // Worklet-based effects (crush, coarse, distort, djf, bytebeat) are loaded by initAudio() above.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await (webaudioMod as any).samples('github:tidalcycles/Dirt-Samples/master')
+
+    // Phase 20-14 α-2: mirror upstream `prebake.mjs` sample-manifest fetches.
+    // Upstream b-cdn manifests unlock `s("piano")` (Salamander), `.bank("tr909")`
+    // (tidal-drum-machines), uzu-drumkit/wavetables, mridangam, VCSL orchestra,
+    // and the inline Dirt-Samples bank set (casio/crow/insect/wind/jazz/metal/
+    // east/space/numbers/num). See upstream prebake.mjs lines 25-155 at SHA
+    // f73b395648645aabe699f91ba0989f35a6fd8a3c.
+    //
+    // Each samples() call is wrapped in try/catch so a b-cdn outage does NOT
+    // break engine boot — the previously-loaded Dirt-Samples + synths still
+    // serve unaffected. Documented as accepted risk in 20-14-PLAN.md §6.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const samplesFn = (webaudioMod as any).samples
+    const baseCDN = 'https://strudel.b-cdn.net'  // upstream prebake.mjs:11
+    const safeSamples = async (label: string, fn: () => Promise<unknown>) => {
+      try { await fn() }
+      catch (e) {
+        // Boot-time soft failure: log + continue. Bd/hh/etc. still work.
+        console.warn(`[StrudelEngine] sample manifest "${label}" failed to load; continuing without it.`, e)
+      }
+    }
+    await Promise.all([
+      // Salamander piano — unlocks `s("piano")`. Closes the symptom of issue #110.
+      safeSamples('piano', () => samplesFn(`${baseCDN}/piano.json`, `${baseCDN}/piano/`, { prebake: true })),
+      // VCSL orchestral library (CC0).
+      safeSamples('vcsl', () => samplesFn(`${baseCDN}/vcsl.json`, `${baseCDN}/VCSL/`, { prebake: true })),
+      // tidal-drum-machines — unlocks `.bank("tr909")`, `.bank("RolandTR808")`, etc.
+      safeSamples('tidal-drum-machines', () => samplesFn(`${baseCDN}/tidal-drum-machines.json`, `${baseCDN}/tidal-drum-machines/machines/`, { prebake: true, tag: 'drum-machines' })),
+      // uzu-drumkit — extra drum banks.
+      safeSamples('uzu-drumkit', () => samplesFn(`${baseCDN}/uzu-drumkit.json`, `${baseCDN}/uzu-drumkit/`, { prebake: true, tag: 'drum-machines' })),
+      // uzu-wavetables — wavetable synth fodder.
+      safeSamples('uzu-wavetables', () => samplesFn(`${baseCDN}/uzu-wavetables.json`, `${baseCDN}/uzu-wavetables/`, { prebake: true })),
+      // mridangam — percussion bank.
+      safeSamples('mridangam', () => samplesFn(`${baseCDN}/mridangam.json`, `${baseCDN}/mrid/`, { prebake: true, tag: 'drum-machines' })),
+      // Inline Dirt-Samples categories (casio/crow/insect/wind/jazz/metal/east/
+      // space/numbers/num) served from b-cdn. Upstream prebake.mjs:42-155.
+      // The earlier `github:tidalcycles/Dirt-Samples/master` call (above) registers
+      // bd/hh/sd/etc.; soundMap.setKey overwrites on duplicate so this call wins
+      // for shared keys — matches upstream behavior (RESEARCH §1c).
+      safeSamples('dirt-extras', () => samplesFn({
+        casio: ['casio/high.wav', 'casio/low.wav', 'casio/noise.wav'],
+        crow: ['crow/000_crow.wav', 'crow/001_crow2.wav', 'crow/002_crow3.wav', 'crow/003_crow4.wav'],
+        insect: [
+          'insect/000_everglades_conehead.wav',
+          'insect/001_robust_shieldback.wav',
+          'insect/002_seashore_meadow_katydid.wav',
+        ],
+        wind: [
+          'wind/000_wind1.wav', 'wind/001_wind10.wav', 'wind/002_wind2.wav', 'wind/003_wind3.wav',
+          'wind/004_wind4.wav', 'wind/005_wind5.wav', 'wind/006_wind6.wav', 'wind/007_wind7.wav',
+          'wind/008_wind8.wav', 'wind/009_wind9.wav',
+        ],
+        jazz: [
+          'jazz/000_BD.wav', 'jazz/001_CB.wav', 'jazz/002_FX.wav', 'jazz/003_HH.wav',
+          'jazz/004_OH.wav', 'jazz/005_P1.wav', 'jazz/006_P2.wav', 'jazz/007_SN.wav',
+        ],
+        metal: [
+          'metal/000_0.wav', 'metal/001_1.wav', 'metal/002_2.wav', 'metal/003_3.wav',
+          'metal/004_4.wav', 'metal/005_5.wav', 'metal/006_6.wav', 'metal/007_7.wav',
+          'metal/008_8.wav', 'metal/009_9.wav',
+        ],
+        east: [
+          'east/000_nipon_wood_block.wav', 'east/001_ohkawa_mute.wav', 'east/002_ohkawa_open.wav',
+          'east/003_shime_hi.wav', 'east/004_shime_hi_2.wav', 'east/005_shime_mute.wav',
+          'east/006_taiko_1.wav', 'east/007_taiko_2.wav', 'east/008_taiko_3.wav',
+        ],
+        space: [
+          'space/000_0.wav', 'space/001_1.wav', 'space/002_11.wav', 'space/003_12.wav',
+          'space/004_13.wav', 'space/005_14.wav', 'space/006_15.wav', 'space/007_16.wav',
+          'space/008_17.wav', 'space/009_18.wav', 'space/010_2.wav', 'space/011_3.wav',
+          'space/012_4.wav', 'space/013_5.wav', 'space/014_6.wav', 'space/015_7.wav',
+          'space/016_8.wav', 'space/017_9.wav',
+        ],
+        numbers: [
+          'numbers/0.wav', 'numbers/1.wav', 'numbers/2.wav', 'numbers/3.wav', 'numbers/4.wav',
+          'numbers/5.wav', 'numbers/6.wav', 'numbers/7.wav', 'numbers/8.wav',
+        ],
+        num: [
+          'num/00.wav', 'num/01.wav', 'num/02.wav', 'num/03.wav', 'num/04.wav', 'num/05.wav',
+          'num/06.wav', 'num/07.wav', 'num/08.wav', 'num/09.wav', 'num/10.wav', 'num/11.wav',
+          'num/12.wav', 'num/13.wav', 'num/14.wav', 'num/15.wav', 'num/16.wav', 'num/17.wav',
+          'num/18.wav', 'num/19.wav', 'num/20.wav',
+        ],
+      }, `${baseCDN}/Dirt-Samples/`, { prebake: true })),
+    ])
+
+    // α-3 lands here: aliasBank(`${baseCDN}/tidal-drum-machines-alias.json`)
+
     // Snapshot all registered sound names (synths + Dirt-Samples) for editor autocompletion.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const soundMapData: Record<string, unknown> = (webaudioMod as any).soundMap?.get() ?? {}

--- a/packages/editor/src/engine/StrudelEngine.ts
+++ b/packages/editor/src/engine/StrudelEngine.ts
@@ -126,7 +126,7 @@ export class StrudelEngine implements LiveCodingEngine {
     // code runs inside Function() with no special scope, so every function it
     // calls must be a global.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const [coreMod, miniMod, tonalMod, webaudioMod, soundfontsMod, xenMod, midiMod] = await Promise.all([
+    const [coreMod, miniMod, tonalMod, webaudioMod, soundfontsMod, xenMod, midiMod, mondoMod] = await Promise.all([
       import('@strudel/core') as Promise<any>,
       import('@strudel/mini') as Promise<any>,
       import('@strudel/tonal') as Promise<any>,
@@ -134,6 +134,14 @@ export class StrudelEngine implements LiveCodingEngine {
       import('@strudel/soundfonts') as Promise<any>,
       import('@strudel/xen') as Promise<any>,
       import('@strudel/midi') as Promise<any>,
+      // Phase 20-14 α-1: audio-pure addition. Exposes `mondo`, `mondi`,
+      // `mondolang`, `getLocations` on globalThis via evalScope. Verified
+      // exports against upstream npm @strudel/mondo@1.1.6 (dist/mondough.mjs).
+      // @strudel/edo (also called for by upstream loadModules at the pinned SHA)
+      // is intentionally NOT added here — it is not yet published to npm
+      // (registry.npmjs.org returns 404 for @strudel/edo on 2026-05-15).
+      // Tracked as a follow-up when upstream publishes it.
+      import('@strudel/mondo') as Promise<any>,
     ])
 
     // Register all module exports into globalThis so eval'd patterns can use them
@@ -144,7 +152,7 @@ export class StrudelEngine implements LiveCodingEngine {
     // into document.body (id="test-canvas") the first time any draw function runs.
     // Stave uses its own visualizer system, so strudel's canvas draw functions
     // (pianoroll, drawFrequencyScope, etc.) are not exposed to user code.
-    await coreMod.evalScope(coreMod, miniMod, tonalMod, webaudioMod, soundfontsMod, xenMod, midiMod)
+    await coreMod.evalScope(coreMod, miniMod, tonalMod, webaudioMod, soundfontsMod, xenMod, midiMod, mondoMod)
 
     // Set up mini-notation string parser (parses "c3 e3 g3" strings as patterns)
     miniMod.miniAllStrings()

--- a/packages/editor/src/engine/tierFlags.ts
+++ b/packages/editor/src/engine/tierFlags.ts
@@ -1,0 +1,99 @@
+// Phase 20-14 α-5 — tier flag schema for heavy / permissioned Strudel modules.
+//
+// Schema only — no conditional imports yet. β-3 introduces the settings-modal
+// UI that writes these flags; β-4 threads the `midi` flag through engine
+// init (calls `enableWebMidi()` when on). The other 7 (csound, tidal, osc,
+// serial, gamepad, motion, mqtt) ship in β-3 as disabled-scaffolded toggles
+// — one queued follow-up issue per module wiring (see 20-14-PLAN.md §7).
+//
+// Source of truth: localStorage. The flags persist via the same mechanism
+// the rest of editorRegistry.ts uses (key/value, lazy safeLocalStorage()
+// access for SSR safety). Keys default to `false` — a missing/malformed
+// localStorage entry reads false, which is the schema invariant: an
+// unset flag is OFF.
+//
+// Lifecycle: read ONCE at engine init. Mid-session toggle changes are NOT
+// observed — toggle UI in β-3 surfaces the "Changes take effect on reload"
+// caption. RESEARCH §4 + §8 documented this.
+//
+// Schema drift: adding a 9th tier later is safe — `getTierFlags()` returns
+// the default (false) for any missing key. Removing a tier requires
+// purging the stale localStorage entry; document at remove time.
+
+const STORAGE_PREFIX = 'stave.strudel.tier.'
+
+export type TierName =
+  | 'csound'
+  | 'tidal'
+  | 'midi'
+  | 'osc'
+  | 'serial'
+  | 'gamepad'
+  | 'motion'
+  | 'mqtt'
+
+export type TierFlags = Record<TierName, boolean>
+
+const ALL_TIERS: TierName[] = [
+  'csound',
+  'tidal',
+  'midi',
+  'osc',
+  'serial',
+  'gamepad',
+  'motion',
+  'mqtt',
+]
+
+function safeLocalStorage(): Storage | null {
+  try {
+    if (typeof window === 'undefined') return null
+    const ls = window.localStorage
+    // jsdom's vitest test env can install a partial-Storage stub where
+    // `getItem` is absent — duck-type before returning to keep readers
+    // total. Same defensive shape as `editorRegistry.ts:safeLocalStorage`.
+    if (!ls || typeof ls.getItem !== 'function') return null
+    return ls
+  } catch {
+    // SSR or hardened environments throw on storage access.
+    return null
+  }
+}
+
+function readTierFlag(name: TierName): boolean {
+  const ls = safeLocalStorage()
+  if (!ls) return false
+  return ls.getItem(`${STORAGE_PREFIX}${name}`) === '1'
+}
+
+function writeTierFlag(name: TierName, on: boolean): void {
+  safeLocalStorage()?.setItem(`${STORAGE_PREFIX}${name}`, on ? '1' : '0')
+}
+
+/**
+ * Read all 8 tier flags. Returns a fresh object each call; never null.
+ * Unset / malformed keys read as `false` (schema-drift safe).
+ */
+export function getTierFlags(): TierFlags {
+  const out = {} as TierFlags
+  for (const name of ALL_TIERS) {
+    out[name] = readTierFlag(name)
+  }
+  return out
+}
+
+/**
+ * Set a single tier flag. Persists immediately; engine reads at next init().
+ * β-3 settings modal calls this from its toggle handler.
+ */
+export function setTierFlag(name: TierName, on: boolean): void {
+  writeTierFlag(name, on)
+}
+
+/**
+ * The canonical tier name list — exported so β-3's UI can enumerate
+ * toggles without hard-coding the schema in two places.
+ */
+export function listTiers(): readonly TierName[] {
+  return ALL_TIERS
+}

--- a/packages/editor/src/engine/vendored/piano.ts
+++ b/packages/editor/src/engine/vendored/piano.ts
@@ -1,0 +1,55 @@
+// Vendored from upstream Strudel.
+//
+// Source: https://codeberg.org/uzu/strudel/src/branch/main/website/src/repl/prebake.mjs
+// Pinned SHA: f73b395648645aabe699f91ba0989f35a6fd8a3c
+// License: AGPL-3.0-or-later — see /LICENSE
+//
+// Phase 20-14 α-4. Upstream injects `Pattern.prototype.piano` as a side
+// effect of importing `./piano.mjs` from `prebake.mjs:4`. The method:
+//   - sets `clip = 1` on each hap value if unset (sustains to next note)
+//   - applies `.s('piano')` to route to the Salamander sample bank
+//     (which α-2 loads via the b-cdn `piano.json` manifest)
+//   - applies `.release(0.1)` so the tail isn't abrupt on hap end
+//   - pans each note by pitch — left for low notes, right for high notes,
+//     width 0.5 centered around the cutoff at C8 (MIDI 108)
+//
+// Why vendored (not re-exported from @strudel/something): the upstream
+// definition lives in the strudel.cc website's prebake.mjs, not in a
+// published @strudel/* package. Reimplementing in-place is the
+// minimum-risk parity move and is license-compatible (AGPL-3.0 ↔
+// AGPL-3.0). When upstream eventually publishes piano.mjs as part of a
+// package, this file becomes a re-export.
+//
+// Lifecycle: this module attaches Pattern.prototype.piano ONCE, on first
+// import. StrudelEngine.init() imports it AFTER evalScope has populated
+// `Pattern` on globalThis (otherwise `Pattern` would be undefined here).
+// Re-importing the module does not re-attach — ES module evaluation is
+// idempotent (the import side-effect runs once per module instance).
+//
+// Setter-trap interaction (P2 / UV2): `injectPatternMethods` overwrites
+// prototypes during evaluate() for `.p`, `.viz`, and the legacy viz names
+// (`pianoroll`, `scope`, `spectrum`, etc.). `.piano` is NOT in that list,
+// so the boot-time install survives across evaluate() cycles. α-4's
+// verify gate confirms this empirically — re-check Pattern.prototype.piano
+// after one evaluate() cycle.
+
+import { Pattern, noteToMidi, valueToMidi } from '@strudel/core'
+
+// Mirrors upstream prebake.mjs:161-173. `maxPan` is the MIDI number for
+// C8 — the topmost piano note. Anything higher pans full right.
+const maxPan = noteToMidi('C8')
+const panwidth = (pan: number, width: number) => pan * width + (1 - width) / 2
+
+// Attach `.piano()` to Pattern.prototype. Done at module-import time so
+// it's a one-shot side effect — no per-eval reinstall.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+;(Pattern.prototype as any).piano = function (this: any) {
+  return this.fmap((v: any) => ({ ...v, clip: v.clip ?? 1 }))
+    .s('piano')
+    .release(0.1)
+    .fmap((value: any) => {
+      const midi = valueToMidi(value)
+      const pan = panwidth(Math.min(Math.round(midi) / maxPan, 1), 0.5)
+      return { ...value, pan: (value.pan || 1) * pan }
+    })
+}

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -31,6 +31,11 @@ export type { HapEvent } from './engine/HapStream'
 // Phase 20-07 (PK13 step 9) — scheduler-level breakpoint registry.
 export { BreakpointStore } from './engine/BreakpointStore'
 export type { BreakpointMeta } from './engine/BreakpointStore'
+// Phase 20-14 α-5 — tier flag schema (8 boolean flags). β-3 reads listTiers()
+// + getTierFlags() to build the settings UI; β-4 reads getTierFlags() at
+// engine init to gate `enableWebMidi()`.
+export { getTierFlags, setTierFlag, listTiers } from './engine/tierFlags'
+export type { TierFlags, TierName } from './engine/tierFlags'
 export type { NormalizedHap } from './engine/NormalizedHap'
 export { normalizeStrudelHap } from './engine/NormalizedHap'
 export { BufferedScheduler } from './engine/BufferedScheduler'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@strudel/mini':
         specifier: ^1.0.0
         version: 1.2.6
+      '@strudel/mondo':
+        specifier: ^1.1.6
+        version: 1.1.6
       '@strudel/soundfonts':
         specifier: ^1.0.0
         version: 1.3.0
@@ -1046,6 +1049,10 @@ packages:
 
   '@strudel/mini@1.2.6':
     resolution: {integrity: sha512-I5GFPLHI3TPcJuD2RdDcurA+lTogaSQ0TB+EimKTgEtSAbU6ZMEkSUOXZIFO5eaAcJcMucgKaBcmTKpD4oZjPA==}
+    engines: {node: '>=18.0.0'}
+
+  '@strudel/mondo@1.1.6':
+    resolution: {integrity: sha512-Yl6p88Dyjwsqd9sPY626uSxDo3G4vHYzCLIt6NUrGjCq8iomm3XDZmvdAzBOsbhJp4nMHMVagX06WNU963nFCg==}
     engines: {node: '>=18.0.0'}
 
   '@strudel/soundfonts@1.3.0':
@@ -2677,6 +2684,10 @@ packages:
   monaco-editor@0.50.0:
     resolution: {integrity: sha512-8CclLCmrRRh+sul7C08BmPBP3P8wVWfBHomsTcndxg5NRCEPfu/mc2AGU8k37ajjDVXcXFc12ORAMUkmk+lkFA==}
 
+  mondolang@1.1.2:
+    resolution: {integrity: sha512-uaKjzRD1sdqMJ0yJDJkOd9SuXft1kOCDEXl7O6cDp+NDCuDZoYYvo5K+L3ILX03Q4Us1BevgmZQK+Z+r8a4ShQ==}
+    engines: {node: '>=18.0.0'}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -4231,6 +4242,12 @@ snapshots:
   '@strudel/mini@1.2.6':
     dependencies:
       '@strudel/core': 1.2.6
+
+  '@strudel/mondo@1.1.6':
+    dependencies:
+      '@strudel/core': 1.2.6
+      '@strudel/transpiler': 1.2.6
+      mondolang: 1.1.2
 
   '@strudel/soundfonts@1.3.0':
     dependencies:
@@ -6151,6 +6168,8 @@ snapshots:
       ufo: 1.6.3
 
   monaco-editor@0.50.0: {}
+
+  mondolang@1.1.2: {}
 
   ms@2.0.0: {}
 


### PR DESCRIPTION
## Wave α of Phase 20-14 — Strudel.cc Parity (closes #110 at γ)

Mirrors upstream `strudel.cc`'s audio-pure bootstrap into `StrudelEngine.init()` and introduces the 8-flag tier schema that β consumes. Audibly verified against 3 user-reported observations + 4 console gates on 2026-05-15; all 1526 editor tests + 297 app tests green.

Upstream pin: `codeberg.org/uzu/strudel` @ `f73b395648645aabe699f91ba0989f35a6fd8a3c` (2026-05-07). Upstream moved from GitHub to Codeberg — `tidalcycles/strudel` is frozen.

### What landed (7 atomic commits)

| Task | Commit | What |
|---|---|---|
| α-1 | `84839b3` | Add `@strudel/mondo` to `evalScope` — verified `globalThis.mondo` is a function. `@strudel/edo` not yet on npm; tracked at #121. |
| α-2 | `798790c` | 6 b-cdn sample-manifest fetches (piano, drum-machines, vcsl, uzu-drumkit, uzu-wavetables, mridangam) — unlocks `s(\"piano\")` (closes the issue #110 silent gap) and `.bank(\"tr909\")`. |
| α-3 | `6a7556e` | `aliasBank()` fetch — adds `RolandTR909 → 909` etc. Includes a runtime gate: boot log `[StrudelEngine] aliasBank: soundMap keys X → Y (Δ ≥0)` confirms merge semantics (not replace). |
| α-4 | `28c9a33` | Vendor upstream `piano.mjs` for `Pattern.prototype.piano` — verified the chain survives Stave's `.p()` setter trap (open question #1 from RESEARCH §7 resolved). License-compatible: both AGPL-3.0-or-later. |
| α-5 | `4b91097` | Tier flag schema (`csound, tidal, midi, osc, serial, gamepad, motion, mqtt`) — boot log `[StrudelEngine] tierFlags read at init:` confirms init consumes it. UI lands in β. |
| α-6 | `cf80a16` | `settingPatterns` audit — RESEARCH §7 question #5: verdict UI-only, no audio gap. |
| α-7 | `a210c79` | α-wave SUMMARY with per-task observation citations. |

### Verification (2026-05-15 live)

All 7 verification gates from `20-14-α-SUMMARY.md`:

- ✅ `[typeof globalThis.mondo, typeof globalThis.mondolang]` → `[\"function\", \"function\"]`
- ✅ Boot log `aliasBank: soundMap keys X → Y` with non-negative Δ
- ✅ Boot log `tierFlags read at init: { … 8 falses … }`
- ✅ `typeof Pattern.prototype.piano` → `\"function\"` (both BEFORE and AFTER one `evaluate()` cycle — load-bearing for RESEARCH §7 open question #1)
- ✅ `s(\"piano\").note(\"c3 e3 g3 b3\").slow(2)` plays Salamander piano (NOT GM soundfont)
- ✅ `s(\"[bd <hh oh>]*2\").bank(\"tr909\").dec(.4)` plays TR-909
- ✅ `note(\"c4 e4 g4 c5\").piano().slow(2)` plays piano chain

### Deviations from PLAN

- **α-1 dropped `@strudel/edo`** — upstream references it but it's not published to npm (`registry.npmjs.org/@strudel%2fedo` → 404 on 2026-05-15). Only `@strudel/mondo` added. Tracked at #121.
- **α-4 test mock additions** — extended `@strudel/core` test mock with stub `noteToMidi`/`valueToMidi` returns; the vendored `piano.ts` imports these. Minimal additive change.

### Catalogue candidates (deferred to post-merge)

- Hetvabhasa: \"upstream module referenced by loadModules but unpublished to npm\" (α-1)
- Krama: \"aliasBank MUST run AFTER manifest fetches — its body walks `soundMap` suffixes\" (α-3 static verify)

### Out of scope

- β-wave (alias layer + tier UI toggles) — next PR
- γ-wave (parity corpus + CI gate) — closes #110
- The 7 non-MIDI tier flags do nothing yet — wired in β-wave/follow-ups per the tier-UI honesty rule in PLAN §2.

### Surfaced during α verification (not blocking)

- **Live-mode phantom slot bug** (#122) — adding `\$:` rows one-by-one in live mode produces empty `d1` phantoms; transport-edge reset (stop + play) clears them. Pre-existing live-mode trade-off from PR #119, not introduced by α.

### Refs

- Phase plan: `.planning/phases/20-musician-timeline/20-14-PLAN.md`
- α SUMMARY: `.planning/phases/20-musician-timeline/20-14-α-SUMMARY.md`
- Issue tracking parent: #110
- Upstream pin doc: `20-14-RESEARCH.md` SHA `f73b395648645aabe699f91ba0989f35a6fd8a3c`

### Test plan

- [x] `pnpm --filter @stave/editor test` — 1526/1526 green
- [x] `pnpm --filter @stave/app test` — 297 green
- [x] Manual: 7 audible + console observation gates above
- [ ] Reviewer: confirm `Pattern.prototype.piano` survives one `evaluate()` cycle in their environment (this is the load-bearing trap for RESEARCH §7 Q1)