### PR TITLE
Phase 20-14 β: alias layer + tier UI + friendly-error integration

### DIFF
--- a/.planning/phases/20-musician-timeline/20-14-β-SUMMARY.md
+++ b/.planning/phases/20-musician-timeline/20-14-β-SUMMARY.md
@@ -1,0 +1,326 @@
+---
+phase: 20-14
+wave: β
+title: Alias layer + tier UI — strudel.cc parity β-wave SUMMARY
+created: 2026-05-15
+branch: feat/20-14-strudel-parity-beta
+commits: β-1..β-5 inclusive
+stacked_on: feat/20-14-strudel-parity (α PR #123)
+---
+
+# Phase 20-14 — β-Wave SUMMARY
+
+β-wave closes the silent-`s("piano")` UX gap class for real-world DAW/
+tracker vocabulary, exposes the tier-flag schema that α-5 introduced as
+a real settings surface, and threads the first tier flag (MIDI) all the
+way through engine boot. Five commits, five tasks. Test-suite checks
+(editor 1536/1536, app 297/297) confirm no regressions; browser-side
+gates require the user to reload-and-eval because the executor cannot
+drive the running dev-server tab.
+
+## Per-task observations
+
+### β-1 — Hand-curated alias map
+
+Commit `808c774`. New module `packages/editor/src/engine/aliases.ts`
+exports a frozen `SOUND_ALIASES` map (30 entries) plus a `resolveAlias`
+helper. Coverage is deliberate, not encyclopedic — each entry is a
+DAW/tracker term that maps to a Dirt-Samples canonical name:
+
+| Family | Entries |
+|---|---|
+| Kick | `kick`, `bassdrum` → `bd` |
+| Snare | `snare`, `snaredrum` → `sd` |
+| Hats | `hat`, `hihat`, `closedhat` → `hh`; `openhat`, `openhihat` → `oh` |
+| Claps / rims | `clap`, `handclap` → `cp`; `rim`, `rimshot`, `sidestick` → `rs` |
+| Cymbals | `crash`, `crashcymbal`, `cymbal` → `cr`; `ride`, `ridecymbal` → `rd` |
+| Toms | `tom`, `midtom` → `mt`; `lowtom`, `floortom` → `lt`; `hightom` → `ht` |
+| Percussion | `cowbell`, `bell` → `cb`; `tambourine` → `tb`; `shaker` → `sh`; `clave` → `cl` |
+
+Excluded by curation rule (per RESEARCH §7 #4): any bare name already
+registered post-α. `piano` self-alias dropped because Salamander
+`piano.json` registers it directly. Conga/bongo dropped because
+Dirt-Samples already has them. The aim is "first-time UX fix," not
+"thesaurus." New entries land via PR (D-02 forbids runtime JSON fetch);
+header comment cites the precedence rule from RESEARCH §3.
+
+**Observation (executor-run):** editor test suite 1526/1526 passing —
+the alias map is pure data; no runtime side effects. Static-only
+addition.
+
+### β-2 — Strategy A intercept in `wrappedOutput` + accumulator
+
+Commit `7291313`. Insertion site: top of `wrappedOutput` BEFORE the
+breakpoint hit-check (RESEARCH §3 anchor preserved post-α). Reads
+`hap.value.s`; guard `liveSoundMap[lower] === undefined` ensures user-
+registered names ALWAYS win (the Strategy A precedence locked in
+CONTEXT D-02 invariant #2 and RESEARCH §7 #4). On a hit:
+
+1. Push `{from, to}` onto `this.lastAliasResolutions` (instance field,
+   per checker β-2/β-5 cross-reference fix — NOT module state, so
+   concurrent engines do not collide).
+2. Shallow-clone `hap.value` with the rewritten `s` — downstream
+   consumers see a stable hap shape.
+
+The live `soundMap` reference is captured on `this.soundMapRef` at init
+(same reference α-3 already stashed in a local — promoted to instance
+state). Live read, not snapshot — a user `samples(...)` call between
+init and trigger is honored.
+
+Accumulator reset is the **first statement** of `evaluate()` after
+`lastEvaluatedCode`. PLAN explicitly forbade burying it in a helper.
+
+**Observation (executor-run):** editor test suite 1526/1526 passing.
+The mocked `soundMap.get()` returns `{}` in test env, which is exactly
+the "name not registered" branch — the intercept correctly no-ops on
+the mock haps emitted by the test fixture (`s: "inst_N"`, where the
+alias map has no entry).
+
+**Browser-side gate (user-verify, REQUIRED for β closure):** open the
+running dev server <http://localhost:3000>, evaluate
+```
+$: s("kick").n(0)
+```
+Expected: audio plays a Dirt-Samples kick (the same as `s("bd")`).
+Then in the dev console:
+```js
+// peek the live engine via the runtime registry
+const fid = Object.keys(stave.runtimes ?? {})[0];
+const eng = stave.runtimes?.[fid]?.engine;
+eng?.getLastAliasResolutions?.()
+```
+Expected: `[{ from: 'kick', to: 'bd' }, ...]` after the eval.
+Confirm `soundMap.get().kick === undefined` to verify autocomplete is
+NOT polluted (D-02 invariant #1).
+
+### β-3 — Strudel module tier toggles in `EditorSettingsModal`
+
+Commit `5fb0583`. New "Strudel modules" section appended to the
+existing settings modal. The 8 tier flags are wired as follows:
+
+| Tier | Status | Follow-up |
+|---|---|---|
+| **midi** | **Interactive** (β-4 wires it to `enableWebMidi()`) | — |
+| csound | Disabled-scaffolded | #124 |
+| tidal | Disabled-scaffolded | #125 |
+| osc | Disabled-scaffolded | #126 |
+| serial | Disabled-scaffolded | #127 |
+| gamepad | Disabled-scaffolded | #128 |
+| motion | Disabled-scaffolded | #129 |
+| mqtt | Disabled-scaffolded | #130 |
+
+Each disabled row carries a `title="Module wiring planned — see issue
+#NNN."` tooltip on hover (renders via native browser tooltip on the
+`<label>` wrapping the disabled checkbox). Cursor switches to
+`not-allowed` and opacity drops to 0.55 so the disabled state is
+visually unambiguous. Csound + Tidal rows additionally show
+`Will load ~6 MB when enabled.` so users don't toggle them on
+expecting a small change.
+
+Section footnote `Changes take effect when you reload the page.`
+codifies the α-5 contract ("engine reads tierFlags once at init").
+
+A dev-only `assertTierSchemaCoverage()` fires on modal open: if the
+schema's `listTiers()` and the wired `TIER_ROWS` ever diverge, the
+dev console warns. The contract surface for adding a new tier is "add
+to TierName + add to TIER_ROWS" — the warning catches the half-done
+case.
+
+**Observation (executor-run):** editor 1526/1526 + app 297/297 green.
+
+**Browser-side gate (user-verify, REQUIRED for β closure):**
+1. Open the running app, click the settings cog → modal opens. Scroll
+   to the "Strudel modules" section. Confirm visually:
+   - 8 rows present (MIDI, Csound, TidalCycles, OSC, Serial, Gamepad,
+     Motion, MQTT).
+   - 7 rows are visibly dimmed (opacity ~0.55).
+   - Hover any dimmed row's checkbox — the
+     `Module wiring planned — see issue #NNN` tooltip appears.
+   - Footnote `Changes take effect when you reload the page.` is
+     visible and not clipped.
+2. Click the MIDI checkbox. The state toggles. Close modal, reload.
+   Re-open modal — MIDI is still on. Dev console shows
+   `[StrudelEngine] tierFlags read at init: { ..., midi: true, ... }`.
+3. Click a disabled checkbox (e.g. Csound). The state does NOT change,
+   no localStorage write — `localStorage.getItem('stave.strudel.tier.csound')`
+   still reads `null` (or `"0"` if previously written).
+
+The follow-up issues #124–#130 are filed and each links back to PLAN §7
+heavy-module dynamic-import wiring. Each issue carries an acceptance
+checklist for flipping its row from disabled to interactive.
+
+### β-4 — Thread `midi` tier flag through engine init
+
+Commit `b803767`. The static comment block at the original
+StrudelEngine.ts:200 ("enableWebMidi() is NOT called here") is replaced
+with a conditional: when `this.tierFlags?.midi === true`, the engine
+calls `await enableWebMidi()` after `evalScope` resolves so
+`Pattern.prototype.midi` chain methods activate at the same lifecycle
+moment they would on upstream strudel.cc.
+
+The module import (`@strudel/midi`) stays unconditional — 80 KB is
+audio-pure and was already paying its bundle cost in α. Only the
+permission-triggering call is gated. The permission-denial path is
+wrapped in try/catch: engine boot survives even if the browser refuses
+MIDI access.
+
+The other 7 flags are deliberately NOT threaded here. Each carries its
+own follow-up issue (#124–#130) where the conditional `await import()`
++ row-flip lands as one atomic PR per module.
+
+**Observation (executor-run):** 1526/1526 green; the mock for
+`@strudel/midi` is `{}`, so the typeof-function guard
+(`typeof enableWebMidi === 'function'`) short-circuits and the engine
+boots without attempting the call. No false-positive permission prompt
+inside vitest.
+
+**Browser-side gate (user-verify):** With MIDI flag OFF (default after
+clean state), boot — no permission prompt. Enable MIDI in settings,
+reload page — browser shows MIDI permission dialog during engine init
+(early-prompt UX per RESEARCH §4). Decline → console shows
+`[StrudelEngine] enableWebMidi() failed; MIDI output unavailable.`
+and the engine continues. Accept → `Pattern.prototype.midi` is callable
+from user code.
+
+### β-5 — Friendly-error message integration
+
+Commit `3143129`. Two-touch addition in `friendlyErrors.ts`:
+
+1. `FormatOptions.aliasContext` is the new opt-in surface. It accepts
+   `resolutions` (from `engine.getLastAliasResolutions()`) and
+   `lookupAlias` (the `resolveAlias` fn from β-1).
+2. `buildAliasSuffix(missingName, ctx)` is the pure suffix-builder.
+   `formatFriendlyError` calls it once and appends to all 4 return
+   paths (mistake hit, fuzzy hit, fuzzy miss, raw).
+
+The accumulator-write side (β-2) is the load-bearing change; β-5 is
+cosmetic message text. New unit tests cover:
+- Empty / missing context → empty string.
+- Single + deduplicated resolutions.
+- Miss-path branches (no entry / entry-but-target-not-loaded).
+- Combined resolved + miss suffix.
+- Integration through `formatFriendlyError` (3 cases).
+
+`buildAliasSuffix` deduplicates `from→to` keys so a hot pattern firing
+10 cycles of the same alias does not drown the message.
+
+The `detect.alias` field at friendlyErrors.ts:240 is left untouched
+(per PLAN — orthogonal CommonMistake mechanism, different layer).
+
+**Observation (executor-run):** editor 1536/1536 (+10 new tests),
+app 297/297 unchanged.
+
+**Browser-side gate (user-verify):**
+1. Eval `$: s("kick")` — no error. (Sanity: alias hit, no friendly
+   message fires.)
+2. Eval `$: s("xyz123")` — friendly error in the console pane shows
+   `sound xyz123 not found! Is it loaded? (alias map: no entry for
+   xyz123)`.
+3. Eval `$: s("bell")` (when the cowbell sample isn't yet loaded by
+   superdough — bell aliases to `cb` per β-1) — friendly error shows
+   `sound bell not found! Is it loaded? (tried alias` bell `→` cb`;
+   alias map:` bell `→` cb `(but` cb `is not loaded))`. If `cb` IS
+   loaded (Dirt-Samples cowbell), the rewrite happens silently and no
+   error fires — that's the resolved-path success case.
+
+## Tier wiring matrix (β-3 + β-4)
+
+The single sentence reviewers care about: **MIDI is the only
+functional toggle in β; the other 7 are visible-but-disabled
+scaffolds, each with a filed follow-up issue.** Reviewers scanning β-6
+for "which toggles work" should learn from this table:
+
+| Tier | Functional? | Tooltip / Follow-up |
+|---|---|---|
+| midi | ✅ Wired (β-4 calls `enableWebMidi()` based on `this.tierFlags.midi`) | — |
+| csound | ❌ Disabled-scaffolded | `Module wiring planned — see issue #124.` |
+| tidal | ❌ Disabled-scaffolded | `Module wiring planned — see issue #125.` |
+| osc | ❌ Disabled-scaffolded | `Module wiring planned — see issue #126.` |
+| serial | ❌ Disabled-scaffolded | `Module wiring planned — see issue #127.` |
+| gamepad | ❌ Disabled-scaffolded | `Module wiring planned — see issue #128.` |
+| motion | ❌ Disabled-scaffolded | `Module wiring planned — see issue #129.` |
+| mqtt | ❌ Disabled-scaffolded | `Module wiring planned — see issue #130.` |
+
+The visible-but-disabled choice (over hide-entirely) is the
+load-bearing UX decision from PLAN §2: musicians coming from
+strudel.cc see the row exists and Stave knows about the tier, so they
+don't assume Stave silently dropped support. Each follow-up issue, when
+it ships, flips exactly one row from disabled to interactive — no
+cascading UI work.
+
+## β verification gate status
+
+Per PLAN §4:
+
+| Gate item | Status | Source |
+|---|---|---|
+| `s("piano")`, `s("kick")`, `s("snare")`, `s("clap")` play without `gm_*` prefix | ⏳ user-verify (browser-side audio) | β-2 paragraph snippet |
+| `soundMap.get().kick === undefined` (autocomplete clean) | ⏳ user-verify | β-2 paragraph snippet |
+| 8 toggles in settings; MIDI interactive, 7 disabled with tooltip | ⏳ user-verify (screenshot) | β-3 paragraph |
+| MIDI toggle persists across reload + reads true in init log | ⏳ user-verify | β-3 + β-4 paragraphs |
+| MIDI permission prompt fires only after toggle-on + reload | ⏳ user-verify | β-4 paragraph |
+| Friendly errors show alias-resolution suffix on 3 test cases | ⏳ user-verify (browser-side eval) | β-5 paragraph |
+| Existing test suite remains green | ✅ executor | editor 1536/1536; app 297/297 |
+| Follow-up issues filed for 7 disabled tier toggles | ✅ executor | #124–#130 |
+
+## Catalogue candidates (deferred for promotion review)
+
+Per executor operational rules, `.anvi/` catalogues are not updated
+mid-wave. Candidates noticed in β to consider after β merges:
+
+- **hetvabhasa candidate**: "PRE-α `wrappedOutput` was the natural alias
+  intercept site for two reasons that have to fire TOGETHER — (a) it sits
+  POST-reify (so `hap.value.s` is a string, not a Pattern, per P1) AND
+  (b) it sits BEFORE the breakpoint hit-check (so a rewrite cannot
+  desync the breakpoint-vs-superdough name resolution). Insertion sites
+  that satisfy only one of these conditions silently break the other
+  invariant." Promote if a third pre-superdough intercept site (e.g.,
+  per-orbit transform, midi-output remap) follows the same pair.
+
+- **vyapti candidate**: "Per-evaluate accumulators owned by the engine
+  must reset at evaluate() entry, NOT inside the run-tail. The reset
+  MUST be a top-of-function statement, not buried in a helper, because
+  the helper may be skipped on the eval-error path — leaving stale
+  state visible to next eval's friendly-error builder." Confirmed via
+  β-2 (lastAliasResolutions) — would have applied to other engine
+  per-eval state if any existed. Promote on second instance.
+
+- **krama candidate**: "tier-flag read happens at init() ONCE; any UI
+  surface that exposes a toggle must carry an explicit
+  `Changes take effect on reload` caption — without it, users mistake
+  the read-once contract for a bug." Confirmed via β-3. Lifecycle
+  entry: schema-read-once boundary is itself a lifecycle stage that
+  invites the wrong UX assumption.
+
+## UX decisions carried into γ
+
+- **Bare-name alias precedence is locked**: user-registered names
+  ALWAYS win over the curated map. γ-2 corpus tests assume this
+  invariant — any future PR that flips it must update γ-2 baselines
+  and call out the inversion in the PR body.
+- **Tier follow-up issues #124–#130 stay parallel**, not stacked. Each
+  is one atomic PR that flips one row from disabled to interactive.
+  None of them should ship "with deps on the others" — keep the
+  blast radius one tier wide.
+
+## Open questions resolution status (mapped to PLAN §6)
+
+| # | Question | β-wave status |
+|---|---|---|
+| 4 | Pre-init alias lookup race | **Resolved** — Strategy A guard reads live `soundMap.get()`; user-registered names override curated map. β-1 header comment documents the precedence rule. |
+
+Other PLAN §6 questions remain at their α-wave verdict (1, 2, 3, 5 in
+α-7 SUMMARY; 6, 7 deferred to γ).
+
+## Out of scope (still queued, unchanged from α-7)
+
+- Per-file `await tier(...)` directive (D-03 part B).
+- γ corpus + CI gate (Wave γ).
+- 7 tier-wiring follow-ups (#124–#130).
+- Post-init `samples()` autocomplete pollution.
+- Pianoroll / scope re-export decision.
+- b-cdn.net availability monitoring.
+
+β branch is ready for user-side reload-and-verify pass + PR. The PR
+will stack on α (#123); when α merges to main, this branch rebases
+automatically and the PR base auto-converts.

--- a/packages/app/src/components/EditorSettingsModal.tsx
+++ b/packages/app/src/components/EditorSettingsModal.tsx
@@ -14,7 +14,12 @@ import {
   setMusicalTimelineSubRowHeight,
   getEditorTheme,
   setEditorTheme,
+  getTierFlags,
+  setTierFlag,
+  listTiers,
   type EditorTheme,
+  type TierFlags,
+  type TierName,
 } from "@stave/editor";
 
 interface Props {
@@ -28,6 +33,111 @@ const THEME_OPTIONS: { value: EditorTheme; label: string }[] = [
   { value: "system", label: "System" },
 ];
 
+// Phase 20-14 β-3 — Strudel modules tier UI. Only MIDI is wired today
+// (β-4 calls `enableWebMidi()` based on `tierFlags.midi`). The other 7
+// ship as disabled-scaffolded toggles. Each row carries:
+//   - a one-sentence description for what the module DOES
+//   - the follow-up issue number for the wiring work (rendered into the
+//     "Module wiring planned" tooltip)
+//   - an optional size hint (csound + tidal — large dynamic imports)
+//
+// Rationale for ship-disabled-not-hidden (per 20-14-PLAN.md §2 "tier-flag
+// UI honesty"): the schema IS the contract. Showing the disabled toggles
+// signals "Stave knows about csound, just not wired yet" to musicians
+// coming from strudel.cc, which prevents the worse failure mode of users
+// assuming Stave silently dropped a tier.
+interface TierRow {
+  name: TierName;
+  label: string;
+  description: string;
+  /** GitHub issue number for the wiring follow-up. */
+  issueNumber: number | null;
+  /** Only true for MIDI in β-3. The other 7 render disabled. */
+  interactive: boolean;
+  /** Extra caption for heavy modules (csound, tidal). */
+  sizeHint?: string;
+}
+
+const TIER_ROWS: TierRow[] = [
+  {
+    name: "midi",
+    label: "MIDI",
+    description: "Send notes to external MIDI devices.",
+    issueNumber: null,
+    interactive: true,
+  },
+  {
+    name: "csound",
+    label: "Csound",
+    description: "Csound synthesis (loadCsound template).",
+    issueNumber: 124,
+    interactive: false,
+    sizeHint: "Will load ~6 MB when enabled.",
+  },
+  {
+    name: "tidal",
+    label: "TidalCycles",
+    description: "Haskell-via-WASM TidalCycles interop.",
+    issueNumber: 125,
+    interactive: false,
+    sizeHint: "Will load ~6 MB when enabled.",
+  },
+  {
+    name: "osc",
+    label: "OSC",
+    description: "Send OSC messages (needs SuperCollider backend).",
+    issueNumber: 126,
+    interactive: false,
+  },
+  {
+    name: "serial",
+    label: "Serial",
+    description: "WebSerial output to microcontrollers / Eurorack.",
+    issueNumber: 127,
+    interactive: false,
+  },
+  {
+    name: "gamepad",
+    label: "Gamepad",
+    description: "Read gamepad input as pattern values.",
+    issueNumber: 128,
+    interactive: false,
+  },
+  {
+    name: "motion",
+    label: "Motion",
+    description: "DeviceMotion (accelerometer / gyro) input.",
+    issueNumber: 129,
+    interactive: false,
+  },
+  {
+    name: "mqtt",
+    label: "MQTT",
+    description: "MQTT broker pub/sub.",
+    issueNumber: 130,
+    interactive: false,
+  },
+];
+
+// Schema-vs-UI safety: if listTiers() ever drifts from TIER_ROWS, the
+// app warns at dev time. Mismatched contract surface is a class of bug
+// we want to catch immediately, not on a reload that drops a row.
+function assertTierSchemaCoverage(): void {
+  if (typeof window === "undefined") return;
+  const declared = new Set(listTiers());
+  const wired = new Set(TIER_ROWS.map((r) => r.name));
+  for (const n of declared) {
+    if (!wired.has(n)) {
+      console.warn(`[EditorSettingsModal] tier "${n}" missing from TIER_ROWS — UI will not surface it.`);
+    }
+  }
+  for (const n of wired) {
+    if (!declared.has(n)) {
+      console.warn(`[EditorSettingsModal] tier "${n}" is in TIER_ROWS but not in listTiers() schema.`);
+    }
+  }
+}
+
 export function EditorSettingsModal({ open, onClose }: Props) {
   const [fontSize, setFontSize] = useState(14);
   const [minimap, setMinimap] = useState(false);
@@ -35,6 +145,11 @@ export function EditorSettingsModal({ open, onClose }: Props) {
   const [vizActionSize, setVizActionSize] = useState(11);
   const [subRowHeight, setSubRowHeight] = useState(18);
   const [theme, setTheme] = useState<EditorTheme>("dark");
+  // Phase 20-14 β-3 — Strudel tier flags. Mid-session toggle changes are
+  // NOT observed by the engine until reload (the engine reads tierFlags
+  // ONCE at init per α-5); the caption below the section makes that
+  // contract visible.
+  const [tierFlags, setTierFlagsState] = useState<TierFlags | null>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -44,6 +159,8 @@ export function EditorSettingsModal({ open, onClose }: Props) {
     setVizActionSize(getInlineVizActionSize());
     setSubRowHeight(getMusicalTimelineSubRowHeight());
     setTheme(getEditorTheme());
+    setTierFlagsState(getTierFlags());
+    assertTierSchemaCoverage();
     const h = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
     window.addEventListener("keydown", h);
     return () => window.removeEventListener("keydown", h);
@@ -147,6 +264,52 @@ export function EditorSettingsModal({ open, onClose }: Props) {
               ))}
             </select>
           </Row>
+          {/* Phase 20-14 β-3 — Strudel modules tier UI. MIDI is the only
+              wired row in β-3; the other 7 are disabled scaffolds, one
+              follow-up issue per row (see TIER_ROWS at top of file). */}
+          <div style={s.sectionDivider} />
+          <div style={s.sectionTitle}>Strudel modules</div>
+          {TIER_ROWS.map((row) => {
+            const checked = tierFlags?.[row.name] ?? false;
+            const disabledTooltip = row.issueNumber
+              ? `Module wiring planned — see issue #${row.issueNumber}.`
+              : "Module wiring planned.";
+            return (
+              <Row key={row.name} label={row.label}>
+                <label
+                  style={{
+                    ...s.switchLabel,
+                    cursor: row.interactive ? "pointer" : "not-allowed",
+                    opacity: row.interactive ? 1 : 0.55,
+                  }}
+                  title={row.interactive ? undefined : disabledTooltip}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    disabled={!row.interactive}
+                    onChange={() => {
+                      if (!row.interactive) return;
+                      const next = !checked;
+                      setTierFlag(row.name, next);
+                      setTierFlagsState((prev) =>
+                        prev ? { ...prev, [row.name]: next } : prev,
+                      );
+                    }}
+                  />
+                  <span style={s.tierDesc}>
+                    {row.description}
+                    {row.sizeHint ? (
+                      <span style={s.tierSizeHint}> {row.sizeHint}</span>
+                    ) : null}
+                  </span>
+                </label>
+              </Row>
+            );
+          })}
+          <div style={s.tierFootnote}>
+            Changes take effect when you reload the page.
+          </div>
         </div>
       </div>
     </div>
@@ -196,5 +359,19 @@ const s: Record<string, React.CSSProperties> = {
     background: "var(--bg-active)", border: "1px solid var(--border-strong)", borderRadius: 4,
     color: "var(--text-primary)", padding: "4px 10px", fontSize: 12,
     cursor: "pointer", fontFamily: "inherit", minWidth: 140,
+  },
+  // β-3 — tier UI styling.
+  sectionDivider: {
+    height: 1, background: "var(--border-subtle)", margin: "8px 0 4px 0",
+  },
+  sectionTitle: {
+    fontSize: 12, fontWeight: 600, color: "var(--text-primary)",
+    marginBottom: 4,
+  },
+  tierDesc: { fontSize: 11, color: "var(--text-secondary)" },
+  tierSizeHint: { color: "var(--text-tertiary)" },
+  tierFootnote: {
+    fontSize: 11, color: "var(--text-tertiary)", marginTop: 4,
+    fontStyle: "italic",
   },
 };

--- a/packages/app/src/components/StrudelEditorClient.tsx
+++ b/packages/app/src/components/StrudelEditorClient.tsx
@@ -29,6 +29,7 @@ import {
   emitLog,
   emitFixed,
   formatFriendlyError,
+  resolveAlias,
   collectCycles,
   runPasses,
   publishIRSnapshot,
@@ -307,7 +308,21 @@ export default function StrudelEditorClient({
       const fileNow = getFile(fileId);
       const runtimeId: RuntimeId = fileNow?.language === "sonicpi" ? "sonicpi" : "strudel";
       const index: DocsIndex = runtimeId === "sonicpi" ? SONICPI_DOCS_INDEX : STRUDEL_DOCS_INDEX;
-      const parts = formatFriendlyError(err, runtimeId, { index });
+      // Phase 20-14 β-5 — pull the per-eval alias resolutions off the
+      // engine instance (StrudelEngine-only — duck-typed so non-Strudel
+      // engines harmlessly pass `undefined`). The friendly-error builder
+      // appends "tried alias `kick` → `bd`" on the resolved path and
+      // "alias map: no entry for `xyz`" on the miss path.
+      const engineWithAlias = engine as unknown as {
+        getLastAliasResolutions?: () => ReadonlyArray<{ from: string; to: string }>;
+      };
+      const aliasResolutions = engineWithAlias.getLastAliasResolutions?.();
+      const parts = formatFriendlyError(err, runtimeId, {
+        index,
+        aliasContext: runtimeId === "strudel"
+          ? { resolutions: aliasResolutions, lookupAlias: resolveAlias }
+          : undefined,
+      });
       // Strudel routes user code through `@strudel/transpiler`, which
       // rewrites `$:` sugar into method calls and wraps everything in
       // an async IIFE. The resulting wrapper offset is NOT constant —

--- a/packages/editor/src/engine/StrudelEngine.ts
+++ b/packages/editor/src/engine/StrudelEngine.ts
@@ -10,6 +10,7 @@ import { propagate, StrudelParseSystem, IREventCollectSystem } from '../ir/propa
 import type { PatternIR } from '../ir/PatternIR'
 import type { IREvent } from '../ir/IREvent'
 import { getTierFlags, type TierFlags } from './tierFlags'
+import { resolveAlias } from './aliases'
 
 type HapHandler = (event: HapEvent) => void
 
@@ -126,9 +127,37 @@ export class StrudelEngine implements LiveCodingEngine {
   // take effect on reload" caption.
   private tierFlags: TierFlags | null = null
 
+  // Phase 20-14 β-2 — alias-resolution accumulator. Reset at `evaluate()`
+  // entry; appended to by `wrappedOutput` whenever the alias map rewrites
+  // a hap's `s` field. β-5's friendly-error builder reads this to surface
+  // "tried alias `kick` → `bd` (resolved)" on a related error. Owned by
+  // the engine instance (NOT module state) so concurrent engines don't
+  // collide and a stale accumulator can't leak across evals.
+  private lastAliasResolutions: Array<{ from: string; to: string }> = []
+
+  // Phase 20-14 β-2 — live reference to superdough's `soundMap`. Captured
+  // at init() (when `@strudel/webaudio` resolves). `wrappedOutput` reads
+  // `soundMap.get()[name]` at trigger time to honour the Strategy A guard
+  // — user-registered names always win over the curated alias map.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private soundMapRef: any = null
+
   /** Read-only snapshot of the tier flags consumed at this engine's init(). */
   getTierFlagsSnapshot(): Readonly<TierFlags> | null {
     return this.tierFlags
+  }
+
+  /**
+   * Phase 20-14 β-2 — read-only snapshot of alias rewrites that have fired
+   * during the current evaluate() window. Each entry is one hap rewrite;
+   * the same `from → to` pair may appear multiple times if the rewrite
+   * fired across multiple cycles.
+   *
+   * Lifecycle: reset to empty at `evaluate()` entry, appended to by
+   * `wrappedOutput`, read by friendlyErrors at message-build time.
+   */
+  getLastAliasResolutions(): ReadonlyArray<{ from: string; to: string }> {
+    return this.lastAliasResolutions
   }
 
   async init(): Promise<void> {
@@ -304,6 +333,10 @@ export class StrudelEngine implements LiveCodingEngine {
     // Wrapped in try/catch for the same boot-resilience reason as α-2.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const soundMapRef = (webaudioMod as any).soundMap
+    // β-2 — stash the live soundMap on the instance so wrappedOutput's
+    // Strategy A guard can read it at trigger time. Live read (not snapshot);
+    // user `samples()` calls between init and trigger should be honored.
+    this.soundMapRef = soundMapRef
     const preAliasCount = soundMapRef?.get ? Object.keys(soundMapRef.get()).length : 0
     try {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -349,6 +382,33 @@ export class StrudelEngine implements LiveCodingEngine {
     //   t = current AudioContext.currentTime
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const wrappedOutput = async (hap: any, deadline: number, duration: number, cps: number, t: number) => {
+      // Phase 20-14 β-2 — Strategy A sound-alias intercept. We are POST-
+      // reify (P1): `hap.value.s` is the final per-event string Strudel's
+      // scheduler resolved. If the bare name is not in the live soundMap
+      // AND the curated alias map has a target, rewrite the hap so
+      // superdough sees the canonical name. User-registered names ALWAYS
+      // win (RESEARCH §3 + §7 open-question #4). Sub-microsecond per hap
+      // (one Map.get + one Object index lookup); negligible vs scheduler
+      // overhead.
+      const rawS = hap?.value?.s
+      if (typeof rawS === 'string') {
+        const lower = rawS.toLowerCase()
+        // Live read — user `samples(...)` calls between init and trigger
+        // should be honored.
+        const liveSoundMap: Record<string, unknown> | undefined =
+          this.soundMapRef?.get?.() ?? undefined
+        if (!liveSoundMap || liveSoundMap[lower] === undefined) {
+          const aliased = resolveAlias(rawS)
+          if (aliased && aliased !== rawS) {
+            this.lastAliasResolutions.push({ from: rawS, to: aliased })
+            // Shallow clone the value so downstream consumers that snapshot
+            // the original hap reference see a stable shape; only this hap's
+            // `s` is rewritten for the audio side.
+            hap.value = { ...hap.value, s: aliased }
+          }
+        }
+      }
+
       // Phase 20-07 (T-α-2) — emit returns the enriched HapEvent so the
       // breakpoint hit-check below reads `irNodeId` in O(1) without
       // re-running findMatchedEvent. P50 single-strategy match preserved.
@@ -399,6 +459,12 @@ export class StrudelEngine implements LiveCodingEngine {
   async evaluate(code: string): Promise<{ error?: Error }> {
     if (!this.initialized) await this.init()
     this.lastEvaluatedCode = code
+    // Phase 20-14 β-2 — reset alias-resolution accumulator at the entry
+    // of every evaluate(). β-5's friendly-error builder reads this; a
+    // stale accumulator from a previous eval would surface aliases that
+    // are unrelated to the current error. Reset must be the FIRST
+    // statement after lastEvaluatedCode, NOT buried in a helper.
+    this.lastAliasResolutions = []
 
     const capturedPatterns = new Map<string, any>() // eslint-disable-line @typescript-eslint/no-explicit-any
     const capturedVizRequests = new Map<string, string>()

--- a/packages/editor/src/engine/StrudelEngine.ts
+++ b/packages/editor/src/engine/StrudelEngine.ts
@@ -197,12 +197,42 @@ export class StrudelEngine implements LiveCodingEngine {
     // Register all module exports into globalThis so eval'd patterns can use them
     // (note, s, gain, stack, etc. must be globals — user code runs in Function())
     // midi: uses onTrigger (additive) — highlighting still fires for every hap.
-    //        enableWebMidi() is NOT called here; users call it explicitly (triggers browser permission prompt).
+    //        enableWebMidi() is gated by the `midi` tier flag (β-4 below).
+    //        The module import is unconditional (80 KB, audio-pure); only
+    //        the permission-triggering call is gated.
     // drawMod (@strudel/draw) intentionally excluded: it injects a full-screen canvas
     // into document.body (id="test-canvas") the first time any draw function runs.
     // Stave uses its own visualizer system, so strudel's canvas draw functions
     // (pianoroll, drawFrequencyScope, etc.) are not exposed to user code.
     await coreMod.evalScope(coreMod, miniMod, tonalMod, webaudioMod, soundfontsMod, xenMod, midiMod, mondoMod)
+
+    // Phase 20-14 β-4: thread the `midi` tier flag through engine init.
+    // When the flag is ON, call `enableWebMidi()` after evalScope resolves so
+    // `Pattern.prototype.midi` and the WebMIDI hookup go live. The browser
+    // permission prompt fires during init (early-prompt UX per RESEARCH §4 +
+    // CONTEXT gray-area #3) — the settings row caption telegraphs this so
+    // the user opts in deliberately.
+    //
+    // When the flag is OFF (default), the call is skipped — preserves the
+    // pre-α behavior where `@strudel/midi` was loaded but no permission
+    // prompt fired. The other 7 tier flags (csound/tidal/osc/serial/gamepad/
+    // motion/mqtt) are NOT threaded here — each has its own follow-up issue
+    // (#124-#130) from β-3.
+    if (this.tierFlags?.midi) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const enableWebMidi = (midiMod as any)?.enableWebMidi
+        if (typeof enableWebMidi === 'function') {
+          await enableWebMidi()
+        } else {
+          console.warn('[StrudelEngine] tierFlags.midi is ON but @strudel/midi did not export enableWebMidi.')
+        }
+      } catch (err) {
+        // Browser-permission denial throws here. Log + continue — engine
+        // boot must succeed even if MIDI is unavailable.
+        console.warn('[StrudelEngine] enableWebMidi() failed; MIDI output unavailable.', err)
+      }
+    }
 
     // Set up mini-notation string parser (parses "c3 e3 g3" strings as patterns)
     miniMod.miniAllStrings()

--- a/packages/editor/src/engine/__tests__/friendlyErrors.test.ts
+++ b/packages/editor/src/engine/__tests__/friendlyErrors.test.ts
@@ -6,6 +6,7 @@ import {
   extractReferenceIdentifier,
   formatFriendlyError,
   parseStackLocation,
+  buildAliasSuffix,
 } from '../friendlyErrors'
 
 const FAKE_INDEX: DocsIndex = {
@@ -397,5 +398,84 @@ describe('formatFriendlyError — commonMistakes cascade', () => {
     expect(r.line).toBe(9)
     expect(r.column).toBe(1)
     expect(r.stack).toContain('Scheduler is not ready')
+  })
+})
+
+// Phase 20-14 β-5 — alias-resolution suffix on friendly errors.
+describe('buildAliasSuffix', () => {
+  it('returns empty when no aliasContext', () => {
+    expect(buildAliasSuffix(null, undefined)).toBe('')
+  })
+
+  it('returns empty when context is empty (no resolutions, no missing name)', () => {
+    expect(buildAliasSuffix(null, {})).toBe('')
+  })
+
+  it('surfaces a single resolution', () => {
+    const s = buildAliasSuffix(null, {
+      resolutions: [{ from: 'kick', to: 'bd' }],
+    })
+    expect(s).toBe(' (tried alias `kick` → `bd`)')
+  })
+
+  it('deduplicates repeated resolutions', () => {
+    const s = buildAliasSuffix(null, {
+      resolutions: [
+        { from: 'kick', to: 'bd' },
+        { from: 'kick', to: 'bd' },
+        { from: 'snare', to: 'sd' },
+      ],
+    })
+    expect(s).toBe(' (tried alias `kick` → `bd`, `snare` → `sd`)')
+  })
+
+  it('miss path — alias map has no entry for the missing name', () => {
+    const s = buildAliasSuffix('xyz', {
+      lookupAlias: (_n: string) => undefined,
+    })
+    expect(s).toBe(' (alias map: no entry for `xyz`)')
+  })
+
+  it('miss path — alias map has entry but target also not loaded', () => {
+    const s = buildAliasSuffix('bell', {
+      lookupAlias: (n: string) => (n === 'bell' ? 'cb' : undefined),
+    })
+    expect(s).toBe(
+      ' (alias map: `bell` → `cb` (but `cb` is not loaded))',
+    )
+  })
+
+  it('combines resolved and miss paths in one suffix', () => {
+    const s = buildAliasSuffix('xyz', {
+      resolutions: [{ from: 'kick', to: 'bd' }],
+      lookupAlias: () => undefined,
+    })
+    expect(s).toBe(
+      ' (tried alias `kick` → `bd`; alias map: no entry for `xyz`)',
+    )
+  })
+})
+
+describe('formatFriendlyError — alias suffix integration', () => {
+  it('appends alias suffix to "sound X not found" miss', () => {
+    const err = new Error('sound xyz not found! Is it loaded?')
+    const r = formatFriendlyError(err, 'strudel', {
+      aliasContext: { lookupAlias: () => undefined },
+    })
+    expect(r.message).toContain('alias map: no entry for `xyz`')
+  })
+
+  it('appends resolutions even when message is non-sound-related', () => {
+    const err = new Error('Something else went wrong')
+    const r = formatFriendlyError(err, 'strudel', {
+      aliasContext: { resolutions: [{ from: 'kick', to: 'bd' }] },
+    })
+    expect(r.message).toContain('tried alias `kick` → `bd`')
+  })
+
+  it('does NOT touch the message when aliasContext is absent', () => {
+    const err = new Error('sound xyz not found')
+    const r = formatFriendlyError(err, 'strudel', {})
+    expect(r.message).toBe('sound xyz not found')
   })
 })

--- a/packages/editor/src/engine/aliases.ts
+++ b/packages/editor/src/engine/aliases.ts
@@ -1,0 +1,112 @@
+// Phase 20-14 β-1 — hand-curated bare-name aliases for strudel.cc parity.
+//
+// Why this exists
+// ---------------
+// After α loaded the Dirt-Samples manifest + Salamander piano + drum-machine
+// banks + soundfonts, the most-typed shorthand sound names from other DAWs /
+// trackers (`kick`, `snare`, `hat`, `clap`, …) still resolve to "sound X not
+// found." Upstream strudel.cc users learn the canonical short names
+// (`bd`, `sd`, `hh`, …) by reading other patterns; first-time Stave users
+// shouldn't have to. This map is the last-resort lookup BEFORE the
+// "not found" error fires.
+//
+// Precedence rule (per 20-14-RESEARCH.md §3 + §7 open-question #4)
+// -----------------------------------------------------------------
+//   1. User code passes `s("name")` → `wrappedOutput` receives a hap whose
+//      `value.s` is the post-reify string.
+//   2. If `soundMap.get()[name.toLowerCase()]` is already populated (because
+//      upstream registered it, OR the user ran a `samples(...)` call that
+//      registered it), the alias map is NEVER consulted. User-registered
+//      names ALWAYS WIN.
+//   3. Otherwise, `resolveAlias(name)` is consulted. A hit rewrites
+//      `hap.value.s` to the canonical name and records the resolution on the
+//      engine's `lastAliasResolutions` accumulator (β-5 reads this).
+//   4. A miss falls through to superdough which throws "sound X not found",
+//      and friendlyErrors β-5 appends "alias map: no entry for `xyz`".
+//
+// Curation rules
+// --------------
+//   - Every key MUST map to a name that exists in `soundMap` after α. Adding
+//     a key that points at an unloaded sample is a worse UX than no entry at
+//     all (the friendly error explicitly says "alias map: `xyz` →
+//     `target` (but `target` is not loaded)").
+//   - Avoid speculative thesaurus entries. ~20-30 well-chosen aliases beats
+//     100 entries the alias author "thinks musicians might type." If a
+//     real-world user hits a gap, that's a PR adding ONE entry with a
+//     comment line citing the surface.
+//   - Avoid keys that already exist in upstream-registered names. The guard
+//     in `wrappedOutput` defends against shadowing, but a redundant entry
+//     adds review noise.
+//   - Keys are lowercased before lookup (mirrors `superdough.mjs:165`
+//     `soundMap.get()[s.toLowerCase()]`). Source-side casing is for
+//     readability only.
+//
+// New entries land via PR — NOT loaded from a JSON URL (locked decision D-02,
+// 20-14-CONTEXT.md).
+
+/**
+ * Bare-name to canonical-name aliases. Frozen so callers can't mutate the
+ * shared table — the alias surface is a contract reviewed via PR, not a
+ * runtime knob.
+ */
+export const SOUND_ALIASES: Readonly<Record<string, string>> = Object.freeze({
+  // ── Kick / bass drum ──────────────────────────────────────────────────
+  kick: 'bd',
+  bassdrum: 'bd',
+
+  // ── Snare ─────────────────────────────────────────────────────────────
+  snare: 'sd',
+  snaredrum: 'sd',
+
+  // ── Hi-hats ───────────────────────────────────────────────────────────
+  hat: 'hh',
+  hihat: 'hh',
+  closedhat: 'hh',
+  openhat: 'oh',
+  openhihat: 'oh',
+
+  // ── Claps / rims ──────────────────────────────────────────────────────
+  clap: 'cp',
+  handclap: 'cp',
+  rim: 'rs',
+  rimshot: 'rs',
+  sidestick: 'rs',
+
+  // ── Cymbals ───────────────────────────────────────────────────────────
+  crash: 'cr',
+  crashcymbal: 'cr',
+  ride: 'rd',
+  ridecymbal: 'rd',
+  // Generic "cymbal" → crash; ride is the deliberate one users spell out.
+  cymbal: 'cr',
+
+  // ── Toms ──────────────────────────────────────────────────────────────
+  // Dirt-Samples uses lt/mt/ht for low/mid/high toms. A bare "tom" is
+  // ambiguous in tracker land; mapping to mid-tom is the least-wrong default.
+  tom: 'mt',
+  lowtom: 'lt',
+  midtom: 'mt',
+  hightom: 'ht',
+  floortom: 'lt',
+
+  // ── Misc percussion ───────────────────────────────────────────────────
+  cowbell: 'cb',
+  bell: 'cb', // Dirt-Samples has no separate 'bell' sample; cb is the
+              // sleighbell-adjacent cowbell from analog kits.
+  tambourine: 'tb',
+  shaker: 'sh',
+  clave: 'cl',
+  // Conga/bongo bare names already exist in Dirt-Samples; no alias needed.
+})
+
+/**
+ * Look up a bare name against `SOUND_ALIASES`. Returns the canonical name
+ * if there is a curated alias, otherwise `undefined`. Lowercases the input
+ * to match superdough's own lookup (`soundMap.get()[s.toLowerCase()]`).
+ *
+ * The caller (`wrappedOutput` in StrudelEngine) must ALSO verify the name
+ * is not in the live `soundMap` before substituting — see header.
+ */
+export function resolveAlias(rawS: string): string | undefined {
+  return SOUND_ALIASES[rawS.toLowerCase()]
+}

--- a/packages/editor/src/engine/friendlyErrors.ts
+++ b/packages/editor/src/engine/friendlyErrors.ts
@@ -202,6 +202,80 @@ export interface FormatOptions {
    * Caller is free to omit it; `kind: 'code'` detectors simply won't fire.
    */
   codeContext?: string
+  /**
+   * Phase 20-14 β-5 — bare-name sound alias context. Distinct from the
+   * doc-level `detect.alias` CommonMistake field (which is per-doc fuzzy
+   * suggestion); this is the runtime alias-resolution layer that
+   * `wrappedOutput` operates.
+   *
+   * - `resolutions`: ordered list of alias rewrites that fired during the
+   *   current evaluate() window. Populated from
+   *   `StrudelEngine.getLastAliasResolutions()`. The friendly-error path
+   *   appends `(tried alias "kick" → "bd")` to the message when populated
+   *   on the same error window.
+   * - `lookupAlias`: project-injected resolver (today, `resolveAlias` from
+   *   `./aliases`). The miss path uses this to distinguish "the alias
+   *   map has no entry for `xyz`" from "we tried `xyz → target` but
+   *   `target` is not loaded either."
+   */
+  aliasContext?: {
+    resolutions?: ReadonlyArray<{ from: string; to: string }>
+    lookupAlias?: (rawS: string) => string | undefined
+  }
+}
+
+// Phase 20-14 β-5 — "sound X not found" pattern matchers. superdough throws
+// `sound bell not found! Is it loaded?` (verified at
+// superdough/superdough.mjs:167 in upstream). Both quoted and unquoted forms
+// observed across engine versions.
+const SOUND_NOT_FOUND_PATTERNS: RegExp[] = [
+  /sound\s+["']?([\w.-]+)["']?\s+not\s+found/i,
+]
+
+function extractMissingSoundName(rawMessage: string): string | null {
+  for (const re of SOUND_NOT_FOUND_PATTERNS) {
+    const m = re.exec(rawMessage)
+    if (m && m[1]) return m[1]
+  }
+  return null
+}
+
+/**
+ * Build the alias-resolution suffix appended to "sound not found" friendly
+ * errors. Returns an empty string when there's nothing to say. Exported
+ * for unit testing — pure function over the inputs.
+ */
+export function buildAliasSuffix(
+  missingName: string | null,
+  ctx: FormatOptions['aliasContext'],
+): string {
+  if (!ctx) return ''
+  const parts: string[] = []
+  // Resolved path — surface any alias rewrites that fired on the same
+  // evaluate window. Deduplicate `from` so a hot pattern firing 10 cycles
+  // of kick→bd doesn't drown the message.
+  if (ctx.resolutions && ctx.resolutions.length > 0) {
+    const seen = new Set<string>()
+    const lines: string[] = []
+    for (const r of ctx.resolutions) {
+      const key = `${r.from}→${r.to}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      lines.push(`\`${r.from}\` → \`${r.to}\``)
+    }
+    parts.push(`tried alias ${lines.join(', ')}`)
+  }
+  // Miss path — when we know which name was missing, say whether the alias
+  // map has an entry for it (and the target was also missing) vs no entry.
+  if (missingName && ctx.lookupAlias) {
+    const target = ctx.lookupAlias(missingName)
+    if (target) {
+      parts.push(`alias map: \`${missingName}\` → \`${target}\` (but \`${target}\` is not loaded)`)
+    } else {
+      parts.push(`alias map: no entry for \`${missingName}\``)
+    }
+  }
+  return parts.length > 0 ? ` (${parts.join('; ')})` : ''
 }
 
 /**
@@ -334,6 +408,26 @@ export function formatFriendlyError(
   const loc = parseStackLocation(err)
   const identifier = extractReferenceIdentifier(err)
 
+  // Phase 20-14 β-5 — alias-resolution suffix.
+  //
+  // The `aliasContext` is the runtime sound-alias layer (`kick → bd`) and
+  // is ORTHOGONAL to the per-doc `detect.alias` CommonMistake field at
+  // line ~240. The two never collide structurally:
+  //   - detect.alias matches a user's typed identifier against a single
+  //     known-misspelling alias from a curated doc entry.
+  //   - aliasContext consults the runtime-wide bare-sample-name map and
+  //     surfaces the result of an attempted hap rewrite.
+  //
+  // We compute the suffix once and append it to whichever message path
+  // fires below. Missing-sound name extraction targets superdough's
+  // "sound X not found! Is it loaded?" throw — when the rawMessage is
+  // about something else, missingName is null and only the "resolutions"
+  // path contributes.
+  const missingName = extractMissingSoundName(rawMessage)
+  const aliasSuffix = buildAliasSuffix(missingName, options.aliasContext)
+  const appendAlias = (msg: string): string =>
+    aliasSuffix ? `${msg}${aliasSuffix}` : msg
+
   // 1. Curated hints (commonMistakes + globalMistakes) — fire first.
   //    Higher specificity than algorithmic fuzzy match: when the author
   //    has hand-written the right hint for this case, it beats the
@@ -365,7 +459,7 @@ export function formatFriendlyError(
           }
         : undefined
       return {
-        message: hit.mistake.hint,
+        message: appendAlias(hit.mistake.hint),
         suggestion,
         stack,
         line: loc?.line,
@@ -393,7 +487,7 @@ export function formatFriendlyError(
         description: hit?.description,
       }
       return {
-        message: `\`${identifier}\` is not defined. Did you mean \`${matches[0].name}\`?`,
+        message: appendAlias(`\`${identifier}\` is not defined. Did you mean \`${matches[0].name}\`?`),
         suggestion,
         stack,
         line: loc?.line,
@@ -401,7 +495,7 @@ export function formatFriendlyError(
       }
     }
     return {
-      message: `\`${identifier}\` is not defined.`,
+      message: appendAlias(`\`${identifier}\` is not defined.`),
       stack,
       line: loc?.line,
       column: loc?.column,
@@ -410,7 +504,7 @@ export function formatFriendlyError(
 
   // 3. Non-reference, no curated hint — raw message.
   return {
-    message: rawMessage || 'Unknown error',
+    message: appendAlias(rawMessage || 'Unknown error'),
     stack,
     line: loc?.line,
     column: loc?.column,

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -361,7 +361,13 @@ export {
   extractReferenceIdentifier,
   formatFriendlyError,
   parseStackLocation,
+  buildAliasSuffix,
 } from './engine/friendlyErrors'
+
+// Phase 20-14 β-1 — bare-name sound alias resolver. The app's friendly-
+// error builder reads this on the miss path so it can distinguish "alias
+// map: no entry" from "alias map: target not loaded."
+export { resolveAlias, SOUND_ALIASES } from './engine/aliases'
 
 // DocsIndex exports so the app can pass runtime indexes into the friendly
 // error formatter without reaching through internal paths.


### PR DESCRIPTION
## Wave β of Phase 20-14 — Strudel.cc Parity (stacked on #123)

**Base:** \`feat/20-14-strudel-parity\` (α-wave). When α (#123) merges to \`main\`, this PR auto-rebases to target \`main\`.

Adds the bare-name alias layer (\`piano\`, \`kick\`, \`snare\`, etc.) on top of α's bootstrap mirror, exposes 8 tier toggles in EditorSettingsModal (MIDI live, 7 scaffolded per tier-UI-honesty rule), and integrates alias resolutions into the friendly-error message path.

### What landed (6 atomic commits)

| Task | Commit | What |
|---|---|---|
| β-1 | \`808c774\` | Hand-curated \`aliases.ts\` (30 entries) — bd/sd/hh and friends. User-registered names always win per RESEARCH §3 precedence rule. |
| β-2 | \`7291313\` | Strategy A intercept in \`wrappedOutput\` — rewrites \`hap.value.s\` post-reify when alias matches AND \`soundMap.get()[raw]\` is absent. Per-evaluate \`lastAliasResolutions\` accumulator owned by \`StrudelEngine\` instance, reset at \`evaluate()\` entry. |
| β-3 | \`5fb0583\` | EditorSettingsModal "Strudel modules" section — MIDI interactive, 7 dimmed with \`Module wiring planned — see issue #NNN\` tooltips linking #124–#130. Reload-required caption below. |
| β-4 | \`b803767\` | MIDI tier flag threaded — \`enableWebMidi()\` conditionally called when \`tierFlags.midi === true\`. Default off; existing comment at StrudelEngine.ts:141-142 preserved. |
| β-5 | \`3143129\` | \`buildAliasSuffix\` helper + \`aliasContext\` field on \`FormatOptions\`. Resolved-path message: \`(tried alias kick → bd)\`. Miss-path message: \`(alias map: no entry for xyz)\`. 10 new pure-function tests. |
| β-6 | \`2553e5d\` | β SUMMARY with per-task observation + tier wiring matrix. |

### Tests

- Editor: **1536/1536** (+10 for \`buildAliasSuffix\`)
- App: **297/297**

### Verification gates

| # | Surface | How to verify |
|---|---|---|
| 1 | Alias resolution | Editor: \`\$: s(\"kick\").n(0)\` → bd kick audible. Console: \`engine.getLastAliasResolutions()\` → \`[{from: 'kick', to: 'bd'}]\`. \`soundMap.get().kick\` → \`undefined\` (no soundMap pollution). |
| 2 | EditorSettingsModal | ⚙️ → \"Strudel modules\" section: MIDI checkbox interactive, 7 others dimmed; hover dimmed → tooltip cites issue number; \`Changes take effect when you reload the page.\` visible below. |
| 3 | MIDI tier wiring | Toggle MIDI ON → reload → browser MIDI permission prompt fires during init. |
| 4 | Friendly errors | \`\$: s(\"xyz123\")\` → message contains \`(alias map: no entry for xyz123)\`. \`\$: s(\"bell\")\` (bell aliased to cb which isn't loaded) → message contains \`(tried alias bell → cb; alias map: bell → cb (but cb is not loaded))\`. |

### Follow-up issues filed (one per scaffolded tier)

| Module | Issue |
|---|---|
| csound | #124 |
| tidal | #125 |
| osc | #126 |
| serial | #127 |
| gamepad | #128 |
| motion | #129 |
| mqtt | #130 |

Each issue has an atomic acceptance checklist for flipping its row from disabled to interactive.

### Catalogue candidates (deferred to post-merge)

Captured in \`20-14-β-SUMMARY.md\` for promotion review:

1. **hetvabhasa** — intercept site must satisfy BOTH post-reify AND pre-breakpoint-hit-check; satisfying only one silently breaks the other invariant.
2. **vyapti** — per-evaluate engine-owned accumulators must reset at \`evaluate()\` entry; reset MUST be top-of-function, not buried in a helper.
3. **krama** — tier-flag read happens once at init; UI surfaces MUST carry an explicit \`Changes take effect on reload\` caption.

### Decisions honored

- D-01 (structural parity only) — no scheduler/waveform changes.
- D-02 (alias = hand-curated TS const, no \`soundMap\` mutation) — verified via \`soundMap.get().kick === undefined\`.
- D-03 (settings panel toggle, default off, reload to apply) — caption + default state confirmed.
- PLAN tier-UI-honesty (option B) — 7 of 8 toggles scaffolded with link to follow-up issue.

### Refs

- Phase plan: \`.planning/phases/20-musician-timeline/20-14-PLAN.md\` §4
- β SUMMARY: \`.planning/phases/20-musician-timeline/20-14-β-SUMMARY.md\`
- Stacks on: #123 (α)
- Next: γ-wave (corpus + CI gate, closes #110)

### Test plan

- [x] \`pnpm --filter @stave/editor test\` — 1536/1536
- [x] \`pnpm --filter @stave/app test\` — 297/297
- [ ] Manual verification of the 4 surfaces above
- [ ] Reviewer: confirm alias resolution is invisible when user manually \`samples()\`-registers a name that collides with an alias (Strategy A guard)