### PR TITLE
Phase 20-14 γ: parity corpus + CI gate + parser-gap fix (closes #110)

### DIFF
--- a/.anvi/hetvabhasa.md
+++ b/.anvi/hetvabhasa.md
@@ -1,0 +1,1802 @@
+# Hetvābhāsa Catalogue — struCode
+
+> Project-specific reasoning error patterns. Load at session start.
+>
+> **Entry structure:** Root cause first, then detection signal, then the trap.
+> **Maintenance:** At every 10th entry, review and prune.
+
+## Universal Error Patterns
+
+### U1: Timing Error (Krama Violation)
+**Root cause:** The dependent operation is async. Your code runs before it completes.
+**Detection signal:** Method call has no effect, returns null/undefined, or operates on uninitialized state.
+**The trap:** You add a retry, setTimeout, or polling loop. The root fix is to run your code INSIDE the async callback.
+
+### U2: Identity Error (Object Mutation Assumption)
+**Root cause:** The method returns a new object. Your property is on the old one.
+**Detection signal:** Property you set is missing on the object downstream in the chain.
+**The trap:** You set the property again downstream, or add it to the prototype. The root fix is to tag the RETURN VALUE.
+
+### U3: Scope Error (Prototype Collision)
+**Root cause:** The framework owns the prototype. Your installation gets overwritten.
+**Detection signal:** Your interceptor/wrapper is never called despite being installed.
+**The trap:** You install it "harder." The root fix is to install AFTER the framework, or inside its initialization hook.
+
+### U4: Observation Error (Mock Divergence)
+**Root cause:** The mock doesn't replicate the real system's transformations.
+**Detection signal:** Tests pass, production fails.
+**The trap:** You fix production code but the mock still doesn't test it. The root fix is to test through the real pipeline.
+
+### U5: Workaround Error (Symptom Suppression)
+**Root cause:** The underlying system doesn't have the information it needs.
+**Detection signal:** Cascading fixes — each fix creates a new symptom.
+**The trap:** Each individual fix seems reasonable. The root fix is at the data source.
+
+### U6: Mutation-for-Observation Error
+**Root cause:** Observation redirected the data flow instead of tapping it.
+**Detection signal:** The observed thing works, everything else on the same path breaks.
+**The trap:** You duplicate the data to fix the broken paths. The root fix is a passive side-tap.
+
+## Project-Specific Error Patterns
+
+### P1: Strudel Transpiler Reification
+**Root cause:** Strudel's transpiler converts all string arguments of Pattern methods into Pattern objects via `reify()`. Your handler receives a Pattern, not the string you expected.
+**Detection signal:** `typeof arg` is `"object"` instead of `"string"`. The object has `_Pattern: true` and a `queryArc` method.
+**The trap:** You check `typeof arg === 'string'` — always false. You add type coercion. The root fix is to extract the original value via `arg.queryArc(0, 1)[0].value` and handle both string and Pattern argument types.
+
+### P2: Strudel injectPatternMethods Overwrite
+**Root cause:** Strudel's `injectPatternMethods()` runs during `repl.evaluate()` and reassigns all Pattern.prototype methods, overwriting any methods you installed beforehand.
+**Detection signal:** Your prototype method wrapper is never called. `typeof Pattern.prototype.yourMethod` shows the framework's version, not yours.
+**The trap:** You install your wrapper before evaluate and assume it persists. The root fix is to install INSIDE the `.p` setter trap, which fires when `injectPatternMethods` assigns `.p` — at that point, the framework's initialization is complete and your wrapper won't be overwritten.
+
+### P3: p5.js Async Setup
+**Root cause:** `new p5(sketch, container)` defers `setup()` to `requestAnimationFrame`. Any method call after the constructor runs before setup completes.
+**Detection signal:** `resizeCanvas()` has no effect. Canvas remains at hardcoded `createCanvas()` dimensions.
+**The trap:** You call `resizeCanvas()` right after `new p5()` — it's a no-op because canvas doesn't exist yet. The root fix is to wrap the sketch's `setup()` and append `resizeCanvas()` at the end of setup, where the canvas exists.
+
+### P4: Canvas Hardcoded Dimensions
+**Root cause:** p5 sketches hardcode `createCanvas(300, 200)` instead of reading from the container.
+**Detection signal:** Canvas overflows container, gets truncated, or doesn't match available space.
+**The trap:** CSS overrides, height constants, post-mount resize. The root fix is `container.clientWidth` / `container.clientHeight` inside setup() — the child inherits from its parent.
+
+### P5: Orbit Reassignment for Observation
+**Root cause:** Reassigning a pattern's orbit to route audio to a per-track AnalyserNode removes the pattern from its default audio chain. Other patterns' audio breaks.
+**Detection signal:** Only the observed track plays audio. All other tracks are silent.
+**The trap:** You try to fix the other tracks by duplicating audio routing. The root fix is to NOT mutate patterns for observation — use passive side-taps on existing audio nodes instead.
+
+### P6: CSS Variables Undefined When Component Mounted Standalone
+**Root cause:** A component reads `var(--background)`, `var(--foreground)`, etc. but never calls `applyTheme()` on its container ref. When the parent doesn't apply theme tokens (e.g., the component is rendered standalone, not inside `LiveCodingEditor`), the CSS variables are undefined and the component falls back to whatever the browser inherits — usually white-on-white or unstyled.
+**Detection signal:** The component looks correct when embedded in another themed component, but renders with wrong colors / no styles when used standalone. `getComputedStyle(el).getPropertyValue('--background')` returns empty string.
+**The trap:** You hard-code colors as fallbacks (`var(--background, #090912)`) — this works for one variable but the design system has 20+ tokens and you'll miss some. The root fix is: every top-level component that uses theme tokens MUST own its theme application. Add a `theme` prop and call `applyTheme(containerRef.current, theme)` in a `useEffect`. Theme ownership is per-root-component, not per-app.
+**First observed:** VizEditor rendered standalone in a tab — toolbar/borders/text were unstyled. Root fix: added `theme` prop + `applyTheme()` call in VizEditor (2026-04-08).
+
+### P7: Empty Preview When No Data Source
+**Root cause:** A preview/visualization is mounted in an authoring context (no playback running). The viz code reads from `scheduler.query()` / `analyser.getByteFrequencyData()` which return empty arrays / silence. The canvas renders only the background color and looks "broken" or "black."
+**Detection signal:** Preview canvas shows only the background color. `events.length === 0` for the entire frame loop. No errors in console.
+**The trap:** You assume the renderer is broken and start debugging the renderer. The root fix is in the **viz code itself**: every preview-able viz must have a "demo mode" branch that draws *something* when no audio source is available, plus a "play a pattern to see live data" hint. The canvas must never look like a bug just because nothing is playing.
+**Universal principle:** Authoring environments need their own data source independent of runtime. Markdown previews can render without a server; viz previews must render without an active audio engine.
+**First observed:** Seeded p5 pianoroll preset rendered black in the Viz Editor tab because the tab had no engine running. Fix: added a `if (events.length > 0) { ... } else { /* animated demo */ }` branch in the seeded code, plus a "preview mode" hint text (2026-04-08).
+
+### P8: Stale Closure in useCallback Deps
+**Root cause:** A React useCallback callback reads state from its closure but the enclosing useCallback's dep array is missing that state OR a downstream helper that captures it. The callback keeps firing with an old state snapshot even after the state updates, so derived computations return stale values indefinitely.
+**Detection signal:** State updates correctly (you can inspect it), but a UI element that depends on a computed value from state is frozen at the initial value. Refs can't explain it because the state is in useState, not useRef.
+**The trap:** You add `useMemo` or `useRef` patches around the derived value, or you add the state to the component's OTHER callbacks, missing the specific one that memoized with stale deps. The root fix is to identify the exact useCallback holding the stale closure and add EVERY state/helper it reads (transitively) to its dep array.
+**Universal principle:** If a helper function `h` captures state via closure, every callback that uses `h` must have `h` in its deps — not the underlying state. Chain it: dep on `h`, and `h` has its own deps on state.
+**First observed:** `renderTabContent` in `WorkspaceShell.tsx` captured `findTabByFileId` via closure but didn't list it in deps. After a preview tab was added to a group, `findTabByFileId` returned the stale null, `previewOpen` stayed false forever, the viz Play button never flipped to Stop (2026-04-10).
+
+### P9: Monaco Editor Has Its Own Theme System Separate from CSS Vars
+**Root cause:** `applyTheme(container, 'dark')` sets CSS custom properties on a DOM element, which affects ANYTHING styled via `var(--*)`. But Monaco editor's gutter, syntax colors, caret, and selection are painted by Monaco's OWN theme engine — they ignore CSS variables entirely. Without a separate `monaco.editor.defineTheme(...)` + `monaco.editor.setTheme(...)` call, the editor paints its default `vs` (white) theme on top of a dark chrome.
+**Detection signal:** Chrome bars, tab headers, borders look correct dark/light, but the Monaco surface inside (code background, line numbers, gutter) renders white-on-black or the wrong variant.
+**The trap:** You keep adding CSS overrides trying to style Monaco via cascade, none of which work because Monaco applies its colors via inline styles on its own elements. The root fix is to register a Monaco theme via `defineTheme` (in `theme/monacoTheme.ts`) and call `monaco.editor.setTheme('stave-dark' | 'stave-light')` inside the editor's mount handler, AND re-call `setTheme` from a `useEffect` on theme prop change.
+**Universal principle:** Foreign rendering engines (Monaco, Hydra, p5, shader-based components) have their own theme/style systems. CSS var theming only reaches them if they're explicitly wired through a bridge function — never assumed.
+**First observed:** `EditorView` in the shell refactor mounted `@monaco-editor/react` without calling `defineStrudelMonacoTheme` or `setTheme`. The editor rendered white while everything around it was dark. Fix: register the theme on mount + add a theme-change effect (2026-04-10).
+
+### P10: Paranoid Early-Return Blocking the Common Case
+**Root cause:** A guard clause designed to prevent a narrow degenerate case (e.g., "infinite loop when X equals Y") catches a MUCH broader case where the same equality holds but the behavior should work normally. The comment justifying the guard sounds reasonable on its own but doesn't match the actual call distribution.
+**Detection signal:** A feature appears to do nothing — no error, no side effect, no state change — and the code path reaches a specific early-return. The guard's reasoning is architectural/worst-case rather than empirical.
+**The trap:** You trust the guard's comment and look for the bug elsewhere. The root fix is to NARROW the guard to the actually-degenerate subset, usually by adding conjunctive conditions (`A === B && someExtraCondition`).
+**Universal principle:** Early returns based on equality of two identifiers are suspect when the two identifiers are frequently the same in normal usage. Question every `if (a === b) return` by asking: "in the normal user flow, how often is a === b? If it's the MAJORITY of calls, this guard is almost certainly wrong."
+**First observed:** `handleDropOnGroup` in `WorkspaceShell` had `if (sourceGroupId === targetGroupId) return` as a "cost-effective no-op" for directional drops. But when the shell seeds all tabs into one group, EVERY drag-to-split has source === target. The guard silently blocked every quadrant drop. Narrowed to `if (sourceGroupId === targetGroupId && source.tabs.length === 1)` in `moveTabToNewQuadrant` (the actual degenerate case) (2026-04-10).
+
+### P11: RTL `fireEvent` Doesn't Propagate `clientX/clientY` to React Synthetic Events
+**Root cause:** `@testing-library/react`'s `fireEvent.drop(el, { clientX, clientY })` passes the init dict to the underlying native event constructor, but for `DragEvent` specifically, either jsdom or React's delegated listener drops the coordinates before the handler sees them. Inside React's onDrop, `e.clientX` and `e.clientY` are `undefined`.
+**Detection signal:** A drop handler that reads `e.clientX`/`e.clientY` to compute positional logic (like a quadrant detector) gets undefined values in tests even though fireEvent was called with explicit coords.
+**The trap:** You convert to native `element.dispatchEvent(new Event('drop'))` which makes it worse — React's delegated listener doesn't receive plain Events, only proper DragEvents built via the `createEvent` factory. The root fix is: build the event via `createEvent.drop(el, { dataTransfer })`, then PATCH `clientX/clientY` via `Object.defineProperty(ev, 'clientX', { value, configurable: true })` BEFORE calling `fireEvent(el, ev)`.
+**Universal principle:** Test environments may strip properties that production browsers preserve. When writing tests for positional event logic, verify the property actually reaches the handler (log it once) before trusting fireEvent's init dict.
+**First observed:** Drag-drop tests for the 2-D layout refactor passed 'center' direction when they expected 'east'/'west'/'north'/'south'. Console log inside the handler showed `clientX: undefined`. Fix: `createEvent.drop` + `Object.defineProperty` + `fireEvent(el, ev)` (2026-04-10).
+
+**Re-applied (2026-05-09, phase 20-08 wave α / commit 037a701):** the
+same trap class fires on `fireEvent.pointerDown(target, { clientX,
+pointerId, button })` against jsdom 24. The PointerEvent constructor
+in jsdom 24 swallows `clientX`/`clientY`/`pointerId`/`button` from
+`PointerEventInit` — they read as `undefined` on the dispatched event.
+Production guards like `if (e.button !== 0) return` early-return,
+swallowing the test path silently. Detection: handler fires (log
+shows entry) but downstream side effects don't. Fix shape mirrors
+P11's drag variant: construct a real `PointerEvent` (or fallback to
+`MouseEvent`) and force-define each lost property via
+`Object.defineProperty(ev, 'pointerId', { value, configurable: true })`,
+then `target.dispatchEvent(ev)`. The `dispatchPointer` helper at
+`packages/app/src/components/__tests__/MusicalTimelineScrub.test.tsx:108-140`
+is the canonical shape; copy it for any future pointer-handler test
+in this codebase.
+
+### P12: Bridge Module Transitive Import Pulls in the Whole Renderer Stack
+**Root cause:** A "pure data utility" module (e.g., `vizPresetBridge.ts`) adds an import for a function that lives in the same directory tree as the renderer code. The new import has a transitive chain into `p5`, `hydra-synth`, `gifenc`, or any ESM-incompatible library. All test files that import the bridge module directly (or via a test subject) now fail to load with ESM CommonJS interop errors — before any test runs.
+**Detection signal:** A test file that used to work starts failing at module load with `SyntaxError: Named export 'X' not found. The requested module 'Y' is a CommonJS module`. The failing test has nothing to do with rendering.
+**The trap:** You try to mock the offending library in every affected test file. The root fix is to **keep the bridge pure**: extract the function that needs `compilePreset` into a SEPARATE sibling file (`namedVizBridge.ts`) that only the app layer / compat shims import. The pure data module stays clean; tests of it stay isolated.
+**Universal principle:** A module's import graph defines its test compatibility surface. Adding an import to a "utility" module can silently break its entire test harness. Audit the transitive load cost before adding imports to shared utilities.
+**First observed:** Added `import { compilePreset } from '../vizCompiler'` to `vizPresetBridge.ts` to auto-register viz files as named descriptors. `vizCompiler` → `P5VizRenderer` → `p5` → gifenc. Broke `vizPresetBridge.test.ts` and `VizEditor.compat.test.tsx` at load time. Fix: moved `registerPresetAsNamedViz` to a new `namedVizBridge.ts` that consumers import separately (2026-04-10).
+
+### P13: Inconsistent Close Paths — Tab × vs Chrome Stop
+**Root cause:** Two different user actions for "dismiss this thing" dispatch to different handlers that do different things. `handleTabClose` (from the tab's × button) removes the tab but leaves an empty group as a "Drop a tab here" placeholder. `closeTabById` (from shell actions used by viz chrome Stop) removes the tab AND auto-collapses the empty group. Same user intent, different outcomes depending on which button they clicked.
+**Detection signal:** User reports "I can't close this area" after using the close button that doesn't collapse the pane. The feature looks broken because the empty placeholder pane is still visible.
+**The trap:** You add a new "dismiss pane" button instead of fixing the existing close path. The root fix is to pick the RIGHT semantic (auto-collapse on last-tab-close matches VS Code and is what users expect) and apply it to BOTH paths. Single source of truth for the close behavior.
+**Universal principle:** When two UI entry points invoke "close" semantics, they must share a single lowest-level handler OR the two higher handlers must do the same thing. Splitting close semantics by entry point creates UX drift that users report as bugs.
+**First observed:** Tab × on preview tab closed the tab but left an empty pane. User couldn't find the tiny group-close × button. Fix: `handleTabClose` now auto-collapses the group when closing its last tab (matching `closeTabById`'s existing behavior), unless it's the only group in the shell (2026-04-10).
+
+### P14: Mount-Effect Thrash from Unstable Derived Object Identity
+**Root cause:** A React component is called with a prop whose value is a DERIVED object (e.g., `compilePreset(file)` returning a new `VizDescriptor`). Every call to the parent's render produces a NEW object ref, even when the SOURCE input is unchanged. A downstream `useEffect([derivedObject])` in the mount component treats every re-render as a dep change, firing its cleanup + setup repeatedly. The imperative instance (p5, canvas, hydra context) is torn down and rebuilt on every state flip.
+**Detection signal:** A user-visible action (pause, toggle, state change) appears to do nothing. The handler fires, the state updates, but the underlying instance is destroyed and recreated so fast that any side effect applied to it (noLoop, pause, setVolume) is invisible — it hits a brand-new instance that hasn't even completed its first frame.
+**The trap:** You keep instrumenting the handler, the state update, the prop propagation — they all look correct. The root fix is to move the derivation INTO the mount component wrapped in `useMemo(..., [INPUT_IDENTITY])` where INPUT_IDENTITY is the stable source of truth (file content, scalar config) — NOT the derived object. The mount effect then only fires on real input changes, not on every render.
+**Universal principle:** React effect deps should be **input identity, not derived object identity**. Two calls to a pure function with the same inputs produce equivalent outputs but NOT the same object reference. Putting the derived object in deps gives you "re-run on every parent render" which is almost never what you want. Memoize at the derivation boundary, or compute inside the component.
+**First observed:** `createCompiledVizProvider.render(ctx)` built a fresh `VizPreset` and called `compilePreset(preset)` on every invocation. The returned descriptor went into `<CompiledVizMount descriptor={...} />`. CompiledVizMount had `useEffect([descriptor])`. When the user clicked Stop on the viz chrome, the paused prop flipped, provider.render was called again, a new descriptor was produced, mount effect tore down the p5 instance and rebuilt it. `renderer.pause()` fired on the new instance one microtask after it was created. Visually: nothing stopped. Fix: moved compile into CompiledVizMount via `useMemo([file.id, file.content, file.language, rendererType])` (2026-04-11).
+
+### P15: Next.js Dev Workspace Dep Staleness
+**Root cause:** A monorepo with a workspace package (`@stave/editor`) compiled to `dist/index.js`, consumed by an app package via Turbopack dev. Rebuilding the dist file updates the bytes on disk but Turbopack's module cache may keep serving the previous version because its workspace dep resolution doesn't always detect file changes inside `node_modules`-equivalent linked packages. Hot refresh in the browser pulls the old bundled code.
+**Detection signal:** Integration tests pass (they import source directly), unit tests pass, `dist` file shows the new code via `grep`, but the user says "the fix isn't in the browser." The user hard-refreshes and still sees the old behavior. The gap between what tests prove and what the browser runs feels impossible.
+**The trap:** You keep debugging the code, adding more tests, looking for subtle React bugs — all of them come up clean. The root fix is environmental: kill the Next dev server, `rm -rf .next`, restart. The module graph rebuilds fresh and picks up the new dist.
+**Universal principle:** Workspace deps in dev servers with module graph caching are a source of silent staleness. Whenever a compiled artifact in a workspace dep is rebuilt and the behavior "should have changed but didn't," restart the dev server BEFORE continuing to debug the code.
+**First observed:** User reported "stop is still not working" after two consecutive fixes that should have resolved it. A shell-level end-to-end integration test proved the full click → pause chain works. Restarting the dev server with cleared `.next` cache was the resolution. (2026-04-11)
+
+### P16: Isolated Unit Tests Pass, Integration Behavior Broken
+**Root cause:** A feature touches three layers: an outer shell, a middle provider, and an inner component. Unit tests cover each layer in isolation with mocks/stubs at the boundaries. Each isolated test passes. But the bug lives in the INTEGRATION: a property of the full pipeline that only emerges when all three layers compose. Because no test exercises the full chain, the bug is invisible until a user reports it.
+**Detection signal:** You have a passing unit test for the chrome, a passing unit test for the provider's `render()`, and a passing unit test for the shell's state flow. The user says "this button doesn't work." You can't reproduce the bug in any test you've written. Every layer looks correct.
+**The trap:** You write MORE isolated unit tests, refining each layer's contract. The root fix is to write an INTEGRATION test that uses the real components at each layer (with minimal mocks only at external resources like WebGL/AudioContext) and exercises the user action end-to-end. That single test catches the "fresh object identity leaks across the boundary" class of bugs that isolated tests by definition can't see.
+**Universal principle:** Unit tests verify contracts at boundaries. Integration tests verify that the contracts COMPOSE. When a feature involves more than two layers of React components communicating via props + callbacks + effects, at least one test must render the full chain. Mocking the provider or the shell to simplify the test discards the exact information needed to catch integration bugs.
+**First observed:** The Stop button regression (P14). Chrome test mocked `renderEditorChrome`'s ctx props directly. Provider test mocked `mountVizRenderer`. Shell test used a stub provider. All passed. The bug was that `provider.render()` built a fresh descriptor on every call — invisible in any isolated test. Fix: added a shell-level integration test that renders `<WorkspaceShell>` with a real `HYDRA_VIZ` provider and mocked `mountVizRenderer`, clicks Preview + Stop, asserts `mountVizRenderer` was called exactly ONCE and `renderer.pause()` was called on the SAME instance. The test failed immediately on the buggy code and passed on the fix — the missing integration proof (2026-04-11).
+
+### P17: p5 v2 Default Canvas Survives instance.remove() Mid-Setup
+**Root cause:** p5 v2's `#_setup()` is `async`, runs on the next animation frame after `new p5(...)`, and contains an UNCONDITIONAL `this.createCanvas(100, 100, P2D)` call BEFORE awaiting the user's setup (line 72544 of p5.js v2.2.3). If the host calls `instance.remove()` BEFORE that rAF fires — e.g., React StrictMode dev double-invoke runs the effect cleanup before p5 has had a chance to run its setup chain — `remove()` cancels the draw loop schedule but does NOT cancel the queued `#_setup` async chain. The chain still fires, the default 100×100 canvas is appended to the host container, the user setup runs and creates a SECOND canvas sized to the requested dimensions, and the draw loop starts on a "destroyed" instance whose remove() was a no-op because no canvas existed yet at the moment of removal. The orphan canvas keeps drawing forever — `pause()` calls on the LIVE renderer ref work fine on the surviving instance, but the orphan has no externally-held reference, so nothing can stop it.
+**Detection signal:** Two `<canvas>` elements appear inside a single `compiled-viz-mount-*` container, both with class `p5Canvas`, both at the requested dimensions. Pause button appears to "half-work": the live canvas freezes but visual change continues underneath because the orphan is still drawing. Console-instrumented logs show `P5VizRenderer.destroy #N BEFORE remove (canvases: 0)` followed by `P5VizRenderer.mount #N → after rAF (canvases: 2)` — proving the canvases appear AFTER destroy ran but BEFORE the next destroy.
+**The trap:** You debug the React state flow, the renderer ref capture, the `pause()` plumbing — all of which are correct. The chrome flips, the prop threads down, `renderer.pause()` is called on the right instance, `noLoop()` does its job. None of this matters because the orphan canvas's draw loop lives on a separate p5 instance. You blame React StrictMode and consider disabling it. Or you add a MutationObserver to manually clean orphan canvases. Both are workarounds that don't address the root cause.
+**Universal principle:** When a host integrates with a library that has DEFERRED initialization (async setup chains, RAF-queued construction), the library's "destroy" call may only cancel work that's already started. Work queued for the FUTURE — async chains awaiting microtasks, RAF callbacks bound to instance methods, onload listeners — survives destroy unless the library explicitly cancels them. The host must either (a) wait for setup to complete before allowing destroy, or (b) actively neutralize the deferred chain via flags/method overrides BEFORE calling the library's destroy. Reading the library's source to understand what its destroy actually cancels (and what it leaves running) is non-negotiable.
+**The fix:** In `P5VizRenderer.destroy()`, set `instance.hitCriticalError = true` (p5's `#_setup` checks this after each await and bails early), and override `instance.setup`, `instance.draw`, `instance.preload`, AND `instance.createCanvas` with no-ops on the instance BEFORE calling `instance.remove()`. Belt-and-suspenders — if any one defense is bypassed by an internal p5 path, the others still prevent the orphan canvas from being created or drawn to. (2026-04-11)
+
+### P18: Strudel reify Tokenizes String Args as Mini-Notation
+**Root cause:** Strudel's transpiler runs every string argument to a Pattern method through `reify()`, which parses the literal as **mini-notation**. Mini-notation has its own grammar — spaces are sequence separators, `:` is the sample-index operator, `*`/`[]`/`<>`/`,`/`?` are other operators. So `.viz("Piano Roll")` doesn't reach the wrapper as a single hap with value `"Piano Roll"`; it reaches as a Pattern with TWO haps `["Piano", "Roll"]` because the space tokenized into a sequence. Similarly `.viz("pianoroll:hydra")` arrives as one hap whose value is the array `["pianoroll", "hydra"]`. Any wrapper that does `haps[0].value` and stops drops the rest of the data.
+**Detection signal:** A `.viz("name with space")` call silently fails to resolve a named viz that IS registered. Single-token names like `.viz("pianoroll")` work fine. The failure surface is "the named registry lookup misses" — no error, no warning, just no inline view zone or no resolved descriptor.
+**The trap:** You blame the registry or the lookup logic. You don't realize the string was already mangled by reify before your code saw it. Adding more entries to the registry under guessed variants ("piano", "roll", "Piano-Roll") doesn't fix it.
+**Universal principle:** Pattern methods that take string arguments in Strudel get mini-notation reify ALWAYS. The wrapper must reconstruct the original literal by inverting reify's tokenization: rejoin multiple haps with spaces, rejoin per-hap array values with `:`. Other operators (`*`, `[`, `<`, `,`, `?`) can't be cleanly inverted — those characters are not allowed in viz names.
+**The fix:** Pure helper `extractVizName(rawArg)` in `packages/editor/src/engine/StrudelEngine.ts` handles all three reify shapes: single-hap string → use as-is; single-hap array → join with `:`; multi-hap → join all hap values (each rendered recursively) with spaces. The wrapper calls the helper instead of inlining the extraction. 11 unit tests in `extractVizName.test.ts`. (2026-04-11)
+
+### P19: Library Default Loop Bypasses Manual Pause Flag
+**Root cause:** When a host integrates with a library that runs its own animation loop by default (hydra `autoLoop: true`, three.js implicit render loops, etc.), setting a host-side `paused` flag is a no-op because the library's loop runs independently and never reads the host's flag. The library keeps drawing forever. The host's `pause()` method appears to do something (it sets the flag) but the user-visible animation never stops.
+**Detection signal:** `pause()` is called, the boolean toggles correctly, no errors anywhere — but the canvas keeps animating. The renderer's own RAF callback might also be running (if the host has one), but cancelling THAT alone doesn't help because the library's separate loop is the one actually drawing.
+**The trap:** You debug the host's pause flag, the click chain, the prop threading. They're all correct. You add `console.log` statements that confirm pause() runs. You don't realize there's a separate independent loop you don't control.
+**Universal principle:** A renderer that wants to support `pause()` MUST own the loop that drives its visible output. No flag-only pauses. If the library you're wrapping has a default loop (autoLoop, internal RAF, polling timer), turn it off and drive the equivalent tick yourself from a loop you can cancel. Single source of ticks → cancellable pause.
+**The fix:** Construct hydra with `autoLoop: false`. Have the renderer's own `pumpAudio` rAF callback call `hydra.tick(performance.now())` per frame in addition to its existing FFT polling. `pause()` cancels the rAF synchronously AND the pumpAudio guard at the top bails if `paused` is true (race-safe in case the browser already queued the callback). `resume()` re-arms the rAF, idempotent. `destroy()` sets a `destroyed` flag so a late async setup resolution can't reschedule into a dead instance. (See `HydraVizRenderer.ts`, issue #6, 2026-04-11.)
+**Sister pattern:** Same shape as P17 (p5 deferred setup) — both are "library does work outside your control unless you explicitly opt out." p5's mechanism is the async `#_setup` chain; hydra's is the autoLoop. Both fixes share the structure: take ownership, neutralize the library's default behavior.
+
+### P20: Layout-Shape Component Remount Wipes Local State
+**Root cause:** When a React parent's render tree branches between two structurally different shapes — e.g., `{onlyOneGroup ? <DirectChild/> : <SplitPane><Wrapper><Child/></Wrapper></SplitPane>}` — the child component is at a DIFFERENT position in the parent element type chain in each branch. React's reconciliation sees the type at that position has changed and **fully unmounts and remounts** the child subtree, even when the data flowing into it is identical. Any `useState` in that subtree is wiped and reinitialized to its default. Refs are recreated. Effect cleanups run, then setups run again.
+**Detection signal:** A user gesture that changes some unrelated layout (splitting a pane, opening a sibling tab, toggling a chrome) silently resets state in a component that isn't visually affected. The component's local `useState` always shows the initial default whenever its parent's tree shape transitions, even if the gesture had no semantic relation to that state.
+**The trap:** You think the state isn't being captured correctly. You check `useCallback` deps, suspect stale closures (P8), check that the state setter is being called. None of it explains why the state KEEPS resetting — the setter IS being called, but the component instance it set on no longer exists.
+**Universal principle:** Component-local state only persists across re-renders that REUSE the same instance. React reuses an instance only when its key + position in the parent's element type chain remain stable. **State that must survive layout changes belongs in the lowest stable parent**, not in the leaf. Lifting is the structural fix; trying to memoize harder won't help.
+**Detection-by-inspection:** When inspecting state-loss bugs in dev tools, put a `console.log` in the component's useState initializer (or use a counter ref that increments on each mount). If the counter resets after a gesture that "shouldn't" affect that component, it's been remounted.
+**First observed:** The viz chrome's `selectedSource` (drum / chord / sample dropdown selection) was wiping back to `default` whenever the user clicked Preview for the first time. Cause: `WorkspaceShell` renders `{layout.length === 1 && layout[0].length === 1 ? renderGroup(g) : <SplitPane>...</SplitPane>}`. Opening a preview tab transitioned from one group to two, switching the IIFE branch to the SplitPane branch, the editor subtree's parent type changed, the chrome remounted, `selectedSource` state was lost. Fix: moved the audio start/stop dispatch from the chrome (which had stale state) to the shell's `onTogglePausePreview` handler (which reads the open preview tab's `sourceRef` from the shell-owned `groups` Map — survives the remount). Issue #3, 2026-04-11.
+
+### P21: Wrong Source Priority — Silent Fallback Wins Over Working Primary
+**Root cause:** A renderer (or any consumer) has multiple paths to get the same data — e.g., a real audio analyser AND a synthetic envelope from event streams. The path-selection logic picks the WRONG one when both are present, locking onto a fallback that happens to be silent/empty/zero. The "working" primary path is silently bypassed. Visually: the consumer animates but doesn't respond to the data it should be reading.
+**Detection signal:** The consumer is alive (loop running, no errors, no zero divisions) but the data it's pulling from is constant. In debugger, the data structure is filled with zeros / defaults / placeholder values. The data SOURCE is producing real values, just not on the path the consumer is reading.
+**The trap:** You blame the source ("the analyser isn't producing data") or the consumer's data extraction ("the FFT bin math is wrong"). You don't realize the consumer was reading from a completely different source the whole time. The path-selection logic is usually buried in a `mount()` or `init()` method and looks innocuous.
+**Universal principle:** When you have N paths to the same data, the priority logic should match what ACTUALLY DELIVERS data, not what's syntactically present. A path that exists but is silent should be a fallback, not a primary. Document the priority and verify with one observation per path: "if both A and B are present, which one wins, and is that one actually populated?"
+**First observed:** `HydraVizRenderer.mount()` had:
+```ts
+if (this.hapStream) { this.useEnvelope = true }
+if (this.analyser && !this.useEnvelope) { /* allocate freqData */ }
+```
+Built-in example sources (drum / chord / sample) construct a HapStream they NEVER emit on. So `useEnvelope = true` won, `freqData` was never allocated, `pumpAudio` populated `s.a.fft[]` from the empty envelope, the hydra shader saw constant zero FFT input, the canvas was visually unresponsive to audio. p5 worked in the same scenario because the user sketch reads `stave.analyser` directly (no envelope path). Fix: invert the priority — analyser ALWAYS wins when present; envelope is fallback only. Issue #7, 2026-04-11.
+
+### P22: Buffer Size vs CSS Display Size on HiDPI
+**Root cause:** `canvas.width` / `canvas.height` are the BACKING-STORE (buffer) dimensions. On HiDPI/Retina (`devicePixelRatio > 1`), p5 (and other canvas libraries) double the buffer for crisp rendering — so `canvas.width = CSS_width × DPR`. Using buffer dims in layout math (CSS transforms, zone heights, scale factors) halves the visual width on Retina screens.
+**Detection signal:** Works in Playwright's default Chromium (DPR=1) and in Firefox (different p5 WEBGL pixel-density handling). Fails in Chrome on Mac with DPR=2: canvas appears at half-width, centered or left-aligned inside its zone.
+**The trap:** You think it's the viz sketch's problem, or the transform formula. You keep tweaking `computeLayout`, wrapper dims, scale math. None of those are wrong — the INPUT to the math is wrong.
+**Universal principle:** In any layout/transform math, ALWAYS use CSS display dimensions (`offsetWidth` / `offsetHeight`) — they're DPR-independent and reflect what the rendered layout sees. Use `canvas.width`/`height` only when drawing INTO the canvas (where you actually want buffer-native coordinates for sharpness).
+**First observed:** `readCanvasNative` in `packages/editor/src/visualizers/viewZones.ts` read `canvas.width | 0`. On Retina, that was 2880 for a 1440px CSS canvas. Scale became `contentW/2880 = 0.39`, visual width = 1440 × 0.39 = 560px (half). Fixed by switching to `canvas.offsetWidth | 0`. Branch `fix/track-analyser-producer`, commit `b0522d1`, 2026-04-14.
+
+### P23: Monaco View Zone Stored Descriptor — Mutate, Don't Recompute
+**Root cause:** Monaco's `editor.changeViewZones((acc) => acc.addZone(zone))` stores a REFERENCE to the `zone` descriptor object. Monaco re-reads `zone.heightInPx` from that reference for: (a) line-number positioning after the zone, (b) restoring the zone's height when it re-enters the viewport after `display:none` scroll-out. Updating `domNode.style.height` and calling `layoutZone(id)` is NOT enough — Monaco's internal `heightInPx` stays at the initial value.
+**Detection signal:** Two flavors. (1) Next line of code after the zone sits with visible empty space above it — gap proportional to (originalHeight − currentHeight). (2) Scrolling the zone off-screen and back resets its height to the uncropped initial value.
+**The trap:** You change `accessor.layoutZone(zoneId)` to be called more often, add `requestAnimationFrame` retries, or try to override with `!important` CSS. None of it works because Monaco's stored value is never touched.
+**Universal principle:** When a framework API takes an object and stores a reference, subsequent updates must MUTATE that same object. Don't replace, don't re-pass — keep the reference and patch it in-place. Match the framework's ownership model.
+**First observed:** After cropping an inline viz zone to e.g. `h:38%`, Monaco placed the next code line as if the zone were still full-height. Fixed by storing the `zoneDesc` object in `ZoneEntry` and mutating `entry.zoneDesc.heightInPx = layout.zoneH` on every layout recompute. Branch `fix/track-analyser-producer`, commits `911e9c6` + `5ac8b58`, 2026-04-14.
+
+### P24: Monaco onDidLayoutChange Excludes Scroll
+**Root cause:** `editor.onDidLayoutChange` fires only on editor-dimension changes (resize, font change, sidebar toggle). Scrolling is a separate event (`onDidScrollChange`). If your code re-computes view-zone geometry only on layout-change, scroll-triggered DOM repositioning is missed.
+**Detection signal:** Hit-testing against zone bounding boxes produces stale results after scroll. Floating UI (action bars, overlays) stays anchored to the cursor's last-tested zone even when the user has scrolled past it.
+**The trap:** You look at the event listener and assume "layout change" covers everything visual. The API naming misleads — scroll is layout-change's sibling, not subset.
+**Universal principle:** When your UI state depends on where zones are in screen space, subscribe to BOTH `onDidLayoutChange` AND `onDidScrollChange` and reuse the same handler. Scroll + resize are orthogonal events in Monaco; both shift DOM positions.
+**First observed:** Inline viz floating edit/crop action bar stayed visible with stale position after scrolling. Also used for re-asserting cropped zone heights on scroll-back since Monaco can reset `heightInPx` when un-hiding. Branch `fix/track-analyser-producer`, commits `911e9c6` + `78326be`, 2026-04-14.
+
+### P25: Async IDB Seed Races Synchronous Consumer
+**Root cause:** `StrudelEditorClient` seeds bundled VizPresets to IndexedDB via async `seedPresets()` in a useEffect (fire-and-forget, no await). Downstream consumers (`addInlineViewZones` → `VizPresetStore.getAll()`) may execute BEFORE the seed writes land. `presets.find(byName)` returns undefined. Any logic gated on `if (!preset) continue` silently skips.
+**Detection signal:** Feature works on second page load (IDB is populated) but fails on first load after clearing site data. Looks intermittent — depends on microtask ordering and IDB transaction speed.
+**The trap:** You think the feature itself is broken. You add Playwright probes that always pass because they run after the IDB has stabilized.
+**Universal principle:** Never gate workspace-file-scoped state behind a concurrently-seeded IDB read. Split responsibilities: per-instance overrides (zone-level, Y.Doc-backed) must be read BEFORE and independently of per-preset defaults. Fall back to defaults when the preset is missing, rather than skipping the whole path.
+**First observed:** Per-instance crop overrides (`zoneOverrides` Y.Map) were read inside `if (!preset) continue`. First page load: preset missing → skip → crop never applied. User pattern: save crop → close tab → reopen → crop "didn't save". Fixed by reading the override first, preset second. Branch `fix/track-analyser-producer`, commit `fd370b3`, 2026-04-14.
+
+
+### P26: Ref-From-Async-onMount Races Sync-Fired Subscription Initial Callback
+**Root cause:** Component subscribes to a bus/store whose `subscribe()` fires the callback SYNCHRONOUSLY once with current state. The callback guards on a ref populated by Monacos async `onMount`. On fresh mount while the bus already has a payload, the subscribe-time sync fire runs BEFORE onMount has assigned the ref — the guard fails silently, payload is lost. Later onMount assigns the ref but ref-assignment does not trigger a re-render, so no re-delivery mechanism ever runs.
+**Detection signal:** A component works at cold start (no publish yet, null payload) but is dead on any second / split / remount while the bus is already publishing. Audio / data keeps flowing but the UI shows stale or initial state.
+**The trap:** You suspect the subscription is wrong or the payload is wrong. You verify both are fine. You do not realize the ref was null only for the first dispatch and nobody redelivers.
+**Universal principle:** When a subscription fires synchronously on subscribe AND the consumer depends on a ref populated by an async child mount, gate the subscribe effect on a `ready` state flag that flips inside the mount handler. The state change re-runs the effect, which unsubscribes and resubscribes — the new subscribe-time sync fire redelivers the payload with the ref now populated.
+**Sister pattern:** `feedback_observer_wire_race.md` — Y.Map observer wire guarded with reference-check, not boolean. Same shape: subscribe-before-ready.
+**First observed:** Splitting an editor group while Strudel was publishing left the new groups inline viz and hap highlight dead. `EditorView` subscribed to `workspaceAudioBus`, callback guarded on `editorRef.current` which was null at the sync initial fire. Fix: `editorReady` state flipped in `handleMonacoMount`, added to the bus-subscribe effect deps. Issue #22, PR #23, commit `98f2fbb`, 2026-04-14.
+
+### P27: Positional Index Mapping Drifts When Source Positions Shift Mid-Edit
+**Root cause:** A live-update path maps stored objects to source positions by index (`trackKey `$N` → afterLines[N]`). Index `N` was assigned at evaluate time by the engine walking `$:` blocks in order. Between evaluations the user can insert/remove/reshuffle blocks — line numbers shift but the stored trackKey does not. Positional lookup returns `afterLines[N]` from the NEW code, which is now a different block. The stored object gets dragged to an unrelated position; if combined with a guard that defers on total-count change, the object sits at a stale afterLine that now lands inside another block.
+**Detection signal:** An inline zone, annotation, or marker "jumps" to a nearby but wrong location after the user edits unrelated code (inserts new blocks above, deletes a block, reorders). Re-evaluating fixes it — but during editing the object is misplaced.
+**The trap:** You add guards: "defer when block count changes" (handles one half); "skip when index out of range" (handles another). Neither handles the common "count stable but positions shifted" case; both leave the object stale instead of wrong.
+**Universal principle:** Dont use positional indices for live-update mapping across code edits. Anchor to the SOURCE TEXT itself — editor decorations track content edits for free. On content change, read the decorations current line, then walk source-structure outward (`$:` block start → end). The decoration IS the single source of truth.
+**First observed:** Inline viz zones drifted into unrelated block content when the user inserted a new `$:` block between existing ones or expanded a comment region. Before: `trackKey $N → scanStrudelBlockAfterLines()[N]` + count-change guard. After: Monaco `IEditorDecorationsCollection` planted on the `.viz("<name>")` source line with `stickiness: 1`; on content change read the decoration line, walk backward to enclosing `$:`, forward to block end, update `afterLineNumber`. Positional scanner deleted. Issue #29, commit `f7a752e`, 2026-04-14.
+
+### P28: Reentrant Mount Via Yjs Observer Firing Synchronously During Active Mount
+**Root cause:** A mount routine (e.g. `addInlineViewZones`) creates resources, then calls an internal bookkeeping API (`pruneZoneOverrides`) that `doc.transact()`s on a Y.Map. The `observeDeep` callback fires SYNCHRONOUSLY on transaction commit — still inside the outer mount. Observer notifies subscribers; one subscriber is a remount effect (`onNamedVizChanged` / `subscribeToZoneOverrides`). The remount effect reads the shared handle ref — which still points at the OLD handle because the outer mounts assignment (`ref.current = addInlineViewZones(...)`) has NOT completed yet (the RHS is still executing). Remount calls `cleanup()` on the old handle (no-op) and `addInlineViewZones()` AGAIN, creating a second set of resources and assigning THAT handle to the ref. Control returns to the outer mount; its return value overwrites the ref with its own handle. Net: two live resource sets in the framework (e.g. Monaco zones), only one reachable through the ref. Cleanup on next cycle misses the orphans.
+**Detection signal:** Duplicates of a resource (inline viz zones, listeners, renderers) accumulate after a specific user gesture. Stop/play / re-evaluate does not clear them — only a full unmount (page refresh) does. Count grows with each gesture; only one copy is reachable programmatically.
+**The trap:** You search for a missing `cleanup()` call. You audit every caller of the mount routine for duplicated dispatch. You find none. The reentry is INSIDE the mount itself, invisible from the outside.
+**Universal principle:** Internal bookkeeping mutations (prune, reconcile, invariant-restore) must not fire user-observable subscribers. When the underlying store exposes transaction origins (Yjs, redux, etc.), tag internal transactions with a distinct origin and filter them in the observer. Alternative: make the subscriber notification async (microtask) so it never reenters an active sync call. Origin filtering is cleaner — it encodes the intent (this mutation is not a user action) in the transaction itself.
+**First observed:** Adding a new `.viz("name")` block duplicated every pre-existing inline zone. `pruneZoneOverrides` inside `addInlineViewZones` did `doc.transact(..., STRUCT_ORIGIN)`. Y.Map `observeDeep` fired sync → `subscribeToZoneOverrides` notified → `EditorView`s `remount` effect re-entered `addInlineViewZones` before the outer assignment completed → two zone sets in Monaco. Stop/play only cleaned the reachable handles zones. Fix: new `PRUNE_ZONE_OVERRIDES_ORIGIN` (module-private Symbol) passed to `doc.transact`; `observeDeep` skips notification when `events[0].transaction.origin === PRUNE_ZONE_OVERRIDES_ORIGIN`. User-driven `setZoneCropOverride` still uses the default origin and fires subscribers normally. Issue #30, commit `1d4f69b`, 2026-04-15.
+**Sister patterns:** P20 (layout-shape remount wipes state) — both involve reentry during a parent operation. P28 is reentry via external subscriber; P20 is reentry via React reconciliation. Both share the remedy: lift stable state out of the reentrant zone.
+
+---
+
+### P29: Stale useCallback Closure Hides Fresh Props in Render IIFE
+
+**Detection signal:** A prop you can verify is reaching the component (logged at the top of render, fresh value present) shows up as the OLD value when read inside an IIFE deeper in the JSX tree. State updates from callbacks land in app state, are forwarded through component props, but the visible UI never reflects them.
+
+**Wrong fix (the trap):** Add yet more state propagation, suspect React reconciliation, suspect prop drilling, restart the dev server, blame turbopack caching, lift the value into context.
+
+**Real root cause:** The IIFE renders inside a `useCallback` whose dep array omits the prop. React keeps the previous closure alive — the closure captured the prop's old value at the previous render and continues returning that value even though the component itself is re-rendering with new data.
+
+**Real fix:** Add every prop / state read inside the `useCallback`'d render function to its dep array. Treat closures returned from `useCallback` as snapshots of their declaration moment unless you list the deps that should invalidate them.
+
+**Confirmed by:** Phase 4 backdrop crop (commit 173dafa range). Save → adapter.saveCrop → React state set → StrudelEditorClient re-render with new `backgroundCrop` (verified via `console.log` at component top), but `WorkspaceShell.renderGroup`'s IIFE saw `crop= null` (verified via `console.log` inside IIFE). Three rebuild + dev-restart cycles before noticing the dep array. Fix: add `backgroundCrop, backdropQuality, backdropOpacity, previewProviderFor, theme` to renderGroup's deps. Same root cause expected to bite any future prop added to the shell render — there's a comment in the deps list now naming this risk.
+
+**Implication:** When a render function reads N props/state, its useCallback dep array MUST list those N values. The React lint rule `react-hooks/exhaustive-deps` catches this if enabled — verify it's on for new files.
+
+### P30: Layered Opaque CSS Hides a Sibling at Lower zIndex
+
+**Detection signal:** A canvas/element renders correctly (verified via `canvas.toDataURL()` raw dump) but is invisible on the rendered page even though the layer above it is supposed to be transparent.
+
+**Wrong fix:** Tweak opacity, change blend modes, blame backdrop-filter stacking-context, swap quality factor, increase contrast.
+
+**Real root cause:** Multiple ancestor `<div>`s between the rendered surface and the viewport each paint `background: var(--background)` opaquely. The layer you "made transparent" was only ONE of them; others above it kept covering. CSS doesn't tell you about layers you didn't suspect.
+
+**Real fix:** Walk DOWN from the cluster you suspect, log every descendant's `getComputedStyle().backgroundColor`, filter to non-transparent. Every opaque ancestor between visible-region and the canvas must be neutralised (e.g., `[data-stave-code-panel][data-stave-backdrop="on"] [data-workspace-view="editor"] { background: transparent !important; }`).
+
+**Confirmed by:** Backdrop visibility fix (Phase 3). Monaco's `.monaco-editor` was set transparent but `[data-workspace-view="editor"]` (its parent in EditorView.tsx) painted `var(--background)` opaque, hiding the viz. Diagnostic: downward bg-walk found `rgb(9, 9, 18)` at depth 1 — that wrapper. Fix added to `globals.css`.
+
+**Implication:** "Make Monaco transparent" is not the same as "make the editor surface transparent." For backdrop-style features, neutralise every opaque div between the backdrop layer and the viewport. The downward bg-walk diag (in screenshot-p5-backdrop.spec.ts comments) is the canonical diagnostic.
+
+### P31: Extension-to-Language Map Mismatch Excludes Files Silently
+
+**Detection signal:** A file picker / filter shows fewer files than expected but throws no errors. Some extensions show; some don't. The "missing" extension's files exist in the project.
+
+**Wrong fix:** Re-check the file list subscription, re-check the projection, suspect Yjs not flushing, restart everything.
+
+**Real root cause:** The extension-to-language token used in code (`"p5"`) doesn't match the language token actually stored on the file (`"p5js"`). The map at `FileTree.tsx:1488` is the source of truth; consumers must match its outputs, not the extension string.
+
+**Real fix:** When filtering by `WorkspaceFile.language`, mirror the exact tokens emitted by `extensionToLanguage`. Currently: `'strudel' | 'sonicpi' | 'hydra' | 'p5js' | 'markdown'`. NOT `'p5'`.
+
+**Confirmed by:** Backdrop popover dropdown showed only `.hydra` files; every `.p5` file was filtered out by `f.language === "p5"` (should have been `"p5js"`). Took a user report to surface — no error, just silent absence.
+
+**Implication:** Centralise the tokens. Better long-term: export the language constants as a const enum from FileTree's helper module so consumers can't typo them.
+
+---
+
+### P32: Blanket CSS `*` Rule Kills Functional Backgrounds
+
+**Detection signal:** A visual element (selection highlight, minimap slider, scroll visor) works in normal mode but disappears when a CSS mode switch activates (e.g., backdrop on).
+
+**Wrong fix:** Add more specificity to the missing element's styles, suspect z-index, suspect display toggling.
+
+**Real root cause:** A blanket wildcard rule (`[scope] .parent *`) sets `background-color: transparent !important` on ALL descendants. The functional element paints via `background-color` — the wildcard kills it. The original comment claims "highlights paint via borders" but that's wrong for many Monaco classes.
+
+**Real fix:** Exempt functional elements from the blanket rule using `:not(.selected-text):not(.selectionHighlight):not(.minimap-slider-horizontal)` etc. Enumerate each class that paints via background-color.
+
+**Confirmed by:** Selection highlight (P46), minimap scroll visor — both killed by `.monaco-editor *` transparent rule in backdrop mode.
+
+---
+
+### P33: Monaco Pointer Capture Blocks View Zone Event Handlers
+
+**Detection signal:** A click/drag handler inside a Monaco view zone's DOM node registers correctly (hover effects work via CSS/mouseenter), but mousedown/pointerdown never fires the handler.
+
+**Wrong fix:** Try different event types, add capture listeners, use stopPropagation.
+
+**Real root cause:** Monaco's `.monaco-scrollable-element` calls `setPointerCapture()` on pointer events, routing all subsequent pointer events to itself. Handlers on child elements (like view zone DOM nodes) never receive the events.
+
+**Real fix:** Register the handler on the view zone CONTAINER in capture phase, and call `resizeHandle.setPointerCapture(e.pointerId)` to steal the pointer capture from Monaco. Use `pointermove`/`pointerup` on the handle (not document) since pointer capture routes events to the capturing element.
+
+**Confirmed by:** Inline viz resize handle — hover worked, drag didn't. Fixed by setPointerCapture on the handle.
+
+---
+
+### P34: Zone Override Subscriber Triggers Full Remount on Every Write
+
+**Detection signal:** Persisting a zone override (crop, height) causes the zone to flash/reset to its default state, even though the override was just saved with the correct value.
+
+**Wrong fix:** Add timing delays, defer the persist, use requestAnimationFrame.
+
+**Real root cause:** `setZoneHeightOverride` mutates the Yjs zone overrides map. The `subscribeToZoneOverrides` observer fires, calling `remount()` in EditorView, which destroys all zones and recreates them. The recreated zones read the override correctly but the remount itself causes a visual flash and resets in-progress drag state.
+
+**Real fix:** Use a dedicated transaction origin (`HEIGHT_RESIZE_ORIGIN`) for height writes. The observer checks the origin and skips subscriber notification for this origin.
+
+**Confirmed by:** Drag-to-resize reverted on mouseup because the persist triggered remount.
+
+---
+
+### P35: Position-Based TrackKeys Break Overrides on Block Reorder
+
+**Detection signal:** After reordering `$:` blocks, cropping one inline viz applies the crop to a different viz.
+
+**Wrong fix:** Clear all overrides on re-evaluate, or use line numbers as keys.
+
+**Real root cause:** Anonymous `$:` blocks get sequential trackKeys (`$0`, `$1`...) based on source position. Overrides are keyed by trackKey. Reordering blocks reassigns keys, but old overrides persist — `pruneZoneOverrides` only checks vizId, not block content. When both blocks use the same viz, both overrides survive at the wrong positions.
+
+**Real fix:** Store a content hash (first 120 chars, whitespace-normalized) in each override. `pruneZoneOverrides` compares stored hash against current block content at each trackKey. Mismatched content = stale override = pruned.
+
+**Confirmed by:** Rearranging `.viz("p5test")` blocks caused crop cross-contamination.
+
+---
+
+### P36: reAnchorZones Swallows Lines Typed After .viz()
+
+**Detection signal:** Text typed after a `.viz()` line appears BETWEEN the `.viz()` call and the inline viz zone, instead of below the zone.
+
+**Wrong fix:** Change decoration stickiness, adjust afterLineNumber offset.
+
+**Real root cause:** `reAnchorZones` scans forward for the block's last non-empty line to position the zone. Gibberish typed after `.viz()` is a non-empty line that doesn't start with `$:`, so the scan includes it as a block continuation, pushing the zone below the gibberish.
+
+**Real fix:** Stop the block-end scan at the `.viz()` call itself (`/\.viz\s*\(/.test(line)`). The `.viz()` line is always the last meaningful line of a block. Falls back to last-non-empty scan if `.viz()` was deleted.
+
+**Confirmed by:** Typing gibberish after `.viz("pianoroll")` pushed the zone below the text.
+
+---
+
+## P37 — Sync React setState inside a runtime error handler can unmount the tree
+
+**Category:** React / Monaco / engine boundary
+**First observed:** 2026-04-19, friendly-errors-console session — StatusBar disappears after a Strudel `ReferenceError` eval.
+
+**Symptom:** After a bad Strudel eval, `[data-stave-statusbar]` vanishes from the DOM. Page errors include `Illegal value for lineNumber`, `Failed to execute 'removeChild' on 'Node'`, and `Canceled`. Valid evals don't trigger it.
+
+**Detection signal:** Any time an engine callback (`runtime.onError`, `engine.setRuntimeErrorHandler`, custom `subscribeLog`) fires DURING a React commit — e.g. Monaco's own `setModelMarkers` path is in the middle of committing when the callback calls `setState`.
+
+**The trap:** "My new `emitLog` subscriber crashed the tree." No — reproduces on main without the subscriber (only the existing StrudelEditorClient `setRuntimeStates` call is enough). Touching subscriber code won't fix it.
+
+**Real root cause:** Monaco's `setEvalError` → marker-commit path throws for Strudel errors whose location metadata doesn't map to a real line. The throw happens during React's commit phase (inside a useEffect child-update). React then unmounts the whole subtree because there's no ErrorBoundary guarding Monaco's children.
+
+**Real fix (not landed yet):** wrap Monaco marker updates in try/catch; validate line numbers before passing to `editor.setModelMarkers`; add an ErrorBoundary around the editor view so a marker-set throw doesn't cascade into the status bar / menu bar.
+
+**Stopgap:** defer any NEW engine-log subscribers to `queueMicrotask` inside `emitLog` so we don't amplify the pre-existing bug. Doesn't fix root cause but avoids making it worse.
+
+**Confirmed by:** Reverting my engine-log bridge AND the whole StatusBar subscribe still reproduced the unmount on a `ReferenceError: notes is not defined` eval.
+
+---
+
+## P38 — Registry key mismatch silently breaks click-to-source
+
+**Category:** Editor / workspace registry / IR Inspector boundary
+**First observed:** 2026-05-02, IR loc-tracking session — Inspector click on event row didn't move cursor.
+
+**Symptom:** User clicks an IREvent row in the IR Inspector panel that has a populated `loc`. No error, no console warning, but the editor cursor doesn't move. Visible state is identical before and after.
+
+**Detection signal:** Any time a downstream component looks up a resource via a key (`fileId`, `presetId`, `runtimeId`) that was sourced from a different field than the registrar used. The lookup returns `undefined`, the no-op-on-miss code path runs silently.
+
+**The trap:** "The click handler must be broken — let me debug `revealLineInFile`." It isn't broken; it returns `false` (editor not found) and the caller doesn't surface that. Walking through the click handler in DevTools shows it executing without error, so the bug looks like it's deeper inside Monaco.
+
+**Real root cause:** `IRSnapshot.source` was populated with `fileNow.path`, but `revealLineInFile(fileId, line)` keys the editor registry by the workspace-file `id`, not the path. The two happen to be equal for some shapes and differ for others — silently wrong on whichever shape mismatches.
+
+**Real fix:** publish `fileNow.id` as `IRSnapshot.source`. Update JSDoc to make the field's contract explicit ("the registry key, not a human-visible label").
+
+**Lesson:** When wiring a NEW handler that looks up registered resources, verify the lookup HIT — not just that the call didn't throw. `if (!found) return false` is a silent failure mode. Either log on miss or add a unit test that asserts the lookup succeeds end-to-end.
+
+**Confirmed by:** Cursor moved correctly after switching `source` from `path` to `id`. Live-browser smoke confirmed.
+
+---
+
+## P39 — Parser pipelines that trim/concat destroy source-range info
+
+**Category:** Parser architecture / source-location tracking
+**First observed:** 2026-05-02, IR loc-tracking session — `parseStrudel`'s original `extractTracks` lost offsets via `.trim()` + `\n`-concat.
+
+**Symptom:** When you go to add `loc` (source ranges) to a parser pipeline AFTER the fact, intermediate string transformations have already dropped position information. There's no way to recover the original char offset of an atom inside a Stack track once the input was trimmed and rebuilt.
+
+**Detection signal:** Any function in the parser chain that does:
+- `input.trim()` — drops leading/trailing whitespace position
+- `chunks.join('\n')` — rebuilds a string whose offsets don't correspond to the original
+- `slice(2)` after a structural marker (e.g. `$:`) without recording where the slice started
+- Any recursion that takes a substring without threading a `baseOffset` parameter
+
+**The trap:** "I'll just `.indexOf()` the matched substring in the original code." Works for unique substrings, breaks the moment the user has two `note("c4")` calls — `.indexOf` returns the FIRST one, which may not be the one being parsed right now.
+
+**Real root cause:** The parser was written for a stage where loc didn't exist, so every helper happily mangled string content. Adding loc to such a pipeline is a refactor, not an addition.
+
+**Real fix:** thread `baseOffset` through every parser entry point. Rewrite slice-producing helpers to return `{ slice, offset }` pairs. For parseStrudel specifically: scan with a regex that records both the structural marker position AND the body start; return `{ expr, offset }[]` from the absolute-position slice (no trim, no concat).
+
+**Lesson:** If a parser has any chance of needing source-range tracking later, design it offset-aware from day one. Threading `baseOffset` through helpers from the start is trivial; retrofitting it across already-mangled string surgery is high cost.
+
+**Confirmed by:** parseStrudel offset-aware refactor (PR #65) — all 1007 tests still green; 12 new loc tests pass; live-browser cursor jump works.
+
+---
+
+## P40 — Curated friendly-error hints can ship "wrong" silently
+
+**Category:** Friendly errors / runtime hint authoring
+**First observed:** 2026-05-02, unified-FES session — the seeded p5 `windowWidth is not defined` hint never fired because p5 v2 still exposes `windowWidth` as a sketch-instance getter.
+
+**Symptom:** A `commonMistakes` entry was added with a message regex that matched a plausible-looking error. Unit tests passed (fed in a fabricated error message). But in the live runtime, that error message never actually fires — the user gets no hint, and the maintainer thinks the hint works because tests are green.
+
+**Detection signal:** Any new `commonMistakes` entry whose detection trigger was inferred from documentation or "what users probably hit," NOT from a captured live failure.
+
+**The trap:** "p5 v2 docs say windowWidth was removed, so it must throw a ReferenceError when accessed." It doesn't — Strudel/p5/Hydra wrap user code in `with (sketch) { ... }` which falls through to `window.windowWidth` (undefined) for unknown identifiers OR returns `undefined` for instance properties not there. Neither throws.
+
+**Real fix:** before shipping any curated hint, reproduce the trigger live (Playwright or manual browser), capture the actual error message that fires, write the regex against THAT message. If you can't reproduce, drop the hint — keep the schema slot wired but unfilled. A wired-and-empty slot is honest; a wired-and-wrong slot looks like coverage but isn't.
+
+**Lesson:** "If you can't demo it, don't ship it" applies harder to friendly errors than to most features. A failed UI element shows; a failed friendly hint silently degrades the empty-state experience.
+
+**Confirmed by:** Dropped the p5 `windowWidth` hint in PR #57 self-review after live-browser smoke showed it never fired. Replaced with empty `globalMistakes: []` slot + comment.
+
+
+## P41 — Stacked PR auto-retarget silently fails when base branch is deleted
+
+**Category:** GitHub workflow / stacked PRs
+**First observed:** 2026-05-02 — PR #65 (loc-tracking) was stacked on PR #63 (Inspector v0). After #63 squash-merged into `main`, GitHub deleted the head branch `feat/ir-inspector-v0`. PR #65's base remained pointed at the deleted branch. Merging #65 marked it MERGED on the API but the merge target was a tombstone — the loc-tracking commits never reached `main`. Status badge said "merged"; `git log origin/main` did not contain the commits.
+
+**Symptom:** A stacked PR shows MERGED in the GitHub UI but `git log main` doesn't contain its commits. CI on subsequent work appears to "lose" features that the user remembers shipping. Worst-case: you ship dependent work on the assumption a feature is on main, only to find it isn't.
+
+**Detection signal:** After merging a stacked PR, `git diff main..feature-branch` is non-empty even though the PR is marked merged. `gh api repos/X/Y/pulls/N --jq .base.ref` returns a branch name that no longer exists (`gh api repos/X/Y/branches/<base>` returns 404).
+
+**The trap:** "GitHub auto-retargets stacked PRs when the base merges, right?" Sometimes yes (UI-side, before merge). NOT after the base is deleted. The merge proceeds against the deleted ref, succeeds at the API level, and lands nowhere.
+
+**Real fix (preventive):** Before merging a stacked PR, verify its base. If the base branch was deleted (because its PR was squash-merged with branch deletion), retarget to `main` first via `gh pr edit N --base main`. Or: avoid stacking entirely on small projects — open the second PR off `main` once the first lands.
+
+**Real fix (recovery):** Cherry-pick the orphaned commits into a new branch off `main`, open a fresh PR. (This session: fix/ir-loc-tracking → PR #66, replacing the orphaned #65.)
+
+**Lesson:** Trust `git log origin/main` over GitHub's MERGED badge. The badge says "the merge ran." It does not say "the changes are on main." For stacked PRs, the base branch's deletion races the second PR's merge — verify the destination, don't infer it from the badge.
+
+**Confirmed by:** PR #66 successfully landed the orphaned commits from #65 onto main; full diff verified before/after. Same gotcha cannot recur silently because the rule is now: `git diff main..HEAD` after every "merged" PR you depended on.
+
+
+## P42 — Predicate-direction inversion silently passes count-equality assertions
+
+**Category:** test design / parity verification
+**First observed:** 2026-05-03 — Phase 19-03 Wave 3, `Degrade` collect arm.
+
+**Symptom:** Implementation of a probabilistic filter passes a symmetric-probability parity test (e.g., p=0.5: ~50% retention either way produces ~same count) but produces a different *set* of retained events than the reference. Asymmetric probe (e.g., p=0.2) reveals the inversion: same total count, but the *opposite* events are kept.
+
+**Detection signal:** Symmetric-probability test green; asymmetric-probability test red on COUNT (or red on SET when count happens to coincide). Re-running the symmetric test still passes. The implementation looks superficially correct because the symmetric case is direction-agnostic.
+
+**The trap:** "Counts match — the filter works. The set difference must be a hashing/seeding nuance." You start chasing seed-state divergence instead of the predicate. Or worse, you weaken the parity to count-only and ship a backwards filter.
+
+**Real fix:** include at least one *asymmetric* probe in any parity test of a probabilistic or threshold-based operator. Strudel's `degrade` predicate is `rand > drop_amount` (strict, `signal.mjs:679`). Our retention `p = 1 - drop`, so the correct ours-side predicate is `seededRand > (1 - p)`, not `< p`. The asymmetric `.degradeBy(0.8)` probe (p=0.2) caught the inversion immediately; the symmetric `.degrade()` (p=0.5) had hidden it.
+
+**Lesson:** Symmetric tests for symmetric properties are tautological — they pass regardless of direction. Asymmetric probes exercise direction. Build at least one in for any threshold operator, predicate filter, comparison-based selector.
+
+**Confirmed by:** Phase 19-03 W3, commit `a769827`. The predicate was inverted on the first implementation; the asymmetric probe (which existed only because the plan-checker explicitly asked for it as warning #4) was the only test that distinguished correct from inverted. The symmetric `.degrade()` probe was green in both versions.
+
+
+## P43 — External-system documented spec disagrees with source-code implementation
+
+**Category:** grounding / Lokayata enforcement
+**First observed:** 2026-05-03 — Phase 19-03, three independent cases in one phase.
+
+**Symptom:** A behavioral claim sourced from documentation, plan text, or a research summary is contradicted by direct read of the dependency's source code. The "spec" describes algorithm A; the actual implementation does B. Building against the spec produces output that diverges from the dependency under test conditions.
+
+**Detection signal:** Strict parity / behavioral comparison fails despite confident-sounding spec. The fix that "should work per docs" doesn't. Re-reading the docs reinforces the wrong model. Reading the source resolves it in minutes.
+
+**The trap:** "The plan / research / docs all agree on the algorithm. The bug must be in OUR implementation." You debug for an hour assuming the spec is right. The actual answer was a 5-minute source read away.
+
+**Three cases this phase:**
+1. **`off` desugar order** — research and plan both stated `Stack(body, Late(t, transform(body)))`. `pattern.mjs:2236-2238` is `func(pat.late(time_pat))` — transform OUTSIDE Late. Strict parity caught it on first run (8 ours vs 12 Strudel).
+2. **`repeatCycles` semantics** — orchestrator brief and plan both said it "slows the body to span n outer cycles." Direct probe + re-read of `pattern.mjs:2530-2545` showed it REPEATS the source cycle on every outer cycle (`delta = cycle - source_cycle`). Opposite of slow.
+3. **`ply` desugar via `Fast(n, Seq(body × n))`** — plan and research said this would work. Probe showed our `Fast` IR scales `ctx.speed` without re-playing body, so the desugar collapsed all events into `[0, 1/n)` instead of spreading across `[0, 1)`. Forced a new `Ply` tag.
+
+**Real fix:** Before modeling any external operator, READ the source. Cite `file:line`. Don't trust prose summaries — including your own. The cost of one source read is 5-10 minutes; the cost of debugging an ungrounded model is hours plus a retracted commit.
+
+**Real fix (preventive):** When designing a parity or behavioral-equivalence test against an external system, run the test against the FIRST candidate model BEFORE writing the implementation. The test result is the cheap arbiter. Failing fast against a 10-line probe beats failing slow against a 200-line implementation.
+
+**Lesson:** Lokayata over inference, every time. Plans, research notes, and docs are claims; source code is truth. The strict parity harness IS Lokayata — it confronted three documented-but-wrong models in one phase, each within minutes of running.
+
+**Confirmed by:** Phase 19-03 W2 (off desugar correction), W3 (repeatCycles correction), W4 (Ply tag pivot). Each correction came from running the strict harness against the documented model. Each took <30 minutes from "docs say X" to "source says Y; harness confirms Y." Without the harness, all three would have shipped wrong.
+
+
+## P44 — Documented spec under-specifies span semantics in re-timing operators
+
+**Category:** grounding / Lokayata enforcement (P43 specialization for span vs. point semantics)
+**First observed:** 2026-05-03 — Phase 19-03 (P43's three cases). Recurred 2026-05-04 — Phase 19-04 W3 Struct (4th in-codebase hit).
+
+**Symptom:** A re-timing operator (`struct`, `keepif`, `chunk`, `off`, `late`) is wired with point-membership semantics (`mask.has(e.begin)`) when the source-of-truth implementation uses span-intersection (`appRight`, `e.begin < slotHi && e.end > slotLo`). The unit tests pass for events whose `begin` lands exactly on a mask onset; events whose span CROSSES an onset boundary but whose `begin` lies in a silence slot are silently dropped. Parity diverges on bodies whose events have non-trivial duration.
+
+**Detection signal:** Parity count divergence in re-timing operators when the body has events with `duration > 1/N` (where N = mask resolution). Tests built from "one event per slot" hide the bug; tests with overlapping spans expose it.
+
+**The trap:** The operator's docstring ("draws values from `pat`," "selects events at mask onsets") reads as point-membership. Writing the collect arm with begin-membership produces missing events whose begin times fall in silent slots even though their spans extend into onset slots. Re-reading the doc reinforces the wrong model. Reading the source (`pattern.mjs:1161` for struct → `_keepif` → `appRight`) shows span-intersection is the actual contract.
+
+**Real fix:**
+1. For any re-timing operator, READ the source's span-handling primitive (`appRight`, `appLeft`, `_keepif`, `squeezeBind`, etc.) before writing the collect arm.
+2. Use `e.begin < slotHi && e.end > slotLo` for span-intersection — never `mask.has(e.begin)` alone.
+3. Verify with a probe whose body events have `duration > slot width` — the bug only surfaces under that condition.
+
+**Real fix (preventive):** Add a row to the parity harness for every re-timing operator with a body of `Pure(...)` × N where N events are guaranteed to span more than one slot. The asymmetric coverage forces span-intersection from the start.
+
+**Lesson:** P43 covered "spec says A but source does B" generically. P44 specializes to **span semantics** — the most common failure mode for re-timing operators. The operator's documentation says nothing wrong; it just doesn't say enough. Source is the only place where "what is in the slot" gets defined precisely.
+
+**Confirmed by:** Phase 19-04 W3 Struct (initial collect arm used `mask.has(e.begin)`; parity caught the divergence on a 2-cycle probe; fix used span-intersection). Cumulative: P43's three Phase 19-03 cases + this case = 4 in-codebase hits within 2 phases on adjacent operators.
+
+---
+
+## P45 — Containment-vs-equality on multi-loc `Play.loc` array
+
+**Category:** assertion-shape / observation-conflation (silent test pass under structural mismatch)
+**First observed:** 2026-05-04 — Phase 19-05 W7 (D-11 containment-helper design); promoted at 19-05 W9 after RESEARCH §8 + §10 #6 confirmed forward-compat risk.
+
+**Symptom:** A test that asserts `event.loc` equality with a fixed
+single-element array — `expect(event.loc).toEqual([{ start: 12, end:
+17 }])` — passes on every plain mini-notation input today. When
+mini-notation `!N` repetition lands (currently NOT implemented in
+`parseMini.ts`; see RESEARCH §8), the same input produces
+`Play.loc.length > 1` (multiple source ranges per node from polymetric
+or repetition origin). The `toEqual([...])` assertion silently fails
+on those inputs, but the parser/collect arm itself is correct — the
+test is wrong.
+
+**Detection signal:** Parity test green on plain inputs (`s("bd hh")`
+→ single-element loc); red on `!N`-bearing inputs once that mini-notation
+feature ships (`s("bd!2 hh")` → 2-element loc on the `bd` event). The
+red wave appears at the boundary between "current parseMini coverage"
+and "future mini-notation feature." Any test that passes today and
+fails the day `!N` lands is a P45 instance.
+
+**The trap:** `Play.loc` is typed `SourceLocation[]` — a list, not
+a single value — exactly to support multi-range origin
+(`@strudel/core`'s `context.locations` collects all locations a hap's
+value flowed through). Tests authored assuming a single-element array
+silently bake in the wrong shape. The test author reads "loc is
+SourceLocation[]" and writes `toEqual([X])` — semantically: "loc is
+exactly one X." But the actual semantic claim is: "loc CONTAINS the
+range that produced this event somewhere among its members."
+
+**Real fix (CURATIVE):** Use the D-11 containment helper
+`assertEventLocWithin(event, code, subExpr)`:
+
+```ts
+const subStart = code.indexOf(subExpr)
+const subEnd = subStart + subExpr.length
+expect(event.loc!.some(l => l.start >= subStart && l.end <= subEnd))
+  .toBe(true)
+```
+
+The `some()` is the load-bearing operator. It handles both 1-element
+and N-element arrays uniformly: "is there at least one element in
+loc whose range falls within the source-range of the originating
+sub-expression?" This is the actual semantic claim ("event came from
+somewhere inside the sub-expression").
+
+**Real fix (PREVENTIVE):** When adding any new `event.loc` assertion,
+default to containment via `assertEventLocWithin`. Reach for `toEqual`
+ONLY when:
+1. The test exhaustively enumerates a known multi-loc shape (e.g., a
+   regression test specifically for a multi-element loc bug).
+2. The element count is part of the assertion's claim, not incidental.
+
+If the test author can't articulate which case applies, default to
+containment.
+
+**Lesson:** Discriminated arrays in IR types (`SourceLocation[]`,
+`PatternIR[]`) carry semantic shape information beyond what the
+type declaration says. A list type is a HINT: "this can have more
+than one." Testing as if it always has exactly one bakes in a
+silent gap. The shape of the list is part of the contract; tests
+should mirror the contract's flexibility, not the current
+implementation's narrowness.
+
+**Confirmed by:** Phase 19-05 D-11 (containment-match parity
+assertions explicitly chosen over exact-offset matching for this
+reason); W7 the 17 per-method `it()` blocks + the 5 round-trip
+subset blocks all use `assertEventLocWithin`; RESEARCH §8 verified
+that `!N` is not implemented today but the type's multi-element
+shape is forward-compatible. The first concrete failure case will
+appear when `!N` lands in a future mini-notation phase; tests
+written today using `assertEventLocWithin` will continue to pass
+without changes.
+
+## P46 — Display-layer projection that hides nodes by default must whitelist parser-failure escape-hatch tags
+
+**Symptom (would-be):** Strudel users see a clean projected Inspector
+tree of their `.layer().jux().off()` patterns — but when their code
+contains a typo like `nooote("c d")` (unparseable), the parser falls
+back to a `Code` IR tag and the projected tree shows... nothing.
+The error is invisible. The user sees an empty tree and assumes
+everything is fine, when in fact the parser silently dropped a
+significant chunk of source. By the time they notice the missing
+audio output, they have no Inspector signal pointing at the failing
+expression.
+
+**Caught BEFORE shipping (planning-time catch).** Phase 19-06
+RESEARCH §3 audit + NEW pre-mortem #8 surfaced the trap during
+planning. Without the audit, the projection rule "if `userMethod ===
+undefined`, splice children into parent (D-02 hide rule)" would have
+applied uniformly — and `Code` carries `userMethod === undefined`
+(parser-failure fallback, no user-method name to record).
+
+**Root cause:** Display-layer projections that operate on
+`userMethod` as a "did the user author this" signal conflate two
+populations:
+1. Synthetic intermediate tags created by desugars (Late inside
+   `.off()`, FX(pan) inside `.jux()`) — `userMethod === undefined`
+   because the user didn't author them directly. SAFE TO HIDE.
+2. Parser-failure escape-hatch tags (`Code` today; future
+   `Unparseable`, etc.) — `userMethod === undefined` because the
+   parser couldn't classify the input. MUST NOT HIDE.
+
+Both populations look the same to a naive `userMethod === undefined`
+check. The hide rule that's correct for population 1 silently
+degrades debuggability for population 2.
+
+**The trap:** Adding a "projection" or "user-friendly view" layer
+that filters by absence-of-author-signal. The natural rule
+("undefined → hide") is right 99% of the time and catastrophically
+wrong the remaining 1% — and the wrongness manifests as INVISIBLE
+output, the worst possible failure mode for a debugger.
+
+**Wrong fix (TEMPTING):** Make the parser populate `userMethod`
+on Code-tags too (e.g., `userMethod: '?unparseable'`). This:
+- Pollutes the `userMethod` namespace with non-user-typed values,
+  breaking PV31's exact-token taxonomy
+- Forces every consumer to filter the synthetic strings out of
+  search/grouping/canonicalization
+- Doesn't actually fix the underlying problem — the projection
+  layer still has to decide WHEN to render the parser-failure
+  escape-hatch differently from a real method
+
+**Real fix (PREVENTIVE):** Maintain a small whitelist of tag-name
+exceptions in the projection's hide-rule. Today the whitelist is
+`{ Code }`. New parser-failure escape-hatches added in the future
+get added to the whitelist explicitly. The check becomes:
+
+```ts
+if (node.userMethod === undefined && !PARSER_FAILURE_TAGS.has(node.tag)) {
+  // hide: splice children into parent
+} else {
+  // render with raw tag name
+}
+```
+
+Where `PARSER_FAILURE_TAGS = new Set(['Code'])` is a module-scope
+constant adjacent to the projection rules.
+
+**Lesson:** Display-layer rules that operate on absence-of-signal
+to hide nodes need to enumerate which absence-bearers are
+intentionally invisible vs. which are visibility-critical-failures.
+The default-hide rule is a debuggability footgun unless the
+escape-hatch population is explicitly named.
+
+**Confirmed by:** Phase 19-06 RESEARCH §3 (userMethod field
+coverage audit caught the gap); CONTEXT NEW pre-mortem #8 (recorded
+the trap and the fix); PLAN T-02 (`projectedLabel` includes the
+explicit `Code` case returning `'Code'`); T-03 unit test
+("Code-fallthrough whitelist test — Code MUST render with label
+'Code', not be hidden"); PR #78 ships the whitelist as
+`PARSER_FAILURE_TAGS` (or equivalent — final naming locked at
+implementation). Promotion based on a single occurrence justified
+because (1) the failure mode is silent (would not have been caught
+post-ship by tests that don't probe parser-failure inputs) and
+(2) the trap is structurally tempting at every future projection
+layer (FE error messages, code-synthesis preview, transform-graph
+display, bidirectional-editing surfaces — each is its own future
+opportunity to repeat the mistake without this catalogue entry).
+
+## P47 — Stage-transition synthetic metadata escape (P39 specialization)
+
+**Symptom:** A per-stage round-trip test that asserts "every `loc`
+field present at stage N is preserved at stage N+1 with same byte
+offsets" fails on the multi-track outer Stack wrapper at the
+MINI-EXPANDED → CHAIN-APPLIED transition. The outer Stack carries
+`loc: [{start: 0, end: code.length}]` at MINI-EXPANDED but has no
+loc at CHAIN-APPLIED. The probe reports "loc dropped at CHAIN-APPLIED"
+— but no real source-correspondence was lost; the outer loc was
+synthetic-from-RAW for tab visualization, not a real anchor.
+
+**Caught at:** Phase 19-07 PR-B T-10.b1 (universal loc-equality
+probe, REV-2). The 6-fixture set included two multi-track `$:`
+patterns; both failed the naive equality assertion. **Catching
+observation:** `expect(caKeys.has(key)).toBe(true)` failed with
+`Stack tag=Stack start=0 end=28` for `$: note("c d")\n$: s("bd hh")`.
+
+**Root cause:** A pipeline stage may carry a SYNTHETIC anchor whose
+purpose is presentation (Inspector tab visualization showing "what
+this stage saw") rather than source-correspondence. When a later
+stage rebuilds the structure to match the canonical engine shape,
+it intentionally drops the synthetic anchor. A test that treats
+every loc as a real source-correspondence will report a false drop.
+
+The trap is two layers deep:
+1. **At impl time:** the synthetic anchor on RAW's outer Stack is
+   correct (it tells RAW-tab viewers "this is the source span this
+   stage operated on"). Today's `parseStrudel(code)` for multi-track
+   `$:` produces an outer Stack with NO outer loc — see
+   `parseStrudel.ts:66`'s `IR.stack(...tracks.map(parseExpression))`.
+   So CHAIN-APPLIED faithfully matches today's shape by dropping
+   the synthetic.
+2. **At test time:** a naive "every loc preserved" assertion would
+   force CHAIN-APPLIED to retain the synthetic, breaking byte-shape
+   parity with `parseStrudel`.
+
+**The trap:** Either of the two wrong fixes:
+- (a) Force the synthetic outer loc to survive into CHAIN-APPLIED.
+  This breaks byte-shape parity with today's `parseStrudel(code)`
+  output; the regression sentinel (T-05.c) would catch it but only
+  for fixtures that hit the multi-track path. Other fixtures pass
+  silently.
+- (b) Drop the synthetic outer loc at MINI-EXPANDED to make the
+  test pass. This breaks the RAW tab's source-span visualization,
+  which IS the intended affordance — the user sees "this stage
+  operated on the full source." A blind regression unrelated to
+  the test's actual goal.
+
+**Real fix (skip-the-synthetic):** When walking stage transitions
+for round-trip equality, identify and skip synthetic-from-stage
+anchors. Concretely: a Stack at the root with `userMethod ===
+undefined` is a synthetic-from-RAW outer wrapper for multi-track
+$: input. Skip its loc entry from the comparison; assert all
+non-synthetic loc entries (every Cycle/Seq/Stack/etc. inside the
+tracks) are preserved.
+
+```ts
+const isSyntheticOuter =
+  me.tag === 'Stack' &&
+  (me as { userMethod?: string }).userMethod === undefined
+const meEntries = collectLocEntries(me).filter(
+  (e, i) => !(isSyntheticOuter && i === 0),
+)
+```
+
+**Why this is a P39 specialization:** P39 names the general failure
+of parser pipelines that trim/concat — losing source-range info
+silently. P47 is the controlled, documented case: the pipeline
+deliberately drops a synthetic anchor at a stage transition to
+match the canonical downstream shape. The synthetic was correctly
+introduced (RAW tab UX); its drop is correct (FINAL parity); the
+test must distinguish synthetic from real anchors.
+
+**Generalization to future stages:** Any future stage transition
+that inserts a presentation-only anchor must mark it (e.g., via
+a sentinel `userMethod` value or a `synthetic: true` field) so
+round-trip tests can identify and exclude it. Or the convention —
+"at stage N, an outer wrapper with `userMethod === undefined` is
+synthetic" — must be documented and respected by every transition
+test.
+
+**Confirmed by:** Phase 19-07 PR-B T-10.b1 (universal loc-equality
+probe; 6 fixtures including 2 multi-track `$:`); the FINAL parity
+sentinel T-05.c (held green across all fixtures). The 6-fixture set
+is the regression surface.
+
+**Cross-references:**
+- **P39** — parser pipelines that trim/concat destroy source-range
+  info. Parent pattern.
+- **PV25** — parser preserves offsets at every hop. The invariant
+  P47's specialization respects: real anchors are preserved;
+  synthetic-from-stage anchors are exempted from the invariant
+  with explicit documentation at the catalogue level.
+- **D-02 / 19-07 stage boundaries** — the source of the synthetic
+  anchor convention.
+- **D-04 / 19-07 uniform projection** — the user-visible payoff
+  of the synthetic anchor (Inspector tab UX).
+
+
+## P48 — External-store hook returns the live mutable buffer reference; downstream useMemo goes stale
+
+**Pattern:** A React hook subscribes to a module-level mutable
+collection (ring buffer, Set, in-place-sorted array) and returns
+the live reference from `getStorage()` directly. A consumer derives
+state with `useMemo([liveRef, ...])`. Pushes that GROW the buffer
+trigger setState (subscriber fires) and the memo recomputes — looks
+correct in casual testing. Pushes that EVICT (in-place `shift`,
+`splice`, in-place mutation) preserve the array's identity but
+change its contents. The dep array sees a referentially stable
+value, useMemo skips recomputation, and the cached derived value
+goes stale.
+
+**Symptom:** UX hazard that depends on the derived state crossing
+a buffer mutation boundary. Manifests as: a "found" indicator that
+never updates after the underlying entry is evicted, a count that
+freezes at a stale total, a "is in" check that returns true
+indefinitely after removal.
+
+**Detection:** the test for the eviction path fails. Pure-grow
+tests pass. Code review surfaces this when reading the hook —
+"why does it return getStorage() directly?" The bug is in the
+return statement, not in the consumer.
+
+**Wrong fix (the trap):** plumb a version counter through every
+consumer and add it to every dep array. Works but pushes the
+contract into every call site — a future consumer that forgets the
+counter is silently buggy.
+
+**Right fix:** shallow-copy at the hook boundary —
+`return [...getStorage()]`. Fresh reference every render. Every
+useMemo that depends on the returned value recomputes whenever the
+buffer mutates, regardless of mutation kind. Cost: one O(n) copy
+per render, bounded by the buffer's max capacity. For ring buffers
+with bounded capacity (Phase 19-08's 500 cap) the cost is
+negligible compared to the React commit cost.
+
+**Even better fix (future):** migrate to `useSyncExternalStore`
+with `getSnapshot()` that returns a fresh reference. Canonical
+React 18+ external-store pattern. Equivalent semantics, no manual
+version counter.
+
+**REF:** Phase 19-08 PR-B T-15 probe (g). Surfaced by the
+"pin-by-reference: held snapshot survives eviction" test. Fix in
+commit `3e67b7b` (`useCaptureBuffer` returns `[...getCaptureBuffer()]`).
+Codified as PV34.
+
+
+## P49 — Inheriting upstream design-doc phrasing without classifying audience ships the wrong primitive
+
+**Pattern:** A phase's CONTEXT.md inherits its framing from an
+upstream design doc (north-star, product roadmap, thesis). The
+framing reads natural-language ("scrub the trace to see the audible
+bug in time") and is interpreted at face value. The phase plans
+mechanics — capture buffer, scrub UI, playhead, J/K step — without
+asking the upstream question: *who is the audience for the scrub?*
+A developer scrubbing eval history wants tick-per-eval. A musician
+scrubbing musical time wants row-per-voice × bar-grid. Both are valid
+"scrub" mechanics. They are mutually incompatible primitives. The
+inherited phrasing didn't distinguish them; the phase shipped one
+and called it "the timeline." User reaction at close-out: "this
+isn't useful — I expected the other one."
+
+**Symptom:** Tests pass. Goal sentence is satisfied verbatim. PR
+descriptions look clean. Self-review (AnviDev §5) finds no gaps.
+Verification (`/anvi:verify-phase`) passes with at most low-severity
+warnings. Then the user uses the feature for one minute and says
+"this is not what I wanted." The framing held; the audience-
+mental-model didn't. The bug isn't in the code — the bug is in the
+discuss-phase that never happened, or that happened without an
+audience classification gate.
+
+**Detection:** Three signals:
+1. The phase name OR goal sentence contains a debugger-shaped verb
+   (`debug`, `inspect`, `trace`, `scrub`, `replay`, `step`, `pin`).
+2. The CONTEXT.md does not explicitly state who the audience is.
+3. The framing was lifted from an upstream doc (north-star, thesis,
+   roadmap) without the inheriting phase re-deriving it from current
+   user-need.
+
+If all three are present, the phase is at risk of P49 BEFORE
+implementation begins. The catch-point is discuss-phase, not
+plan-phase or executor.
+
+**Wrong fix (the trap):** ship the feature, then add a "v2" follow-up
+that "really means it" with the multi-track UI. This compounds the
+problem — now the surface has two debugger primitives competing for
+the same chrome, and the original (low-value) one has user-facing
+weight (rename costs, deprecation period, doc rewrites). Worse: the
+v2 ships with the same audience-ambiguous framing because the
+discuss-phase question was never added to the workflow.
+
+**Right fix:** When the symptom appears, do TWO things:
+1. **Reframe the shipped feature** as serving its actual narrow
+   audience (here: the developer-console eval-history). Rename to
+   match vocabulary. Demote in chrome. Document audience in CONTEXT
+   retroactively.
+2. **Add the audience-classification gate to discuss-phase** so the
+   next debugger-shaped phase doesn't inherit-and-ship the same
+   ambiguity. Codified as PV35 (audience-classification gate). The
+   gate forces every CONTEXT.md for debug/inspect/trace/timeline/
+   playhead/scrub/breakpoint/replay phases to lock `D-AUDIENCE:
+   developer | musician`.
+
+**Even better fix (proactive):** before plan-phase, run the audience
+classification as the first discuss-phase question. If the answer is
+ambiguous, split the phase into two surfaces (shared data layer, two
+distinct UIs) BEFORE writing the plan.
+
+**REF:** Phase 19-08 close-out (2026-05-06). Inherited phrase: "scrub
+the trace to see the audible bug in time" from
+`artifacts/stave/IR-DEBUGGER-NORTH-STAR.md` Step 4. CONTEXT.md
+implemented it as tick-per-eval (developer audience) but never
+labeled it as such; user expected row-per-voice × bar-grid (musician
+audience). Codified as PV35. Reframe plan: rename
+`IRInspectorTimeline` → `IRInspectorEvalHistory`, demote in chrome,
+build musician timeline as separate phase with audience locked.
+
+### P33: Silent-drop in `applyMethod`'s `default:` arm — unrecognised chain methods become invisible to the debugger
+
+**STATUS: ELIMINATED 2026-05-08 (PR #96 / PV37).** Entry retained as
+historical record + cautionary tale for future "defensive default that
+swallows the signal" diagnoses. The silent-drop site at
+`parseStrudel.ts:729` and ~10 typed-arm failure branches all wrap via
+`wrapAsOpaque(inner, method, args, callSiteRange)`. Detection signal
+inverts: feeding `note("c").<unknown>(0).<unknown>(1)` to
+`parseStrudel` now produces a `Code-with-via` wrapper carrying both
+unknown call sites; `toStrudel` round-trips byte-equivalent.
+
+**Symptom (parser-side):** The user types `note("c4 e4").s("sawtooth").release(0.3).viz("pianoroll")`.
+After `parseStrudel(code)`, the produced IR carries Play(c4) Play(e4)
+with `params.note` set, NO `params.s`, NO `release`, NO `viz`.
+Surrounding chain — gone. `toStrudel(ir)` re-emits `note("c4 e4")` only.
+
+**Symptom (debugger-side):** The runtime still applies `.s("sawtooth")`
+and `.release(0.3)` (Strudel's own dispatch); audio plays as the user
+expects. But the IR Inspector / MusicalTimeline / click-to-source see no
+representation of those methods. Setting a breakpoint on the line is
+either impossible (no IR node owns that range) or fires for the wrong
+event (the underlying `note(…)` Plays). The debugger silently lies
+about what is executing.
+
+**Symptom (downstream):** `groupEventsByTrack` falls back to
+`evt.trackId ?? evt.s ?? '$default'`. Without `params.s`, every
+`note(…).s(...)` block collapses into a single `$default` row in the
+timeline — multiple `$:` blocks with distinct intentions merge into
+one indistinguishable row. User reports "the timeline doesn't show
+my first block."
+
+**Root cause:** `applyMethod` (parseStrudel.ts:303-732) is a switch over
+~30 known methods. The `default:` arm at parseStrudel.ts:729-731 is
+`return ir` — an unrecognised method returns the *receiver* unchanged,
+discarding the typed source. The switch was scoped during phase 19 to
+model *transforms* (Category A: fast/slow/every/jux/layer/…). Per-event
+control params and synth selectors (Category B: s/n/release/attack/…)
+were added opportunistically — only those a downstream gate explicitly
+needed (gain/lpf/pan/…). No phase ever scoped "the IR must wrap or
+recognise *every* chain method." The silent drop survived because the
+absence is silent — no warning, no test failure, the underlying pattern
+parses fine and audio plays via Strudel.
+
+**The trap (wrong fix):** "Add cases for the missing methods one by one
+until coverage is complete." This treats the symptom (specific
+unrecognised method X) instead of the root cause (the `default:` arm
+silently discards data). It is also unbounded: Strudel adds methods;
+controls.mjs is open; users define custom helpers. Coverage is a
+moving target.
+
+**The real fix (PV37):** The `default:` arm wraps the receiver in an
+opaque `Code`-with-loc node carrying the entire `.method(args)` call
+site as its source range. The wrapper:
+1. Preserves the typed source (round-trip honest)
+2. Gives the debugger a node to point at (PV36 loc-completeness)
+3. Allows the inspector to render `[opaque: .release(0.3)]` with the
+   inner pattern still inspectable
+4. Makes coverage *gradual* — typed arms can be added when stepping
+   inside the method matters; until then, the wrapper is sufficient
+
+The fix converts ~25 missing-method bugs into a single architectural
+invariant: "no method silently discards source." Each typed arm added
+later is an *upgrade* (opaque → steppable), not a bug fix.
+
+**Detection signal:** Run `grep -n "default:" packages/editor/src/ir/parseStrudel.ts`
+on the `applyMethod` switch. If the arm is `return ir` (or any variant
+that does not produce a node carrying `callSiteRange`), the trap is
+present. Confirm by feeding `note("c").<unknown>(0).<unknown>(1)` to
+`parseStrudel` and checking that the produced IR is `Play(c)` —
+identical to `parseStrudel('note("c")')`. If the two are
+indistinguishable, the silent-drop is live.
+
+**Family:** Same shape as P21 (silent fallback wins over working primary)
+and P31 (extension map mismatch excludes silently). All three: a
+defensive default that swallows the very signal that should fire.
+
+**REF:** parseStrudel.ts:729-731 (the silent-drop site); PV37 (the
+invariant the fix codifies); PV36 (the loc-completeness contract the
+wrapper restores); 2026-05-07 disparity-catalog conversation (where the
+trap class was named).
+
+## P50 — Workaround cascade: each fix-up papering over a missing contract creates a new symptom
+
+**Pattern:** A symptom appears (e.g. click-to-source resolves to the
+wrong line for a transform-derived event). Instead of asking "what
+contract is missing?" the response is to add a fallback layer (regex
+walk over `$:` blocks). The fallback fixes the visible case but produces
+a new failure mode for a different shape (sample-name lookup needed).
+Add another fallback. Repeat. Each fallback layer builds on the previous
+one's framing — none of them surface the actual question: *the IR's
+provenance channel is missing a contract*.
+
+**Symptom (process-side):** A short series of commits — usually 3 to 6
+— with messages like `fix: add X fallback for Y`, `fix: prioritize A
+over B in walker`, `fix: handle the C edge case`. Each individual diff
+is small and reasonable. Each individual test passes. The symptom
+returns under a slightly different shape and a new fallback is added.
+Tests lock in the workaround behaviour (see P51) so the workaround
+becomes the contract.
+
+**Symptom (architectural-side):** A function that grew from one path to
+five paths. A switch statement with a `default:` arm full of fallbacks.
+A resolver that tries `A ?? B ?? C ?? D` where each branch is a different
+heuristic, none of them named, none of them principled.
+
+**Detection signal:** Three signals, each independently load-bearing:
+1. **Commit log shape:** N successive `fix:` commits in the same area
+   within a short window, each addressing a different shape of the same
+   symptom class.
+2. **Resolver fan-out:** the offending function has an early-return
+   ladder where each `if` is a different heuristic. Read top-down: each
+   condition is an attempt to detect a case the previous attempt missed.
+3. **No invariant cited:** none of the commits reference a vyāpti, a
+   contract, or a structural rule. They reference the specific shape
+   they fix.
+
+If 2+ of the 3 signals fire, the cascade is live and the framing is
+wrong. STOP adding fallbacks.
+
+**The trap (wrong fix):** "One more layer will catch the remaining
+case." The trap is that this is plausible at every individual step —
+the new case really did need handling, the new fallback really does fix
+it. The cumulative cost (resolver complexity, test coupling, framing
+debt) is invisible at each step.
+
+**The real fix:** Ask "what contract is missing?" Read the producer side
+(parser, builder, source-of-truth). Find the case where the producer
+DOESN'T attach the channel the consumer is trying to recover. Codify the
+producer-side contract as a vyāpti. Replace the resolver fallbacks with
+a single one-line consumer that trusts the contract. The fallbacks
+become deletable; the contract is the new abstraction.
+
+**Family:** Same shape as P21 (silent fallback wins over working
+primary), P31 (extension map mismatch excludes silently), P39 (parser
+pipelines that trim/concat destroy provenance). All share the pattern:
+the producer side has an unwritten contract; downstream consumers reach
+for compensation logic; the compensation hides the original gap.
+
+**REF:** Slice-γ click-to-source (5 successive fix commits cc19d5b,
+571898d, 599826c, e71627e, eab49d5 in 2026-05-08 — the canonical
+example; reverted in PR #95 once PV36 was codified). PV36 (the contract
+that eliminated the resolver). 20-03 wave γ commit body (records the
+recognition that "5 fix-ups were instances of one root cause"). Generic
+process-level cousin to PV36's invariant: when the consumer reaches for
+compensation, ask the producer.
+
+**Discipline held across debugger v2 (2026-05-08):** Phases 20-05/06/07
+all maintained single-strategy match. `findMatchedEvent(loc, begin,
+lookup)` is THE match function — one map lookup, one tie-break loop,
+miss → undefined (PV37-aligned runtime-only path). NO fallback shapes
+("if no match by id, try by loc; if no match by loc, try by begin")
+anywhere in the diff. The temptation surfaces every time a hap doesn't
+match (e.g. fast(N) duplicate disambig at the timeline subscriber);
+each time, the right answer was tighter producer-side semantics
+(content-addressed irNodeId, leaf-only assignment, snapshot lookup
+tables) — not consumer-side compensation. The breakpoint hit-check at
+StrudelEngine.ts:219 is the same: `if (irNodeId && store.has(id))
+pause()` — single check; no ladder.
+
+## P51 — Tests asserting symptom behaviour lock the bug into the contract
+
+**Pattern:** A bug ships. Someone writes a test that asserts the
+buggy-but-stable output ("ply(2.5) produces just the 2 unscaled events
+and silently drops the 0.5 scaled portion" / "Pick userMethod fixture
+returns events without selector loc"). The test passes because it
+documents what actually happens. Later, the bug is fixed (a new contract
+lands). The test now fails — but it fails because it was asserting the
+SYMPTOM, not the SPEC. Worse: if the test is interpreted as
+authoritative, the fix gets reverted.
+
+**Symptom:** During a contract-landing PR (PV36, PV37, etc.), one or
+more existing tests fail. The diff that caused them is correct per the
+new contract. The test assertions look reasonable in isolation.
+
+**Detection signal:** Three checks at PR-author time:
+1. The failing test pre-dates the contract being landed.
+2. The test asserts a specific output shape (count, exact event list,
+   exact projection text) without citing an invariant.
+3. Updating the test to assert the new contract's output is mechanical —
+   no semantic re-interpretation of what the test was probing.
+
+If all three: the test was documenting a symptom. Update the assertion
+in the same PR; add a comment citing the contract reference (e.g.
+`// PV37 — wrap contract: ply(2.5) failure branch wraps; was P33`).
+
+**The trap (wrong fix):** Revert the contract change because "tests
+fail." Or: keep the contract, leave the symptom-tests skipped/disabled,
+ship anyway. Both produce silent erosion: option 1 reverts the work;
+option 2 leaves the bug-pattern living in the codebase as inert
+documentation, still findable by `grep` and likely to be re-asserted
+elsewhere.
+
+**The real fix:** When landing a contract, audit tests in the
+contract's domain BEFORE writing the implementation. Surface tests that
+assert the OLD broken behaviour and update them in the same PR with
+explicit references to the new contract. Each updated test is now
+documentation OF the contract, not documentation AGAINST it.
+
+**Family:** Same shape as P50 (workaround cascade — there, the cascade
+is in production code; here, the cascade is in test fixtures
+calcifying the cascade's outputs).
+
+**REF:** Phase 20-04 deviation #3 (3 pre-existing tests asserted P33
+silent-drop bug behaviour: `integration.test.ts` ply(2.5) test,
+`parity.test.ts` Pick userMethod test, `app/irProjection.test.ts` pick
+projection fixture; updated each with phase-reference comments in PR #96
+once PV37 wrap contract landed). Slice-γ tests — never written because
+the resolver was a fallback ladder, but the same principle would have
+applied if any were. PV36 / PV37 (the contracts whose landing surfaced
+the pattern). P50 (the production-code cousin).
+
+**Re-applied successfully (2026-05-08, PR #103 phase 20-06):** when
+20-06 replaced cycle-derived glow with hap-driven (PV38 consumption),
+the 3 cycle-derived active-glow tests at MusicalTimeline.test.tsx:549-630
+locked the OLD contract. P51 protocol applied verbatim: REPLACE in place
+within the existing describe block, update header to "(20-06 —
+hap-driven; replaces 20-02 cycle-derived per P51)", inline PV38
+reference comment. Audit grep at plan time confirmed zero
+`.toEqual({...begin...})` shape-locking assertions elsewhere. Pattern
+now self-applying: each contract landing in the debugger sequence
+(PV36, PV37, PV38) has surfaced and absorbed its P51 instances within
+the same PR — no inert symptom tests left behind.
+
+## P52 — Silent-semantics-after-PV37: typed character lands as IR but downstream effect vanishes
+
+**Status:** RESOLVED 2026-05-09 for the 10-method whitelist (Phase 20-10).
+Open for the remainder of the silent-drop list (release/attack/sustain/
+decay/crush/distort/shape/amp/detune/octave/tremolo/lfo/legato/unison/
+coarse/fine) until follow-up param phase.
+
+**Pattern:** PV37 (wrap-never-drop, 20-04) ensures every chain method
+has an IR representation. But if the IR representation is `Code`-with-
+via (opaque wrapper) instead of a typed semantic tag, `collect.ts case
+'Code'` walks `via.inner` WITHOUT reading `via.method` / `via.args` —
+the wrapper preserves source range only, not effect. Downstream
+consumers that read event-level fields (`evt.s`, `evt.gain`) see null
+because nothing wrote them. PV37's representation honesty creates a
+sibling silent-drop class at the SEMANTICS layer.
+
+**Symptom:** `evt.<key> === null` downstream of a chained `.<key>(value)`
+invocation in source. The IR has the chain present (PV37 honest); the
+effect on event-level fields is missing. Issue #108 manifestation: the
+user's `note(...).s("sawtooth")...` rendered all events on a single
+`$default` track because `groupEventsByTrack` falls back to `'$default'`
+when `evt.s ?? '$default'`. Three synth voices and four drum stems
+collapsed into one bucket.
+
+**Detection signal:** Three checks at debugger time:
+1. Test the IR representation of the chain — `parseStrudel(code).tag` is
+   `'Code'` with `via.method === '<key>'`. Confirmed = PV37 honest.
+2. Test the collect output — `collect(parseStrudel(code))[0].<key>` is
+   `null`. Confirmed = SEMANTICS silent-drop.
+3. Compare to Strudel runtime — `(await evaluate(code)).pattern.queryArc(
+   0, 1)[0]` carries a non-null `<key>`. Confirmed = drift between IR
+   semantics and Strudel runtime semantics.
+
+If all three: the method is PV37-honest but P52-broken. Promote it to a
+typed semantic IR tag in the parser arm.
+
+**The trap (wrong fix):** "Read `via.method` and `via.args` in `collect.
+ts case 'Code'`." This couples the opaque wrapper to method-specific
+semantics; turns PV37's clean fallback into a switch over method names;
+does NOT generalize when the method's argument shape needs structural
+introspection (e.g. pattern-args like `.s("<bd cp>")`). The wrapper is
+representation-deferred BY DESIGN — coupling it to semantics defeats
+PV37's purpose.
+
+**The real fix:** Promote the method to a typed semantic IR tag at the
+parser arm (`Param`, `FX`, etc.). The typed arm in `applyMethod`
+constructs the tag explicitly with structured `value`; `collect.ts` has
+a dedicated case that reads the structured `value` and merges into
+`ctx.params` / spreads into the event. This is the SEMANTICS layer of
+PV37: representation honesty (PV37) + effect honesty (PV39) = full
+observation completeness.
+
+**Family:** Same shape as P33 (silent-drop, REPRESENTATION class —
+closed 20-04). P33: "method's typed character vanishes from IR." P52:
+"method's typed character is in IR but its effect vanishes from
+downstream events." Both are silent. Both are sibling classes — same
+detection-style (compare typed source to downstream output), different
+root cause (parser layer vs collect layer).
+
+**Cross-ref:** P37 (defer-comment-is-the-bug — the `// walks via.inner`
+comment in `collect.ts` near line 334 WAS the bug for the 10
+whitelisted methods; it documented the SEMANTICS deferral as if it
+were a deliberate choice). P50 (workaround cascade — coupling `case
+'Code'` to method-specific semantics would create new symptoms when
+pattern-args appear; the typed-arm-promotion sidesteps this entirely).
+
+**REF:** Phase 20-10 PLAN §0; PV39 (the vyapti codifying the
+SEMANTICS-completeness sibling layer); `packages/editor/src/ir/
+collect.ts:case 'Param':` (the typed-arm fix shape).
+
+### P37: "Defer-comment is the bug" — TODO marking next to silent data loss
+
+**Root cause:** A code site contains an explicit "v0 defers this; v1 will handle" comment, AND the deferred work causes silent data loss in the present tense (not a future feature gap). The comment turns the bug into a feature in the reader's mind: "this is documented, therefore it's not a problem." But the deferred work is exactly what makes downstream consumers behave wrong, RIGHT NOW.
+
+**Detection signal:** A TODO / "for v0" / "future consumer" comment lives directly above a parser/projection/transform site whose output flows to a feature that's silently degraded. Search hits that mention a comment like "X is dropped here for v0 — when a consumer needs Y, fix this" while a feature shipping today already needs Y.
+
+**The trap:** You read the comment and accept the deferral as documentation. Tests pass because they don't probe the deferred dimension. The bug surfaces only via end-user observation (in this case: clicking a sample-track event navigates to line 1 of the file). When you finally trace it, you re-read the same comment and feel relieved it's a known limitation — and risk re-deferring.
+
+**The real fix:** When a defer-comment is found next to a feature already in production, IT IS A BUG, not a TODO. Promote it to an issue immediately. Carry the fix in the same PR as whatever surfaces it. Replace the defer comment with the explainer for what was lifted (so future readers see the v1 contract, not the abandoned v0 deferral).
+
+**Universal principle:** Documentation that defers something is also a contract about what is and isn't supported. A defer-comment + a downstream feature relying on the deferred work are mutually exclusive — one of them is lying.
+
+**REF:** Phase 20-08 follow-up #107 (2026-05-09). `parseStrudel.ts:248-250` had: `// stack(a, b, c) — Argument offsets are dropped here for v0 — when a future consumer needs loc through stack(), splitArgs would need to return slice positions too.` MusicalTimeline click-to-source had needed loc through stack() since Phase 20-01 (line numbers wrong since then; nobody traced to this comment). Surfaced via user observation, fixed in commit 7c64d77 with `splitArgsWithOffsets` helper. Defer-comment replaced with v1 explainer per this protocol.
+
+### P38: Two-state proxy conflates a tri-state model
+
+**Root cause:** The runtime has a tri-state transport model (`stopped | playing | paused`), but downstream consumers only ask one binary question (`isPaused?`). The negation `!isPaused` reads true for BOTH `stopped` and `playing` because the engine is "not paused" in either case. Code that branches on `!isPaused` therefore conflates the two states.
+
+**Detection signal:** A bool-returning accessor named `isX()` / `getX()` is used as a proxy for "the active state." On scrutiny, the runtime has 3+ states, and `!isX()` collapses two of them. A bug surfaces specifically in the underrepresented state (stopped, in this case).
+
+**The trap:** You add a guard like `if (!getIsPaused()) doPlayingThing()`. Tests pass because they exercise paused vs not-paused, but never construct the third state (stopped) explicitly. Symptom appears only on the third path: a behaviour that should be playing-only fires from stopped too. Adding more paused/not-paused guards compounds the trap.
+
+**The real fix:** Expose the missing state explicitly. Don't synthesise it from `!other_state` at every call site. In our case: add `getIsPlaying()` returning `isPlayingState && !getPaused()` directly on the runtime; consume that at every place that wants "actively producing audio." The two-state proxy goes away.
+
+**Universal principle:** Every bool accessor implies a two-state world. If the underlying world has more states, EVERY call site is at risk of conflating two of them. Solution is at the boundary, not the call site.
+
+**REF:** Phase 20-08 follow-up #105 (2026-05-09). `MusicalTimeline.tsx:322` captured `wasPlayingOnScrubStartRef = !getIsPaused()`; for a stopped engine this read true, and release fired `runtime.resume()` → audio started from cycle 0. Fix added `getIsPlaying()` to `LiveCodingRuntime`, threaded through StrudelEditorClient + StaveApp + MusicalTimelineProps, and changed pointerdown to read it directly. Commit d0a59df.
+
+### P39: jsdom-24 PointerEvent constructor swallows init properties
+
+**Root cause:** jsdom 24's `PointerEvent` constructor accepts `PointerEventInit` per the type signature, but on dispatch the produced event has `clientX`, `clientY`, `pointerId`, and `button` reading as `undefined`. Init dict is silently dropped at construction time. RTL's `fireEvent.pointerDown(target, init)` builds the event via this constructor — the init dict never reaches the handler.
+
+**Detection signal:** A pointer-handler test asserts a side effect should fire on `pointerdown` (e.g. mock spy called) but the spy is never called even though the binding is correct. Inserting `console.log(e.button)` inside the handler shows `undefined`. Production guards like `if (e.button !== 0) return` early-return, swallowing the test path.
+
+**The trap:** You suspect React batching, ref staleness, or wrong handler binding. You verify the binding by hand (it's correct). You finally instrument and discover the init dict is dropped.
+
+**The real fix:** Construct the event via `new PointerEvent(...)` (or `MouseEvent` fallback) and force-define each lost property post-construction with `Object.defineProperty(ev, 'pointerId', { value, configurable: true })`, then `target.dispatchEvent(ev)`. Helper shape:
+
+```ts
+function dispatchPointer(target: HTMLElement, type: 'pointerdown' | 'pointermove' | 'pointerup' | 'pointercancel', init: { clientX: number; pointerId: number; button?: number }): void {
+  const ev = new PointerEvent(type, { bubbles: true, cancelable: true, composed: true, ...init, pointerType: 'mouse' })
+  Object.defineProperty(ev, 'pointerId', { value: init.pointerId, configurable: true })
+  Object.defineProperty(ev, 'clientX', { value: init.clientX, configurable: true })
+  Object.defineProperty(ev, 'button', { value: init.button ?? 0, configurable: true })
+  target.dispatchEvent(ev)
+}
+```
+
+**Family:** P11 variant. P11 catalogued the same trap class for `DragEvent`. P39 is the PointerEvent variant — same fix shape, different event constructor.
+
+**REF:** Phase 20-08 wave α (commit 037a701). `MusicalTimelineScrub.test.tsx:108-140` ships the canonical helper. All 6 of the wave-α scrub tests initially failed silently because `e.button === undefined !== 0` early-returned the handler before any spy was called.
+
+## P53 — `groupEventsByTrack` inferring identity from `evt.s` is a fallback, not a primitive
+
+**Status:** RESOLVED 2026-05-09 for the `$:` and `.p()` track-identity sources (Phase 20-11). Open for future track-identity sources (e.g. `.bus()`, `.scope()` — if added in a future phase).
+
+**ORIGIN:** Phase 20-08 / γ-4 manual gate session — two identical `$: stack(s("hh*8")...)` drum blocks rendered as a single timeline row. Diagnostic walk at CONTEXT §0 traced the collapse to `groupEventsByTrack.ts:41` keying on `evt.trackId ?? evt.s ?? '$default'` — a 3-level fallback ladder. When the parser produced events without a `trackId`, the fallback to `evt.s` bucketed two distinct user-authored tracks together because they happened to play the same sample.
+
+**Trap class:** A consumer infers identity from event content when the producer never asserted it. The inference is structurally lossy: any time two distinct authored sources share content (same `s`, same `note`, etc.) the inference cannot recover the distinction. Sample-derived fallbacks LOOK reasonable in single-track inputs (one bucket, one sample, one row) but silently collapse multi-source inputs that share content.
+
+**Detection signal:** the user has TWO `$:` blocks with identical (or sample-overlapping) contents; the timeline shows ONE row instead of two; audio doubles audibly. Or: a single-source pattern with a chained `.p("custom")` shows up labeled by its sample (`bd`) instead of the user-typed track name (`kick`).
+
+**Wrong fix (cascade trigger — see P50):** "Add `evt.s + evt.gain` or `evt.s + position-in-source` or some other multi-field key to disambiguate." Each compound key is a workaround that papers over the missing primitive. The user can always write a new fixture that collapses the latest key — `$: s("bd").gain(0.3)` twice still collides on `(s, gain)`.
+
+**Real fix:** Populate `evt.trackId` at the parser level using the user's authored identity assertion. The `$:` block index (`d{N}`) IS the user's track-identity claim; preserve it through the IR (PV37 wrap-never-drop model) → collect (`case 'Track'` ctx spread + makeEvent conditional spread) → presentation. The fallback to `evt.s` stays for hand-built IR fixtures (no Track wrapper ever applied) but never fires for parser-derived events.
+
+**Cross-ref:** P33 (silent-drop, REPRESENTATION class — closed Phase 20-04). P50 (workaround cascade — adding a second compound key when the first didn't disambiguate is the canonical cascade trigger). P52 (mount-path) — BOTH MusicalTimeline call sites (`:445` dot + `:510` per-event background) had to swap together; partial migration would partially-mask the trap by colouring half the chrome from the new palette and half from the old.
+
+**Pair-of:** PV40 (track-identity-parser-assigned, codified Phase 20-11). P53 names the trap; PV40 names the contract that closes it.
+
+**REF:** Phase 20-11 PLAN §0; `groupEventsByTrack.ts:41` (the 3-level fallback); `case 'Track'` arm in `collect.ts`; `parseStrudel.ts:97-130` (parser-side identity assignment).
+
+## P54 — Label-trap-at-typical-zoom: chrome bars carry no text
+
+**Class.** Discoverability-failure dressed as discoverability-success.
+
+**ORIGIN:** Phase 20-11 design debate; locked in `20-11-DESIGN-DEBATE.md`. Reviewers reflexively asked "how does the user know which sample plays at this bar?" The naive answer ("label the bar with `evt.s`") works for a single bar-wide selection (a held-zoom screenshot) but the steady-state view at default zoom puts a 1/16 cell at ~30px wide and ~12px tall — too small for any legible glyph.
+
+**Symptom.** A reviewer or contributor suggests adding a `<text>` element inside event rects: "just put the sample name inside each bar." Implementation looks reasonable on a single-event fixture (one wide bar = one readable label). It then degrades silently as the user adds events — labels overflow the cell, get clipped, and at typical zoom ratios are unreadable but visually noisy.
+
+**Detection signal.** Any of:
+- Adding a `<text>` / `<span>` element inside an event rect with `font-size ≤ 12`.
+- A request like "make the bars carry their note name" / "label the bars with the sample."
+- A draft PR that adds a per-bar label child element to the event-render loop.
+
+**Trap (wrong fix).** Adding labels at any size. They will be unreadable at typical zoom. The follow-up instinct is the canonical workaround cascade (see P50): zoom-conditional label rendering → hide-on-overflow → fade-in-on-hover → marquee-scroll. Each step performs accessibility while harming it.
+
+**Real fix.** Apply PV41's 5-channel contract:
+1. **Row header carries track-level identity** (chevron + name + swatch dot — readable at default zoom).
+2. **Row color carries the track family** (palette slot or user override).
+3. **Bar opacity carries gain** (`clamp(evt.gain, 0.15, 1)`).
+4. **Bar Y carries pitch** (auto-fit per leaf for melodic; flat for percussive).
+5. **Hover tooltip carries the full chain** (native `title=`; pointer-events: none; screen-reader friendly; zero CSS cost).
+
+Per-event identity surfaces through HOVER, never through on-bar text. The 5-channel contract is the correct discoverability mechanism at the chrome's typical zoom.
+
+**Cross-ref:**
+- PV41 (5-channel identity contract) — names the contract that closes this trap.
+- P50 (workaround cascade) — adding labels then zoom-conditional labels then overflow-hide is the canonical cascade trigger.
+- PV35 (musician-vocabulary discipline) — same audience target; P54 is the visual-substrate sibling of PV35's textual discipline.
+
+**REF:** `.planning/phases/20-musician-timeline/20-12-CONTEXT.md` §3 D-01..D-05; `20-11-DESIGN-DEBATE.md` "no bar labels EVER" lock; `20-12-MANUAL-GATE.md` visual check #8 (a label appearing on any bar BLOCKS PR — PV41 violation); `MusicalTimeline.tsx:854-877` (the bar render — note the absence of any text child element by design).
+
+## P55 — Popover commit-then-close ordering: write must fire BEFORE close, never after
+
+**Class.** Single-tick lifecycle race in commit-on-click UI primitives.
+
+**ORIGIN:** Phase 20-12 β-6 — the swatch popover has a single click that performs TWO actions: `onPick(color)` (write the user's choice into trackMeta) and `onClose()` (unmount the popover). If `onClose()` fires first, the unmount can clear in-flight state (focus restoration, anchor refs, transient timers) AND the parent's update loop can run before `onPick` lands, observing a popover that is closing without a write. Symptom: the popover closes but the color does not update; user clicks again, gets the same outcome; concludes the feature is broken. Anticipated trap from BackdropPopover.tsx (Phase 19) — Trap 5 (write storm) is the related trap when the commit fires on `mousemove` instead of click; P55 is the sibling on the close-ordering axis.
+
+**Detection signal.** In a popover whose click handler does both a write and a close:
+- `onClose()` is invoked before `onPick()` in the click handler body.
+- The popover is unmounted by parent state synchronously inside the same click before the write reaches the store.
+- A test asserts only "onPick was called once" + "onClose was called once" without pinning their relative order.
+
+**Trap (wrong fix).** "Defer onPick to a `requestAnimationFrame` so the close can fire first and the write happens 'after the popover is gone'." This papers over the ordering by introducing a different race (the rAF can fire after a navigation event, dropping the write entirely). It also makes the write asynchronous to the click, which breaks `act()` boundaries in tests and forces every consumer test into `await waitFor` shape.
+
+**Real fix.** Two clauses:
+1. **Source order:** in the click handler body, call `onPick(color)` FIRST, then `onClose()`. Both are synchronous; the parent's setState calls inside both are React-batched into the same commit, so the write and the close land atomically from React's perspective. The popover unmounts AFTER the parent has observed the new color.
+2. **Test pin:** the unit test asserts `onPick.mock.invocationCallOrder[0] < onClose.mock.invocationCallOrder[0]` — pinning the contract directly, not via integration symptom (`bar updates after click`). Without the order pin, a refactor that swaps the source-order would still pass the count assertions but reintroduce the race in production.
+
+**Cross-ref:**
+- P50 (workaround cascade) — deferring writes to rAF or microtasks is the canonical workaround; it papers over without resolving.
+- PV41 (5-channel identity) — the popover commits CHANNEL 2 (row color) of the contract; a dropped write silently violates PV41.
+- BackdropPopover (Phase 19) deferred-attach pattern — same family of single-tick lifecycle hazards in commit-on-click popovers.
+
+**REF:** `.planning/phases/20-musician-timeline/20-12-PLAN.md` §5 γ-3 PART C; `TrackSwatchPopover.tsx` click handler; `TrackSwatchPopover.test.tsx:60-82` ("clicking a swatch calls onPick(color) then onClose()") — the canonical fixture pinning the contract via `mock.invocationCallOrder`.
+
+## P56 — Single-body wrapper hides multi-body structure from depth-walkers (peel-or-miss)
+
+**ORIGIN:** Phase 20-12 hotfix wave (2026-05-10). User's `stack(...).viz(...)` IR ran the timeline through `flattenLeafVoices`, which only recursed on bare `Stack`. The `.viz(...)` chain wrapped the Stack in `Code{via: Stack}`, so the walker saw `Code` (a non-Stack tag) and terminated as a single leaf. Result: 4 chevrons but only 1 sub-row per track when expanded; user clicked "uncollapse" and the row appeared identical to collapsed. Same shape as 20-11's irChildren projection trap — tree depth-walkers that look for ONE multi-body tag and fail to peel through single-body modifiers above it. Recurring pattern; needs codification.
+
+**Detection signal.** Three coincident:
+1. The walker has an explicit recursion gate keyed on a single tag (`if (n.tag === 'Stack') ...`).
+2. The data passes through a parser/lowering pass that wraps the structural node in single-body modifiers (Param, Fast, Code-with-via, FX, etc.).
+3. A user-typed `.method(...)` chain whose lowering wraps the structural node — `.viz()`, `.gain()`, `.fast()`, `.late()`, `.degrade()` — produces an output where the walker terminates one level too high.
+
+The smoking-gun observation is COUNT mismatch: the user wrote `stack(a, b, c)` (3 voices) but the chrome shows 1 leaf. Click-to-expand is a no-op. Same shape as P53 — the fallback is invisible to the user; the feature just looks broken.
+
+**Trap (wrong fix).** "Add `Code` to the recursion gate." Specific to the immediate symptom but doesn't address the class. Next time the user writes `stack(...).gain(0.5)` (Param wrapper) or `stack(...).fast(2)` (Fast wrapper), the walker terminates again. Each new wrapper requires a one-off fix; the trap stays open across the wrapper-tag growth.
+
+**Real fix.** Peel one layer of any single-body uniform-modifier wrapper before terminating. Single-body wrappers (Code-with-via, Param, FX, Fast, Slow, Elongate, Late, Degrade, Ply, Struct, Swing, Shuffle, Scramble, Chop, When, Every, Loop, Ramp) are all "this is a uniform modifier on the inner pattern" — peeling them is structurally safe. NOT peeled: multi-path nodes (Choice, Pick) and structural carriers (Stack, Seq, Cat — they ARE the topology). Code without `via.inner` (parse-failure leaf) is NOT peeled.
+
+The peel set is the same set used in `flattenLeafVoices`'s sister `countLeavesInIR` (collect.ts) — both must agree, or layoutTrackRows' leaf count and the chrome's render leaf indices drift.
+
+**Cross-ref:**
+- PV41 (5-channel identity contract) — peel-or-miss in the leaf walker silently breaks channel-1 (sub-row identity).
+- P53 (`groupEventsByTrack` `evt.s` fallback) — same class of silent-fallback when a primitive isn't found.
+- 20-04 era's `irChildren` projection had a similar shape; the peel-or-miss principle was implicit there but never codified.
+
+**Pair-of:** PV37 (wrap-never-drop) governs the parser side — it must wrap, not drop. P56 is the consumer-side dual: walkers must peel, not terminate. Together they close the producer/consumer loop on opaque-wrapper-around-structural-content.
+
+**REF:** `irProjection.ts:344-411` (`flattenLeafVoices` + `peelSingleBodyWrapper`); `collect.ts:countLeavesInIR` (sister implementation in editor package); `irProjection.test.ts:752-862` (6 wrapper-peel regression tests); commit `5524e70`.
+
+## P57 — Window-relative-static events vs monotonic-runtime begin: identity matching breaks at window boundary
+
+**ORIGIN:** Phase 20-12 hotfix wave (2026-05-10). After `IRSnapshot.events` was changed to `collectCycles(finalIR, 0, WINDOW_CYCLES)`, event begins live in `[0, 2)`. The MusicalTimeline highlight handler matched runtime hap events to chrome events by exact equality on `(irNodeId, begin)`. Strudel's hap stream emits `hap.whole.begin` as the absolute, monotonic cycle index — at cycle 2 begin is 2.x, at cycle 3 it's 3.x, etc. After the playhead wrapped from x=1222 back to x=63 (the visual window boundary), no hap matched any event and bars stopped highlighting. Active-bar count went from "5/5 samples per second" to 0 at t≈3.7s.
+
+**Detection signal.** Identity-match between two sources where:
+1. One source emits **window-relative** identity (event.begin ∈ `[0, N)` for a fixed N).
+2. The other source emits **monotonic-absolute** identity (hap.begin ∈ `[0, ∞)`, increments forever).
+3. The match uses exact equality (`a === b` or `Math.abs(a - b) < ε`).
+
+Symptom: the feature works for the FIRST window pass and silently goes dead after the wrap. No error, no warning — just a behavior cliff at the window boundary. Diagnose by sampling state across multiple window lengths; the cliff is the smoking gun.
+
+**Trap (wrong fix).** "Re-collect on every wrap." Doubles the work for every cycle and creates GC pressure. Or: "subscribe the chrome to a wrap event and re-key all events." Layered ceremony for a simple modular-arithmetic problem. Both paper over without addressing that the two sources have different identity domains.
+
+**Real fix.** Modulo the monotonic source by the window length before equality compare. `hapBegin % WINDOW_CYCLES` folds [0, ∞) into [0, WINDOW_CYCLES), aligned with the static source. Two-line fix at the comparison site, no architecture change.
+
+The deeper rule: when two systems with different identity-time domains must match, ONE of them must adopt the other's convention at the boundary. Static-window-relative is the cheaper convention (no growing state); modulo at the boundary is the cheapest adapter.
+
+**Cross-ref:**
+- PV42 (events span equals chrome display window) — defines the window length the modulo folds against. PV42 is the contract; P57 is the trap that violating it (or not adapting to it) lands in.
+- P50 (workaround cascade) — re-collecting on every wrap is the canonical workaround; modulo is the diagnosis-first answer.
+
+**REF:** `MusicalTimeline.tsx:608-616` (the modulo line); commit `24b72a4`; verified by Playwright probe over 6s playback (~3.2 windows): active-bar count holds steady at 5/5 samples-per-second through every wrap.
+
+## P58 — Collect arm scales-speed-only instead of replicating events (silent-semantics in collect)
+
+**ORIGIN:** Phase 20-12 hotfix wave (2026-05-10). User's `s("hh*8")` should produce 8 hh events per cycle (Strudel's `*N` mini-shorthand = `pat.fast(N)`). The Fast collect arm at `collect.ts:577` only multiplied `ctx.speed` and walked the body ONCE, producing one event with 1/N duration. Audio runtime correctly fired 8 times per cycle; IR projection saw 1. Same class as P52 (silent-semantics) but in the COLLECT arm rather than the parser.
+
+**Detection signal.** A multi-event Strudel operator is implemented in collect by:
+1. Setting `ctx.speed *= factor` (or similar scaling),
+2. Walking `ir.body` exactly once,
+3. Returning the single-walk events.
+
+If the operator's runtime semantics is "play body N times per cycle" (Fast, fast, `*N`, `!N`, repeat-style), the single walk produces N× fewer events than runtime. User-facing symptom: timeline shows 1 bar where they expected 8; sound correct, viz wrong.
+
+The pre-existing test that pinned the broken behavior (`Fast compresses time` + `note("c d").s("hh*8") → second body event falls outside slot range`) is itself the smoking gun — comments saying "PINNED — future fix updates the expectation when Fast gains repeat semantics" mark a known wrong contract. P37 trigger: defer-comments next to a wrong-but-shipping contract are the bug.
+
+**Trap (wrong fix).** "Just multiply event count." Naive: `for i in 0..N: events.push(walk(body))` without time-shifting produces N events at the SAME begin — no spread across the cycle. Or: scale begin/end after the fact, breaking child Seq's cursor logic.
+
+**Real fix.** Iterate `factor` times. Each iteration walks `ir.body` over a slot of width `ctx.duration / factor` advancing `ctx.time` by that slot. Do NOT also multiply `ctx.speed` — the duration shrink already encodes the "twice as fast" semantic; multiplying speed too would double-shrink Play durations and Seq cursor advance, leaving inter-slot gaps.
+
+```ts
+const slotDuration = ctx.duration / factor
+for (let i = 0; i < factor; i++) {
+  events.push(...walk(ir.body, {
+    ...ctx,
+    time: ctx.time + i * slotDuration,
+    duration: slotDuration,
+  }))
+}
+```
+
+**Cross-ref:**
+- P52 (silent-semantics-after-PV37) — same class but parser-side. P58 is the collect-side dual: representation honest, collect interpretation wrong.
+- P37 (defer-comment-is-the-bug) — the "future fix updates the expectation when Fast gains repeat semantics" comments next to passing-but-wrong tests are the canonical instance.
+- P50 (no fallback ladder) — the speed-scaling shortcut is a fallback; replicating is the primitive.
+- PV39 (semantics-as-typed-args) — the operator's typed args (factor) must drive the SEMANTIC count, not just a scaling parameter.
+
+**REF:** `collect.ts:577-633` (Fast/Slow arms post-fix); `PatternIR.test.ts:250-282` (3 collect tests pinning correct N-event output); `integration.test.ts:1267-1283` (corrected `note("c d").s("hh*8")` test); commit `dbeabc5`.
+
+## P59 — Pattern-arg promotion silently violates wrap-as-opaque (consumer reads typed value from a non-typed shape)
+
+**ORIGIN:** Phase 20-12 wave-δ (2026-05-10). User's `s("sine").freq("<200 880>")` Y-staircased on the chrome timeline. The `freq` Param promotion arm (added in α-1 / D-06 to support numeric `.freq(440)` as Y-as-pitch source) used the shared `parseParamArg`, which has THREE accepting arms — literal-number, literal-string, mini-pattern. The third arm wrapped the inner `<200 880>` as a sub-IR; collect resolved it per-cycle to numbers; chrome's `extractPitch.freqToMidi` happily mapped them to MIDI Y. The user wrote what looks like an "opaque parametric" shape (PV37 wrap-never-drop) and saw the chrome silently extract pitch from it.
+
+**Detection signal.** A new Param key gets added to a parser whitelist for ONE specific reason (chrome's pitch axis, audio routing, etc.). The parser uses a SHARED arg-parsing helper that admits multiple value shapes (literal, mini-pattern, etc.). Downstream consumers read the typed value as if the literal arm were the only path, but the mini-pattern arm produces values that satisfy the type signature too. Symptom: a behavior intended for ONE arm fires for a shape the user wrote thinking it would route elsewhere.
+
+**Trap (wrong fix).** "Make `parseParamArg` reject mini-pattern globally." Breaks `s("<bd cp>")`, `n("<0 1 2>")`, every legitimate parametric Param across the codebase. Or: "patch chrome to skip pattern-resolved freqs." Adds a per-key consumer-side gate that future consumers will have to remember; the gate is in the wrong place (consumer, not producer).
+
+**Real fix.** Gate the SPECIFIC Param key at the parser. After `parseParamArg` returns, check whether the KEY's intended semantics matches the value's shape. For `freq` (numeric Hz), accept only `typeof value === 'number'`; pattern values fall through to `wrapAsOpaque`, preserving PV37 in the right place — at the parser, not the consumer.
+
+```ts
+const parsed = parseParamArg(args, isSampleKey, baseOffset)
+if (!parsed) return wrapAsOpaque(...)
+if (method === 'freq' && typeof parsed.value !== 'number') {
+  return wrapAsOpaque(...)
+}
+return IR.param(method, parsed.value, ...)
+```
+
+**Cross-ref:**
+- PV37 (wrap-never-drop) — the rule the trap silently violates. PV37 says unmodelled REPRESENTATIONS go through wrapAsOpaque; the trap is interpreting the rule too narrowly (only "unmodelled methods", missing "unmodelled value-shapes for known methods").
+- P50 (single-decision) — gate is one place, not two. Don't add a SECOND gate at the consumer.
+- P54 (label-trap-at-typical-zoom) — pair-of relationship: a chrome surface promising one contract while another path delivers data that breaks it.
+
+**Generalisation.** Whenever a Param-style whitelist is extended for a NEW downstream consumer, audit: do existing arg-parsing arms produce values that satisfy the consumer's READ contract by accident? If yes, gate at the parser per key.
+
+**REF:** `parseStrudel.ts:855-880` (gate); `parseStrudel.test.ts:177-225` (3 wave-δ tests); `MusicalTimeline.tsx:875` (chrome consumer that would have read the bad value); commit `94162a9`.
+
+## P60 — React `onChange` ≡ native `input` for stateful UI controls (auto-close races every drag frame)
+
+**ORIGIN:** Phase 20-12 wave-ε (2026-05-11). Wave-δ shipped a custom `<input type="color">` row in `TrackSwatchPopover` whose React `onChange` handler called both `onPick(value)` and `onClose()`. The author reasoned: "native `change` fires on dismiss, so closing-on-change matches the click-to-pick contract from the 32-swatch grid." Manual gate Check #18: as soon as the user adjusted any color in the OS color panel, the swatch popover unmounted before the picked color could persist.
+
+**Detection signal.** A React handler on a stateful native input (`<input type="color">`, `<input type="range">`, `<input type="number">` typing flow, `<input type="search">` incremental search) attached via JSX `onChange` AND performs a side-effect that wouldn't be safe to fire on every keystroke / drag frame (close a popover, navigate away, send an HTTP request, write to a Y.Map without de-dup). Symptom: the side-effect fires before the user's interaction has converged; the UI feels like it "rejects" the user mid-action.
+
+The trap is specifically that React's `onChange` is **NOT** a 1:1 alias of the HTML `change` event. Per React's documented behavior, `onChange` for form elements maps to the native `input` event — fires on EVERY value change while the user is interacting. Native `change` (which fires once on commit/dismiss for color/range/text-search) has no React shorthand; you have to attach via `ref + addEventListener('change', ...)`.
+
+**Trap (wrong fix).**
+- "Use a setTimeout to debounce the close." Papers over the symptom; the close still races interaction patterns the timeout doesn't anticipate (slow mouse drags, accessibility key sequences). Tests will flake.
+- "Detect when the OS picker is open and suppress the close." There's no portable way to detect this in browsers — `focus`/`blur` semantics differ across Mac/Win/Linux + native vs. Chromium-rendered pickers.
+- "Switch to native `change` via ref." Solves the immediate bug but introduces a different one — many platforms fire `change` on EVERY commit (drag tick on Win), not just dismiss. Cross-platform UX is still inconsistent.
+
+**Real fix.** Decouple "value commit" from "dismiss" entirely.
+- `onChange` (= native `input`) writes through `onPick(value)` so the rest of the app live-previews the choice during interaction.
+- `onClose` is bound to the user's explicit dismiss intent — outside-click, Escape — NOT to any value-change event.
+- The LAST `onPick` value persists; the data store de-duplicates equal writes (Y.Map does this for free per tick) so the per-frame write rate is fine.
+- For controls where the live-preview is too expensive (large data writes, expensive renders), debounce or throttle `onPick` BUT keep the dismiss decoupled.
+
+```ts
+// WRONG — fires on every drag frame, unmounts before commit
+<input type="color" onChange={(e) => { onPick(e.currentTarget.value); onClose() }} />
+
+// RIGHT — live preview on change, dismiss only on explicit user intent
+<input type="color" onChange={(e) => onPick(e.currentTarget.value)} />
+// (popover's outside-click + Escape listeners handle onClose separately)
+```
+
+**Cross-ref:**
+- P55 (popover commit-then-close ordering) — applies to discrete-click flows like the 32-swatch cells. P60 is the dual: continuous-interaction inputs need the OPPOSITE rule (decouple commit from dismiss).
+- P50 (single-decision) — close decision is one place (the dismiss listeners), not two.
+- PV41 channel-2 (palette dot color) — the live-preview behavior P60 enables makes the channel feel responsive.
+
+**Generalisation.** Any React handler attached via JSX `onChange` on a form element should be reviewed for: "does this side-effect tolerate firing on every value tick during interaction?" If no, decouple commit from dismiss; or attach the dismiss-fire handler via ref + native `change` listener.
+
+**REF:** `TrackSwatchPopover.tsx:120-126` (post-fix commented handler); `TrackSwatchPopover.test.tsx:165-216` (live-preview + multi-frame tests); commit `dd42ec6`. React docs: "form elements with onChange use the native `input` event, not `change`" — `react.dev/reference/react-dom/components/input#noteworthy-differences-from-html`.
+
+## P61 — Density slider scales the container, leaves the contents at fixed sizes (one-layer geometry leak)
+
+**ORIGIN:** Phase 20-12 wave-ε (2026-05-11). Wave-δ shipped a sub-row height slider that propagated through `layoutTrackRows` to set each leaf band's `height`. The bar rendered inside the band, however, used a hardcoded `LEAF_BAR_HEIGHT = 6` constant from the wave-γ hotfix. Manual gate Check #19: dragging the slider made the bands tall but the bars stayed thin — a 6px ribbon floating in a 48px box. The slider produced a structurally-incoherent change ("the container got bigger but its contents didn't").
+
+**Detection signal.** A new control (slider, sizer, density toggle) is added that propagates to one geometry value (height, width, font-size, padding). The change reaches the controlled value and one or two derivations, but downstream visual elements that LOGICALLY depend on it (children-that-fill, glyphs-inside, bars-on-top) keep using their pre-slider constants. Symptom: dragging the control produces visible motion at one layer, none at the next.
+
+The trap is that the implementer treated the slider as feeding ONE downstream value (the container) instead of as the SOURCE in a derivation graph. Every dependent value should be a function of the controlled value, not a sibling constant.
+
+**Trap (wrong fix).**
+- "Add a second slider for the dependent." Doubles the cognitive load; the user has to keep two values in proportion themselves. Wrong primitive — the dependent SHOULD be derived.
+- "Hardcode a different constant for each band height." Lookup table that encodes the function badly.
+- "Document the limitation: `LEAF_BAR_HEIGHT is fixed; tune subRowHeight around it`." Defer-comment-is-the-bug (P37 family).
+
+**Real fix.** Replace the dependent's constant with a pure function of the controlled value. Reserve a fraction of the container for non-dependent visuals (axis room, padding, etc.); take the rest:
+
+```ts
+// WRONG — bar size constant, container scales independently
+const LEAF_BAR_HEIGHT = 6
+// ... barHeight = LEAF_BAR_HEIGHT
+
+// RIGHT — bar size derives from container size
+const PITCH_RESERVE = 12   // px reserved for pitch motion
+function leafBarHeight(bandHeight: number): number {
+  return Math.max(MIN_BAR, bandHeight - PITCH_RESERVE)
+}
+// ... barHeight = leafBarHeight(leaf.height)
+```
+
+The reserve constant carries the UX intent ("how much of the band stays for axis motion"); the function name documents that the bar IS a function of the band, not a sibling.
+
+**Cross-ref:**
+- P52 family (silent semantics) — the user's mental model said "make sub-rows bigger" = "everything inside gets bigger"; the implementation broke that contract silently.
+- PV41 channel-4 (Y-as-pitch) — pitch motion needs preservation when the bar grows; the reserve constant encodes the trade-off.
+- P37 (defer-comment-is-the-bug) — "barHeight is fixed for now" is a defer comment that would have hidden this.
+
+**Generalisation.** Any new density / size control needs a downstream-dependent audit: enumerate every constant in the same visual region (bar height, label font-size, gap, glyph size). For each: should it derive from the new control? If yes, rewrite as a function. If no, document why with a comment so the next density change doesn't re-trigger this trap.
+
+**REF:** `MusicalTimeline.tsx:117-124` (post-fix `leafBarHeight` derivation); commit `89ff5fc`.
+
+---
+
+## P62 — External transpiler quietly rewrites the value before the API sees it (Strudel double-quote → mini-Pattern)
+
+**ORIGIN:** Phase 20-11 wave-δ γ-7 manual gate (2026-05-12). 20-11 D-01 specified `.p("name")` as the canonical user idiom for track-id override. The IR parser arm matched a double-quoted string literal and wrapped as a `Track` tag. At eval time, the user's source `.p("kick")` reached Strudel's runtime `.p` as `.p(<Pattern>)` — and Strudel's `.p` calls `id.includes("$")`, which throws `TypeError: k.includes is not a function` on a Pattern. Strudel's transpiler (`@strudel/transpiler/transpiler.mjs:81-89`) eagerly rewrites EVERY double-quoted string literal to `mini(value)` because that's the right default for `s("bd cp")` / `note("c d")`. The 20-11 design and the Strudel transpiler were in disagreement about what `"name"` means inside `.p()`.
+
+**Detection signal.** A chain method's user-facing argument has a TYPE expectation that diverges from the ambient transpiler / preprocessor's behavior. Symptom: an IR-level parser arm matches the literal cleanly; unit tests pass against the parsed shape; the live runtime crashes OR silently drops the call. Stack trace points at a function INSIDE the external runtime (`Ie.f.p` for Strudel) — not at our code. The boundary is the transpiler stage, BEFORE the runtime function executes.
+
+This is a relative of P52 (silent-semantics-after-PV37) but at the EXTERNAL boundary: P52 was about our IR collect arm missing the field projection; P62 is about an external preprocessor mangling the value before our wrapper or the external runtime sees it. Same shape (silent), different layer.
+
+**Trap (wrong fix).**
+- "Patch the IR parser arm to also accept single quotes." Necessary but not sufficient — the wrapper at runtime still sees a Pattern object and crashes.
+- "Patch the external runtime to accept both types." Not our code; doesn't ship.
+- "Document the constraint in the parser comments and ship." Users still write `.p("name")` because that's the natural JS string syntax. Defer-comment-is-the-bug (P37).
+
+**Real fix.** Three-layer remediation, all required:
+
+1. **IR layer:** parser arm accepts BOTH quote styles. The IR-level Track wrap fires regardless of what the user typed, so the timeline label is consistent (the IR is permissive about source style).
+
+2. **Runtime guard layer:** wrap the external runtime's call with `typeof arg !== 'string' → return this` so the transpiler-mangled value no-ops gracefully instead of crashing. The user's chain doesn't blow up; the runtime registration silently fails but the eval completes.
+
+3. **Lint / quick-fix layer:** Monaco diagnostic provider flags the wrong-idiom site at WRITE time with a quick fix to rewrite to the working idiom. Surfaces the contract to the user before they hit eval.
+
+Layer 1 alone gives correct IR but broken runtime. Layer 2 alone makes runtime not crash but the override silently no-ops. Layer 3 alone catches it at write time but doesn't help users who paste working code. All three together close the gap.
+
+**Generalisation.** Any external preprocessor / transpiler that rewrites a user-typed value before it reaches the destination API is a P62 site. Catalogue them: which transformations does Strudel's transpiler apply? `"..."` → `mini()`; backticks → `mini()`; labeled statements → `.p('label')`. Each rewrite is a potential P62. Audit any new chain method against this list.
+
+**Cross-ref:**
+- P52 (silent-semantics-after-PV37) — sibling, but at the INTERNAL boundary (collect arm missing the field). P62 is the EXTERNAL-boundary sibling.
+- PV37 (wrap-never-drop) — the IR layer's permissiveness in the parser arm is a direct PV37 application: accept the user's typed character, even if a downstream layer can't honor it.
+- F-2 follow-up (commit `9033001`) — Monaco lint + quick-fix shipped.
+
+**REF:** Wave-δ fix commit `f4e66b4` (layers 1 + 2); F-2 commit `9033001` (layer 3); Playwright regression `wave-delta-gate.spec.ts` FIXTURE B + B2.
+
+---
+
+## P63 — Yjs lazy-create during render → observer cascade → setState-in-render
+
+**ORIGIN:** Phase 20-11 wave-δ Playwright runs (2026-05-12). `MusicalTimeline.tsx` rendered the timeline via `layoutTrackRows`, which called `collapsedFor(trackId)`, which called `getTrackMeta(fileId, trackId)`. `getTrackMeta` called `ensureTrackMetaMap(fileId)`, and on FIRST call for a file the helper wrote `fileMap.set('trackMeta', new Y.Map())` to the Y.Doc. The write triggered observe cascades; subscribers attached via `useSyncExternalStore` re-evaluated their snapshots and called `setState` on EditorView — DURING the render of MusicalTimeline. React warned: `Cannot update a component (EditorView) while rendering a different component (MusicalTimeline)`. Pre-existing bug (not introduced by wave-δ) but only surfaced because the new Playwright fixtures booted from a clean state and the warning fires on first-render-for-any-file.
+
+**Detection signal.** A getter named `getX(...)` (or `useX(...)`) is called from a component's render or from `useSyncExternalStore.getSnapshot`. The getter, on first call for some key, lazily creates a sub-store on the Y.Doc. Symptom: React warning about cross-component setState during render OR StrictMode tearing OR observable jank on the FIRST visit to a file/key (subsequent visits silent).
+
+The trap: lazy creation IS a legitimate optimization (don't allocate sub-stores until needed). But it must not happen on the READ path. If readers and writers share a single `ensureXMap` helper, every read-during-render becomes a write-during-render.
+
+**Trap (wrong fix).**
+- "Defer the read to `useEffect`." Moves the problem: now the first-render snapshot is empty, then `useEffect` writes, then re-render. UX jank.
+- "Wrap the write in `setTimeout`." Hides the problem behind a microtask. Still violates the "no doc-write during render" rule, just async.
+- "Disable React strict mode warnings." Hides the symptom; the underlying observer cascade still fires.
+
+**Real fix.** Split the helper into two functions with distinct semantics:
+- `getXMap(id)` — read-only; returns existing map or null; wires observer lazily if found (observing an existing map is doc-write-free). SAFE during render.
+- `ensureXMap(id)` — create-if-absent; mutates the doc; ONLY called from write paths (`setXMeta` and friends).
+
+Readers (`getX`, `subscribeToX`) use the read-only path. When a writer later creates the map, the observer wires at that point and back-fires to all already-registered subscribers via an out-of-band subscriber set.
+
+**Generalisation.** Any Yjs sub-store (Y.Map / Y.Array / Y.Text) that's lazily allocated must obey: **lazy creation lives on the write path; never on the read path**. The reader returns a shared frozen sentinel (e.g. `EMPTY_TRACK_META`) when the sub-store doesn't exist yet — and the sentinel must be ref-stable across reads to satisfy `useSyncExternalStore`'s tearing-detection contract.
+
+**Cross-ref:**
+- PV45 (this catalogue, below) — codifies the read-write split as an invariant.
+- `feedback_useeffect_per_render_dep.md` — sibling React-Yjs interaction trap.
+- PM-architecture entries (`project_pm_architecture.md`) — broader Yjs+React contract.
+
+**REF:** F-4 fix commit `2ef4697`; before-after at `packages/editor/src/workspace/WorkspaceFile.ts` `getTrackMetaMap` vs `ensureTrackMetaMap`.
+
+## P64 — Empty/ghost row in MusicalTimeline → check slotMapRef before the parser
+
+**Symptom:** the bottom-drawer timeline shows a track row with a faded label
+and zero note blocks where the user expected the row to be gone (e.g. after
+commenting out a `$:` line, or after stopping playback in a state the user
+considered "fresh").
+
+**The trap:** infer that the upstream parser (`parseStrudel` / `extractTracks`
+in `packages/editor/src/ir/parseStrudel.ts`) failed to filter the commented
+line, or produced a stray `Track` wrapper. Run regex sweeps. Edit the parser.
+Land a "fix" that doesn't change observed behaviour because the parser was
+already correct.
+
+**The real cause:** `MusicalTimeline.tsx:548-561` retains slot indexes across
+re-evals via `slotMapRef` + `stableTrackOrder` (per D-04's "stable across
+snapshots" contract — the Trap-5 fix from Phase 20-01). A trackId that
+disappears from the IR keeps its slot reserved as an empty placeholder; the
+row renders with no note blocks but with a faded label. This is INTENTIONAL
+for the A/B audition workflow (comment a `$:` while playing to mute a voice
+without losing row layout, uncomment to restore).
+
+**Diagnostic walk (first thing to check, before any parser hypothesis):**
+1. Run `parseStrudel` on the exact fixture and print `extractTracks` output.
+   If track count matches the user's expectation, the parser is innocent.
+2. Read `slotMapRef.current` (add a temporary log at `MusicalTimeline.tsx:562`).
+   If it contains a trackId that's absent from the current snapshot, you're
+   looking at slot retention, not a parser bug.
+3. Check transport state. Per Phase 20-12.1, `slotMapRef` clears on the
+   `non-null → null` edge of `currentCycle`. If transport is currently
+   playing, ghost rows are expected (D-04 audition case). If transport is
+   stopped, the edge should have already cleared the map — investigate why
+   it didn't (drawer-closed sub-case? rAF loop suspended without poke
+   sampling?).
+
+**Why this matters:** F-1 (FOLLOWUPS.md#F-1) was filed against the parser
+on 2026-05-11 and misdiagnosed for two days. The fix landed in Phase 20-12.1
+on the timeline component, not the parser. Future observers of the same
+symptom must check downstream slot retention BEFORE blaming upstream parse.
+
+**ORIGIN:** F-1 misdiagnosis (2026-05-13 reframe in
+`.planning/phases/20-musician-timeline/FOLLOWUPS.md:14-51`). Original
+hypothesis ("`extractTracks` doesn't skip JS-commented `$:` lines") was
+falsified by direct observation of `parseStrudel` output. Real cause was
+`slotMapRef` retention per D-04.
+
+**WHY:** without this entry, the next observer of an empty/ghost timeline
+row will re-derive the parser hypothesis from scratch. Slot retention is a
+parser-output sink, not a parser-bug source — a class of confusion this
+entry forecloses.
+
+**HOW:** directs the diagnostic walk to `MusicalTimeline.tsx:548-561` +
+`packages/app/src/components/musicalTimeline/stableTrackOrder.ts` first.
+Cross-refs Phase 20-12.1 (transport-stop reset), D-04 in
+`20-01-CONTEXT.md:53-56`, P63 (Y.Doc render-write — neighbouring code, not
+this trap), P52 (mount-path — related general class).
+
+**REF:** Phase 20-12.1 plan + commits on `fix/20-12.1-pause-resets-slot-map`;
+diagnostic anchor at `packages/app/src/components/MusicalTimeline.tsx:555-582`
+(prevCycleNullRef declaration + stop-edge reset block).
+
+---
+
+## P65 — Transport accessor returns a frozen value after stop (engine-state not gated)
+
+**Symptom:** any consumer that listens for a "transport stopped" signal via the
+cycle/time accessor (`getCycle()`, `getCurrentCycle()`, `scheduler.now()`) never
+fires its stop-edge logic. The accessor keeps returning the LAST playhead value
+forever after `engine.stop()`. Stop-edge reset blocks in `MusicalTimeline.tsx`,
+analyser teardown, scrub-position resets — anything keyed on `cycle === null` —
+silently no-ops.
+
+**The trap:** assume the accessor "naturally" goes null when the engine stops
+because that's what the type signature suggests (`() => number | null`). Wire
+a `prev/curr` edge tracker. Write tests that drive `setCurrentCycle(null)`
+directly — those pass — and ship. The bug only surfaces against the LIVE engine
+(P52 mount-path family).
+
+**The real cause:** Strudel's scheduler (`@strudel/core`) retains
+`scheduler.now()` as the last position. `LiveCodingRuntime.getCurrentCycle()`
+read it through with `Number.isFinite(v) ? v : null` — but isFinite is true
+for the retained value, so null is never returned. The accessor must explicitly
+gate on `isPlayingState`.
+
+**Diagnostic walk:**
+1. If a "stop-edge" feature works in unit tests (jsdom, manual `setState(null)`)
+   but fails in the browser, suspect the accessor — not the consumer.
+2. Read the accessor's implementation. If it reads engine internals without
+   gating on the engine's own play/stop state, you've found it.
+3. Add `if (!isPlayingState) return null` at the top of the accessor. Verify
+   the consumer's edge fires in the browser.
+
+**ORIGIN:** Phase 20-12.1 follow-up (2026-05-14). User reported "stop+play
+doesn't drop the ghost row" on `fix/20-12.1-pause-resets-slot-map`. The
+MusicalTimeline stop-edge reset was correct; `LiveCodingRuntime.getCurrentCycle()`
+at `packages/editor/src/workspace/runtime/LiveCodingRuntime.ts:641-644` was the
+real culprit.
+
+**WHY:** transport accessors are a chokepoint — many consumers downstream. A
+silent-failure here breaks unit-test-passing-but-broken features (T-8 manual
+gate from Phase 20-12.1 was the canonical case). One catalogue entry forecloses
+a whole class of future "edge listener doesn't fire" investigations.
+
+**HOW:** directs the next observer to read the accessor BEFORE writing more
+edge-tracking. Pairs with PV46 (transport accessors must gate on engine state).
+
+**REF:** `packages/editor/src/workspace/runtime/LiveCodingRuntime.ts:641-650`
+(post-fix); commit `667615d` on `fix/20-12.1-pause-resets-slot-map`. Related:
+P52 (mount-path silent failure class).
+
+---
+
+## P66 — Workspace package's compiled `dist/` is stale → app runs old code
+
+**Symptom:** edits to source in a workspace package (e.g. `packages/editor/src/`)
+don't reflect in the running dev server. The user reports a bug that you've
+already "fixed", you stare at the patched code, run unit tests (all green),
+push commits, force a hard refresh — and still see the OLD behaviour. Hours
+wasted iterating on a theory while the actual problem is build caching.
+
+**The trap:** assume HMR (Turbopack / Vite) picks up source changes uniformly
+across the monorepo. It does for files the dev server compiles directly (the
+top-level app), but NOT for workspace packages whose `package.json` `main` /
+`module` / `exports` point to `./dist/*`. The app imports the COMPILED bundle,
+which is only refreshed when the package's build step (`tsup`, `tsc`, etc.)
+runs.
+
+**The real cause:** `packages/editor/package.json` exports via
+`"main": "./dist/index.cjs"` + `"module": "./dist/index.js"`. The app's
+`@stave/editor` workspace dependency resolves through these fields, NOT
+through `src/`. So Next.js dev server doesn't watch
+`packages/editor/src/` — it watches the dist files. Without `tsup --watch`
+running, source edits stay invisible.
+
+**Diagnostic walk:**
+1. If "fix in source, test pass, dev server still shows old behaviour": check
+   the workspace package's `package.json`. If `main`/`module` point to `dist/`,
+   you're stale.
+2. Confirm with `ls -la packages/<name>/dist/index.js` — timestamp older than
+   your source edit means stale.
+3. Run the package's build script (`pnpm --filter <pkg> build`) or start its
+   watch script (`pnpm --filter <pkg> dev`).
+
+**Workflow rule:** when iterating on a workspace package's source against the
+running app, START `pnpm --filter <pkg> dev` in the background BEFORE editing.
+tsup's `--watch` flag rebuilds dist on each save; the app's HMR then picks it
+up. Without this you'll burn time on a theory that doesn't match what the
+browser is running.
+
+**ORIGIN:** Phase 20-12.1 follow-up session (2026-05-13/14). User reported
+"the rearrangement is back" after my parser fix had been pushed — symptoms
+matched the PRE-fix code. Manual `pnpm --filter @stave/editor build` reproduced
+the expected behaviour. tsup `--watch` started for future iterations.
+
+**WHY:** the canonical "I fixed it but it doesn't work" trap in this repo.
+Bites every new contributor (and re-bites old ones who forget). Closely
+neighbours `feedback_viz_bugs.md` (editor-dist staleness) — but that note
+records the lesson; this catalogue entry records the diagnostic recipe.
+
+**HOW:** any "fix not reflected in browser" investigation should check
+`packages/<pkg>/dist/index.js` mtime BEFORE checking HMR config, browser
+cache, or anything else.
+
+**REF:** `packages/editor/package.json` (`main`/`module`/`exports` fields);
+`packages/editor/package.json` scripts `build` (`tsup`) + `dev` (`tsup --watch`).
+Related: PK14 (stacked-PR dist conflicts — same dist-as-source-of-truth root),
+`feedback_viz_bugs.md` (stale-dist lesson, prior occurrence).
+
+## P67 — Tag-only IR discrimination conflates opaque-`via` wrappers with bare-`Code` fallbacks
+
+**Symptom:** a parser/projection/round-trip code path that branches on
+`ir.tag === 'Code'` treats TWO structurally distinct nodes identically:
+(a) a genuine unparsed fallback (`Code` with `code: <verbatim>`, no `via`),
+and (b) a structural opaque wrapper from `wrapAsOpaque` (`Code` with
+`code: ''` + a populated `via: { method, args, inner }` subtree — PV37 /
+20-04). The path discards or mis-renders the wrapper as if it were an
+unparsed blob, throwing away the inner IR (and its loc, its chain).
+
+**The trap:** `tag === 'Code'` reads as "this is the unstructured escape
+hatch" because that was the ONLY meaning before 20-04 introduced the
+opaque-via wrapper. The tag was overloaded; the discriminator wasn't
+updated. The two cases share a tag but have opposite meanings — one is
+"parsing failed here", the other is "parsing succeeded, wrapped for
+round-trip fidelity".
+
+**The real cause:** `Code` is a tri-state carried on one tag —
+{bare-fallback | opaque-via-wrapper | (lang-tagged embed)}. The
+discriminating field is `via`, not `tag`. Any check that means
+"is this an unparsed blob?" must be `tag === 'Code' && via === undefined`,
+not `tag === 'Code'`.
+
+**Detection signal:** a structured expression (has a recognizable root +
+chain) round-trips or projects as if it were opaque; OR a `.via`-bearing
+node's `inner` subtree never appears in collect/projection output. Cost
+one round-trip in Phase 20-14 γ (cluster-B success surfaced it: once the
+multi-line chain walker worked, `parseExpression`'s `rootIR.tag === 'Code'`
+guard started discarding the now-structured wrappers).
+
+**The fix:** discriminate on `via`. `tag === 'Code' && via === undefined`
+= true bare-fallback. `tag === 'Code' && via !== undefined` = structural
+wrapper, walk `via.inner`. Audit every `=== 'Code'` site when adding a new
+Code sub-state.
+
+**ORIGIN:** Phase 20-14 γ-wave parser-gap fix (2026-05-15). Surfaced when
+cluster-B (multi-line chain walker) succeeded and `parseExpression` began
+throwing away wrapAsOpaque wrappers as bare-Code.
+
+**REF:** P33 (silent-drop in applyMethod default arm — same `Code`
+overload lineage), PV37 (wrap-never-drop — the invariant the wrapper
+serves); `packages/editor/src/ir/parseStrudel.ts` (`wrapAsOpaque`,
+`parseExpression` rootIR guard). Ground Truth: 20-14-γ-SUMMARY.md
+"Parser-gap fix" §.

--- a/.anvi/krama.md
+++ b/.anvi/krama.md
@@ -1,0 +1,647 @@
+# Krama Catalogue — struCode
+
+> Project-specific lifecycle and timing patterns. Load at session start.
+> **Maintenance:** At every 10th entry, review and prune.
+
+## Universal Krama Patterns
+
+### UK1: Constructor → Async Setup → Ready
+**Lifecycle:**
+1. `new Framework(config, container)` — SYNC — creates instance, schedules setup
+2. `setup()` — ASYNC (rAF/microtask) — creates internal state, DOM
+3. Instance ready for method calls
+
+**Common violation:** Calling methods between 1 and 2.
+
+### UK2: Framework Init → Method Registration → User Code
+**Lifecycle:**
+1. Framework loads — SYNC
+2. `initialize()` — SYNC during evaluate — registers methods on prototypes
+3. User code executes
+
+**Common violation:** Installing interceptors before step 2.
+
+### UK3: Pipeline Transform → Execute Handler
+**Lifecycle:**
+1. User writes `obj.method("value")`
+2. Pipeline rewrites call — may wrap arguments
+3. Handler receives transformed arguments
+
+**Common violation:** Handler assumes original argument type.
+
+### UK4: Install → Execute → Capture → Restore
+**Lifecycle:**
+1. Install interceptors — SYNC
+2. Execute scoped operation — may be ASYNC
+3. Interceptors fire during step 2
+4. Restore original state — SYNC in finally block
+
+**Common violation:** Not restoring in `finally` block.
+
+### UK5: Cleanup Old → Create New (Re-entry)
+**Lifecycle:**
+1. Trigger event fires
+2. Cleanup previous state — SYNC — must complete before 3
+3. Execute new operation — ASYNC
+4. Create new state from results
+
+**Common violation:** Creating new state without cleanup. Or cleaning up state that should persist (destroy vs pause).
+
+## Project-Specific Krama Patterns
+
+### PK1: StrudelEngine.evaluate() Full Lifecycle
+**Lifecycle:**
+1. Install `.p` setter trap on Pattern.prototype — SYNC
+2. `repl.evaluate(code)` — ASYNC — triggers steps 3-5 internally
+3. `injectPatternMethods()` fires — SYNC during evaluate — reassigns Pattern.prototype.p (triggers our setter)
+4. Our setter fires — installs `.viz()` wrapper + `.p()` wrapper + legacy method wrappers — SYNC
+5. User code executes — calls `.viz("name")` → `.p("$")` — our wrappers capture patterns + viz requests
+6. evaluate completes — build trackSchedulers + vizRequests from captured data — SYNC
+7. Restore all prototype state — SYNC in finally block
+
+**Common violation:** Installing `.viz()` before step 3 (gets overwritten). Installing `.viz()` after step 5 (too late, user code already ran).
+**Correct placement:** Inside the `.p` setter (step 4) — after framework init, before user code.
+
+### PK2: p5 VizRenderer Mount Lifecycle
+**Lifecycle:**
+1. `new p5(wrappedSketch, container)` — SYNC — creates instance, schedules setup
+2. `wrappedSketch.setup()` fires — ASYNC (rAF) — calls `createCanvas()` then our `resizeCanvas(container.clientWidth, container.clientHeight)`
+3. `draw()` loop begins — every frame
+4. ResizeObserver fires on container resize — calls `renderer.resize(w, h)` only when dimensions actually change (>1px delta)
+
+**Common violation:** Calling `resizeCanvas()` between step 1 and 2 (no-op). Calling `resizeCanvas()` on every ResizeObserver event (clears spectrum waterfall).
+
+### PK3: Inline View Zone Lifecycle
+**Lifecycle:**
+1. `handlePlay()` fires — user presses play or live mode triggers
+2. `viewZoneCleanupRef.current?.cleanup()` — destroys old zones — SYNC
+3. `engine.evaluate(code)` — ASYNC — captures patterns + viz requests
+4. `addInlineViewZones(editor, ...)` — SYNC — creates zones only for tracks in vizRequests
+5. `viewZoneCleanupRef.current?.resume()` — resumes paused zones — SYNC
+6. On stop: `viewZoneCleanupRef.current?.pause()` — freezes zones (visible but static)
+7. On next play: return to step 1
+
+**Common violation:** Calling `cleanup()` on stop instead of `pause()` (destroys zones when they should freeze). Not calling `cleanup()` before step 4 (orphaned zones accumulate).
+
+### PK4: .viz() Capture Chain
+**Lifecycle:**
+1. User writes: `$: note("c4").s("sine").viz("pianoroll")`
+2. Transpiler rewrites: `note("c4").s("sine").viz(reify("pianoroll")).p('$')`
+3. `.s("sine")` returns NEW Pattern B (not original A)
+4. `.viz(reifiedArg)` — our wrapper extracts string from Pattern via `queryArc(0,1)[0].value`, sets `result._pendingViz = "pianoroll"`, returns result of Strudel's `.viz()` (Pattern C)
+5. `.p('$')` — our wrapper reads `this._pendingViz` on Pattern C, stores in `capturedVizRequests`, calls Strudel's `.p()`
+
+**Common violation:** Setting `_pendingViz` on `this` instead of return value (step 4). Checking `typeof arg === 'string'` when transpiler sends a Pattern (step 2).
+
+### PK5: Viz Code Hot-Reload Lifecycle
+**Lifecycle:**
+1. User edits a viz code tab in `VizEditor` — Monaco fires `onChange(value)`
+2. `handleCodeChange(groupId, tabId, value)` updates the tab's preset, marks dirty, calls `triggerHotReload(groupId, updatedPreset)`
+3. `triggerHotReload` — clears any pending debounce timer for this group, sets a new 300ms `setTimeout`
+4. Timer fires — calls `compilePreset(preset)` → wraps user code in `new Function()` (or `HydraVizRenderer(patternFn)` for hydra)
+5. On compile success — `setPreviewDescriptors(prev => Map.set(groupId, descriptor))` triggers React re-render
+6. The preview pane's React `key` prop includes the descriptor id — React unmounts the old `VizPanel`, mounts a new one
+7. New `VizPanel` calls `useVizRenderer` which calls `mountVizRenderer` — new renderer instance, new canvas, new `mount()` call with current audio components
+8. Old renderer's `destroy()` runs in the prior `useEffect` cleanup — releases hydra/p5 instance, removes canvas
+
+**Common violation:** Recompiling without destroying the old renderer (canvas leaks, hydra contexts leak, RAFs accumulate). Reusing the renderer instance instead of creating a new one (state from old code persists). Not debouncing — compile fires on every keystroke and locks up the main thread.
+
+**Krama dependency:** Step 7 (mount new renderer) MUST be preceded by step 8 (destroy old). React's `key`-based unmount/mount enforces this ordering when the key includes the descriptor id. If you forget the key (or use a stable key), React tries to update the component in place and the renderer reuses its old internal state.
+
+### PK6: Standalone Component Theme Application
+**Lifecycle:**
+1. Component mounts — `containerRef.current` is null until after first render
+2. First render commits — `containerRef.current` is now the DOM element
+3. `useEffect(() => applyTheme(containerRef.current, theme), [theme])` fires
+4. `applyTheme` iterates DARK_THEME_TOKENS / LIGHT_THEME_TOKENS, calls `el.style.setProperty('--background', '#090912')` etc.
+5. CSS variables are now set on the element
+6. Children re-render and `var(--background)` resolves to the set value
+7. On `theme` prop change — effect re-runs, new tokens overwrite old
+
+**Common violation:** Calling `applyTheme()` synchronously during render (ref is null). Forgetting the effect entirely (CSS variables never set, fallback colors used). Setting tokens on a parent element that the component doesn't actually mount inside (variables don't propagate through React composition, only through the DOM tree).
+
+### PK7: Viz Chrome Three-State Button Lifecycle (closed → running → paused → running)
+**Lifecycle:**
+1. `renderTabContent` (editor tab case) computes `existingPreview = findTabByFileId(fileId, 'preview')` → sets `previewOpen = existingPreview !== null`
+2. Same code path computes `previewPaused = pausedPreviews.has(fileId)`
+3. Chrome's `handlePrimaryButtonClick` derives the three-state button from these two flags: `closed` (!previewOpen) | `paused` (previewOpen && previewPaused) | `running` (previewOpen && !previewPaused)
+4. **Closed click** → calls `onOpenPreview(selectedSource)`. Shell handler opens a preview tab (or no-ops if one exists). Lazy-starts a built-in example source if the dropdown selection points to one.
+5. **Running click** → calls `onTogglePausePreview()`. Shell handler flips the file id in `pausedPreviews` via `setPausedPreviews`. React re-renders. Chrome recomputes `previewPaused = true` and renders "▶ Play".
+6. PreviewView re-renders with `paused={pausedPreviews.has(tab.fileId)}`. Provider's ctx gets `paused: true`. CompiledVizMount's `useEffect([paused, hidden])` fires and calls `renderer.pause()` (p5.noLoop / hydra halt).
+7. **Paused click** → same path, flipping back. `renderer.resume()` called.
+8. Preview tab's × button is the ONLY path that tears down the preview. Clearing `pausedPreviews` on tab close ensures a re-opened preview starts un-paused.
+
+**Common violation:**
+- Missing `pausedPreviews` from `renderTabContent`'s useCallback deps → second-click toggle uses stale closure (P8 recurrence).
+- Computing the button state in the chrome from stale closed-over props (chrome must derive from LATEST `previewOpen`/`previewPaused` every render, not cache in local state).
+- Closing the preview tab on Stop click instead of pausing. The preview is a persistent editing surface; Stop freezes, × dismisses.
+- Not clearing `pausedPreviews[fileId]` in `handleTabClose` for preview tabs → reopening a preview starts frozen with no visible Play button path to un-freeze.
+
+### PK9: HydraVizRenderer Mount + Loop-Ownership Lifecycle
+**Lifecycle:**
+1. `new HydraVizRenderer(pattern?)` — SYNC — creates instance, no hydra yet
+2. `mount(container, components, size, onError)` — SYNC
+   - Resolves audio source priority: analyser FIRST, hapStream envelope as fallback (PV13 / P21)
+   - Allocates `freqData` if analyser path; subscribes envelope handler if envelope path
+   - Creates `<canvas>`, appends to container
+   - Calls `initHydra(size).catch(onError)` — schedules ASYNC chain
+3. `initHydra` — ASYNC
+   - Awaits `import('hydra-synth')` (dynamic import)
+   - Guards: `if (!this.canvas || this.destroyed) return` — bails if mount was torn down before hydra loaded (StrictMode dev double-mount safety)
+   - Constructs `new Hydra({ canvas, autoLoop: false, ... })` — `autoLoop: false` is load-bearing per PV13
+   - Bridges `synth.a = this.hydra.a` so user patterns can use `s.a.fft[]`
+   - Runs the user pattern (or `defaultPattern`)
+   - Schedules first rAF: `this.rafId = requestAnimationFrame(this.pumpAudio)` — does NOT call pumpAudio synchronously (so pause is observable from frame 1)
+4. `pumpAudio(now)` — rAF callback, runs every frame while not paused
+   - Guard: bails + sets `rafId = null` if `paused` or `destroyed`
+   - Polls FFT into `s.a.fft[]` (analyser path or envelope path per PV13)
+   - Calls `this.hydra.tick(now ?? performance.now())` — single source of ticks
+   - Schedules next: `this.rafId = requestAnimationFrame(this.pumpAudio)`
+5. `pause()` — SYNC — sets `paused=true`, `cancelAnimationFrame(rafId)`, `rafId=null`
+6. `resume()` — SYNC — clears `paused`, re-arms rAF if `rafId==null && !destroyed`
+7. `destroy()` — SYNC — sets `destroyed=true`, cancels rAF, unsubscribes hapStream, removes canvas, nulls all refs
+
+**Common violation:**
+- Setting a `paused` flag without cancelling the rAF (P19) — pumpAudio keeps polling and ticking forever
+- Constructing hydra with `autoLoop: true` (P19) — hydra owns its own rAF that we can't reach
+- Calling `pumpAudio` synchronously inside `initHydra` instead of scheduling via rAF — first frame happens before any pause check, racing pause-from-frame-zero
+- Not setting `destroyed` flag — async `initHydra` resumes after teardown and creates an orphan instance
+- Picking the silent envelope path over a working analyser (P21) — see PV13's audio-source resolution rule
+
+**Krama dependency:** Step 3 (initHydra) MUST check `destroyed` before constructing hydra, or a destroy that races against the dynamic import creates an orphan. Step 4 (pumpAudio) MUST guard on `paused`/`destroyed` at the top, in case the browser fires a callback that was queued before cancelAnimationFrame ran. Step 5 (pause) MUST cancel the rAF synchronously — race-safe pause requires both the cancel AND the guard.
+
+### PK8: OfflineAudioContext Loop Rendering Lifecycle
+**Lifecycle:**
+1. User clicks Preview on a viz tab with a built-in example source (drum / chord) selected
+2. Chrome handler fires `builtin.startIfIdle()` which calls the source's `start()` (async)
+3. `start()` creates a new `AudioContext` (real, user gesture required)
+4. `start()` calls `renderLoopBuffer()` which instantiates an `OfflineAudioContext(channels, sampleRate * duration, sampleRate)`
+5. Synthesis runs: oscillators/noise sources scheduled with `start(t)` / `stop(t)`, gain envelopes via `setValueAtTime` + `linearRampToValueAtTime` / `exponentialRampToValueAtTime`, filters + connections — all drawn into the offline graph
+6. `await offline.startRendering()` returns an `AudioBuffer` with the full pre-rendered loop (~30–80ms for a 2s bar on desktop hardware)
+7. Real graph built: `AudioBufferSourceNode.buffer = renderedBuffer`, `source.loop = true`, connect through `GainNode → AnalyserNode → destination`
+8. `source.start()` — the loop begins playing in the real context
+9. Payload published to `workspaceAudioBus` with `{ analyser, scheduler, hapStream }`. Analyser now reflects the live FFT of the looping buffer.
+10. `notifyPlaybackStarted(sourceId)` — playback coordinator stops any other active source.
+11. On stop: `source.stop()`, disconnect, unpublish, `notifyPlaybackStopped(sourceId)`, close `AudioContext`.
+
+**Common violation:**
+- Calling `start()` outside a user gesture → `new AudioContext()` throws under autoplay policy.
+- Not gating parallel starts during the async render window with a `starting` flag → double-click on Preview spawns two renders, two loops, two bus publishes.
+- Rebuilding the buffer on every start (cheap but wasteful) vs. caching in the module. Current impl re-renders on each start; caching is a follow-up optimization.
+- Scheduler `query()` and the synthesized audio pattern drift apart when someone edits one without updating the other. The invariant "scheduler events align with audio hits" is maintained by construction (same beat offsets in both) but must be preserved by any future edits.
+
+### PK9: IR Inspector snapshot lifecycle
+**Lifecycle:**
+1. User edits Strudel code in the workspace file (Y.Doc-backed).
+2. User triggers eval (Cmd+Enter or auto-eval from live mode).
+3. `LiveCodingRuntime.evaluate(content)` runs Strudel's transpile + scheduler-update.
+4. On success Strudel fires `runtime.onEvaluateSuccess` callback (StrudelEditorClient.tsx).
+5. The handler:
+   - clears any error state for the file
+   - calls `emitFixed({ runtime, source: fileId })` so the Console panel's Live mode can hide stale errors
+   - **only when runtimeId === 'strudel' and fileNow exists**: parses + collects + publishes IRSnapshot
+6. `parseStrudel(fileNow.content)` — pure function over the source string. Tracks char offsets so Play nodes carry `loc`.
+7. `collect(ir)` — pure walk that produces `IREvent[]` for one cycle window. Propagates Play.loc onto event.loc.
+8. `publishIRSnapshot({ ts, source: fileNow.id, runtime: 'strudel', code, ir, events })` — fan-out to all `subscribeIRSnapshot` listeners.
+9. IRInspectorPanel React component (subscribed via useEffect) re-renders with the new snapshot.
+10. User clicks an event row whose `loc` is set → handler computes line from offset → `revealLineInFile(source, line)` — looks up the editor by `fileId` and moves the cursor.
+
+**Common violation:**
+- `IRSnapshot.source` set to `path` instead of `id` (P38) — silent click-to-source failure.
+- `parseStrudel` errors thrown synchronously instead of caught + ignored — would block the eval-success path.
+- Skipping the `runtimeId === 'strudel'` gate — Sonic Pi etc. fall through to a parser that doesn't understand them, produces opaque Code nodes, wastes work.
+
+**Krama dependency:**
+- Step 5's three actions (clear error, emitFixed, IRSnapshot publish) are independent — order doesn't matter, but ALL must run on every successful eval. Skipping the IRSnapshot leaves the Inspector stuck on stale data.
+- Steps 6-7 must complete BEFORE step 8 — the snapshot must be fully populated when subscribers fire (subscribers don't re-fetch).
+- The `parseStrudel` → `collect` step uses `baseOffset` plumbing (PV25). Any change to the parser pipeline that drops offsets breaks step 10's click-to-source without breaking earlier steps.
+
+**Update (Phase 19-07):** Step 6 + 8 changed shape. The eval-success handler now seeds the pipeline with `IR.code(content)` and runs `STRUDEL_PASSES = [RAW, MINI-EXPANDED, CHAIN-APPLIED, Parsed]` via `runPasses`. Every snapshot publishes 4 passes (`STRUDEL_PASSES.length === 4` from 19-07 onward; `passes[3].ir` is the FINAL output that matches today's `parseStrudel(code)` byte-shape). PV27's alias-drift invariant still holds: `snap.ir === snap.passes[passes.length - 1].ir`. The Inspector renders 4 tabs by data flow alone — UI unchanged.
+
+**Update (Phase 19-08, steps 8a + 8b):** `publishIRSnapshot` fan-out now decomposes into two parallel side-effects, both fired on every successful eval. Order independence (PK9's core invariant) is preserved — neither side-effect depends on the other.
+- **Step 8a — timeline capture fan-out.** `captureSnapshot(snap, { ts, cycleCount })` pushes the snapshot REFERENCE into the timelineCapture FIFO ring buffer (default capacity 30). The buffer holds references, not copies; UI consumers (`IRInspectorTimeline`) hold a captured reference in React state so FIFO eviction never invalidates a pin (D-07 / RESEARCH §7 trap #5).
+- **Step 8b — listener fan-out.** Single-slot consumers (the IR Inspector panel's live subscribe) re-render with the new snapshot.
+
+In the current implementation (`packages/editor/src/engine/irInspector.ts:55-64`) 8a runs before 8b textually, but ordering is incidental — either order satisfies the invariant. Future publishers may add additional side-effects at this step so long as none of them depend on read-after-write of the others.
+
+**Update (Phase 19-08, step 2 sub-step):** `Cmd+Enter` is bound to a play/stop **toggle** in `StrudelEditorClient.tsx`:504-506. Pressing it on a playing runtime calls `stop()` — which does NOT fire `onEvaluateSuccess` and does NOT publish an IRSnapshot. To force a re-evaluate during testing or programmatic use, the call sequence must be `stop()` → `play()` (or the keyboard equivalent `Cmd+./Cmd+Enter`). Two consecutive `Cmd+Enter` presses yield exactly ONE capture, not two. Codified in `ir-inspector-timeline.spec.ts` as the `reEvalStrudel(page)` helper.
+
+
+### PK10: @stave/editor barrel re-export propagation
+**Lifecycle:**
+1. Author adds a new export to a sub-barrel (e.g., `packages/editor/src/ir/index.ts` re-exports `runPasses` from `./passes`).
+2. Author runs `pnpm --filter @stave/editor build` — tsup compiles dist.
+3. Consumer in `@stave/app` imports the symbol — TS errors out. Author re-checks src files; types are correct.
+4. Author greps `dist/index.cjs` / `dist/index.d.ts` — symbol is missing.
+5. Root cause: `packages/editor/src/index.ts` is **hand-curated**, not a wildcard re-export. Sub-barrels do NOT auto-propagate.
+6. Fix: add the symbol to the top-level `src/index.ts` explicitly. Rebuild dist. Confirm by re-grep.
+
+**Common violation:**
+- Adding a sub-barrel re-export without also adding to the top-level barrel — the dist ships without the symbol, app-side `@stave/editor` import fails to resolve.
+- Author "rebuilds harder" (clean install, delete dist, etc.) instead of reading the top-level `index.ts`.
+
+**Krama dependency:**
+- The hand-curated barrel is intentional — controls the public surface of `@stave/editor`. Wildcards would leak internal symbols.
+- Build (tsup) only follows what the top-level index exports. Sub-barrels are private unless re-exported from the top.
+- Task list for any new public symbol: (a) export from sub-barrel for editor-internal use, (b) export from top-level barrel for app consumption, (c) rebuild dist, (d) verify by `grep <symbol> packages/editor/dist/index.cjs`.
+
+**Confirmed by:** Phase 19-02 Task 3 — `runPasses` was missing from dist after first build because it was added to `ir/index.ts` only. Fixed by also adding to `src/index.ts`.
+
+
+### PK11: Forced-tag introduction sequence in PatternIR
+**Lifecycle:**
+1. Add the tag to `PatternIR.ts` union + smart constructor on the `IR` object.
+2. Add the `case '<Tag>':` arm to `collect.ts` (event production semantics + `loc` propagation).
+3. Add the `case '<Tag>':` arm to `toStrudel.ts` (round-trip emit — for new tags this is the user-typed method name; for desugars structural emit is acceptable).
+4. Add shape unit tests in `__tests__/PatternIR.test.ts` (or `integration.test.ts`): construction, default values, `loc` propagation through collect, semantic-correctness on a small probe.
+5. Add `case '<methodName>':` to `parseStrudel.ts` `applyMethod` switch (parser dispatch).
+6. Add a parity `it()` block to `__tests__/parity.test.ts` that compares `parseStrudel(code) → collect` vs `evaluate(code).queryArc()` on the dimensions the tag claims to model.
+
+**Common violation:**
+- Skipping step 6 (parity) — the tag's collect arm claim goes unverified. Symmetric-only tests miss direction inversions (P42); spec-only verification misses spec-vs-implementation gaps (P43).
+- Bundling steps 1-3 with step 5 in a single commit — when the parser starts producing the tag and collect goes wrong, the bug surfaces conflated with the parser change. Atomic per-step commits make bisection trivial.
+- Adding the tag to `PatternIR.ts` only and not propagating to barrels. For new properties on the existing `IR` smart-ctor object, propagation is automatic (the object is already exported). For new top-level exports (helpers, types), PK10 applies — both `src/ir/index.ts` and `src/index.ts` must export.
+
+**Krama dependency:**
+- Step 1 (union + smart ctor) MUST land before step 2 (collect) — TypeScript will error otherwise.
+- Step 2 (collect) MUST land before step 6 (parity) — parity calls collect.
+- Steps 3 (toStrudel) and 4 (shape tests) are commutable with each other but must precede step 6.
+- Step 5 (parser wire) can land before or after step 6; if before, the parity test's input string can be the user-typed method (cleaner). Plan PK11 calls for: tag-end-to-end (steps 1-4) commits FIRST, then parser wire + parity (steps 5-6) commit SECOND. This gives two atomic commits per forced tag.
+
+**Confirmed by:** Phase 19-03 — Late, Degrade, Chunk, Ply each followed this sequence. Late shipped as 2 commits (tag end-to-end + parser+parity). Degrade and Chunk bundled their tag commits together (shared collect surface area), then each had its own parser commit. Ply shipped as 1 commit (tag + parser + parity together because all wiring was small after 3 prior tags established the pattern). All four ship without parity regressions.
+
+---
+
+## PK12 — `loc.start` convention for chained-method tags includes the leading `.`
+
+**ORIGIN:** Phase 19-05 W3/W7 — every chained-method tag's `loc.start`
+landed at the leading `.`, not at the method name. This was not an
+accident: `applyChain` walks `remaining` starting at the dot, computes
+`consumed = remaining.length - rest.length` BEFORE calling `applyMethod`,
+and passes `callSiteRange = [remainingOffset, remainingOffset + consumed]`
+to `tagMeta`. The full token captured is `.method(args)` end-to-end.
+First observed in W3 when populating the per-method case bodies; locked
+in W7 by D-11 containment tests on a 3-method chain
+(`s("bd").fast(2).late(0.125).gain(0.5)`) where each tag's loc must
+contain its full `.method(args)` substring.
+
+**WHY:** Without this convention, future Inspector / bidirectional
+consumers might assume `loc.start` lands at the method name (a natural
+assumption — "the method's location is where its name is written").
+That assumption would mis-render click-to-source: the user clicks
+`.fast(2)` expecting to land at the dot or method name, but the IR's
+`loc.start` actually points one character earlier (the dot is included).
+Worse, a consumer that highlights the loc range would highlight from
+the dot, which differs from how IDE-style "go to method definition"
+tools usually work. Documenting the convention prevents the next
+consumer from re-discovering it through a mismatched highlight bug.
+
+**HOW:** Three load-bearing pieces:
+
+1. **`applyChain` advances after the call.** The walker's `remainingOffset`
+   points at the leading `.` of the current method during the iteration;
+   it advances to the next `.` (or end of chain) AFTER `applyMethod`
+   returns. This is the source of dot-inclusion.
+
+2. **`tagMeta(method, callSiteRange)` builds the `loc` array.**
+   `callSiteRange[0]` IS `remainingOffset` (the dot position).
+   `callSiteRange[1]` is `remainingOffset + consumed` where `consumed`
+   = the substring length applyMethod is about to handle. Returns
+   `{ loc: [{ start, end }], userMethod: method }`.
+
+3. **`argsAbsoluteOffset` is a separate axis.** PRE-01 established
+   `argsAbsoluteOffset = remainingOffset + argsOffset` where `argsOffset`
+   points at `args[0]` (first character INSIDE the parens). For a
+   chain `.fast(2).late(0.125)`, the `.late` iteration has
+   `argsAbsoluteOffset` pointing at `0` of `0.125` while
+   `callSiteRange[0]` points at the `.` of `.late`. Conflating the
+   two would drift the tag-loc range by `methodName.length + 1` (the
+   `.method(` prefix). The 3-method chain test is the offset catcher.
+
+**Common violation:** Using `argsAbsoluteOffset` as a substitute for
+`callSiteRange.start`. They differ by `methodName.length + 1`. A test
+on `s("bd").fast(2)` would pass either way (loc.start at 7 or 13 both
+land "near" the method); a test on a longer method
+(`.degradeBy(0.5)` — 9 chars) would expose the drift immediately.
+
+**Krama dependency:**
+- The `applyChain` walker MUST advance `remainingOffset` AFTER
+  `applyMethod` returns, never before. Pre-emptive advance would lose
+  the dot position.
+- `tagMeta` MUST be called with `callSiteRange` from
+  `applyChain`, never reconstructed from `argsAbsoluteOffset`.
+- D-11 containment tests on chains of length ≥ 2 are the only reliable
+  catcher; single-method probes silently pass either convention.
+
+**Confirmed by:** Phase 19-05 W3 (29 single-tag case-body populations);
+W4 (3 desugar branches); W7 (per-method containment tests on 17 multi-arg
+methods + 3-method-chain offset catcher). PK11 sequence step 5 (parser
+wire) for forced tags must follow this convention going forward — every
+new `case` in `applyMethod` either calls `tagMeta(method, callSiteRange)`
+or builds the literal-construction with the same `[start, end]` shape.
+
+## PK13 — Source-level debugger projection lifecycle (parse → loc → collect → publish → run → match → render → break)
+
+**Domain:** end-to-end pipeline that turns a typed `.strudel` source
+into an inspectable, breakpointable program-execution surface. The
+contract that makes "click-to-source" / "highlight-on-play" / "set
+breakpoint" a single coherent feature rather than three independently
+broken ones.
+
+**Sequence (every step is mandatory; skipping any one creates a dark
+region the debugger cannot point at):**
+
+1. **Parse.** `parseStrudel(code)` produces an IR tree. Every leaf
+   `Play` carries `loc` (parseStrudel.ts:175-188). Every transform
+   tag carries `loc` via `tagMeta(method, callSiteRange)` (PK12).
+   **Krama violation:** an `applyMethod` arm that constructs a node
+   without `tagMeta` (or equivalent literal-construction) — the node
+   joins the tree loc-less. Downstream click-to-source on this node's
+   range fails.
+
+2. **Wrap unknowns.** `applyMethod`'s `default:` arm wraps unrecognised
+   chain methods as `Code`-with-loc (PV37). The wrapper carries the
+   `.method(args)` call-site range and a back-pointer to the inner IR.
+   **Krama violation:** `return ir` in the default arm — the typed
+   source disappears. Future steps cannot recover it.
+
+3. **Loc-tag every produced event.** `collect(ir)` walks the tree;
+   every collect arm that produces an `IREvent` MUST attach `loc` to
+   the event (PV36). For `Play`, this is `event.loc = ir.loc`
+   (collect.ts:247). For events produced by `Stack` / `Seq` / `Every`
+   / `Late` / `Fast` / etc., the produced events inherit the parent's
+   `loc` AND/OR the originating leaf's `loc`.
+   **Krama violation:** a collect arm that returns events without
+   `loc` — those events are runtime-visible but source-invisible.
+
+4. **Assign IR-node identity.** Each `IREvent` gets a stable
+   `irNodeId` (PV38) — derived at collect time from the IR node it
+   came from + position-in-output. The IRSnapshot exposes a lookup
+   `id → IREvent`.
+   **Krama violation:** identity assigned post-publish (e.g. by the
+   inspector) — the channel is no longer authoritative; runtime
+   matching becomes lossy.
+
+5. **Publish.** `publishIRSnapshot({ events, ir, code, source, … })`
+   exposes the snapshot to consumers (StrudelEditorClient.tsx:357).
+   The snapshot is immutable post-push (PV33) — the lookup table
+   never drifts.
+
+6. **Run.** `StrudelEngine` evaluates the user's code through Strudel's
+   `repl`; per-track `PatternScheduler`s emit haps via `queryArc()`
+   (StrudelEngine.ts:362-373). `normalizeStrudelHap(hap, trackId)`
+   produces a `NormalizedHap`.
+
+7. **Match.** Each `NormalizedHap` is enriched with `irNodeId` by
+   structural lookup against the published snapshot (matching by
+   `hap.value.context.locations` + `hap.whole.begin`). When no match
+   is found, the hap is tagged `irNodeId: null` and rendered as
+   "runtime-only" — same opaque-but-visible treatment PV37 gives
+   parser-unmodelled regions.
+   **Krama violation:** matching on `time` alone (drifts under
+   `fast`/`slow`); matching on `value` alone (collisions on repeated
+   notes). Must use `loc + position-in-arc` together.
+
+8. **Render.** The Inspector / MusicalTimeline / Monaco click-to-source
+   resolve `irNodeId → IREvent → loc → source range` and render. The
+   chain history walks from leaf back to root, stamping every
+   transform's `loc` along the way (the "stack frames" view).
+   **Krama violation:** rendering directly from `evt.loc` without
+   going through `irNodeId` — the projection becomes lossy when
+   multiple events share a loc range (e.g. all 8 hits of `s("hh*8")`).
+
+9. **Break (when scheduler-breakpoint phase lands).** Before triggering
+   each hap, the scheduler evaluates registered breakpoint conditions
+   (matching on `irNodeId` or on `loc` ranges). On match, the
+   scheduler clock pauses; the inspector renders the chain history
+   at this hap; the user resumes.
+   **Krama violation:** breakpoint matching after audio dispatch — the
+   user hears the note before the break fires, defeating the purpose.
+
+**Invariants threaded through this krama:**
+
+- **PV24 / PV36:** every IR node + every event carries `loc`.
+- **PV37:** unrecognised methods wrap, never drop.
+- **PV38:** every observable hap maps to an `irNodeId`.
+- **PV33:** snapshots are immutable after publish — the identity
+  channel is stable for the snapshot's lifetime.
+- **PV35:** the rendered surface honours the audience (musician for
+  timeline / piano roll; developer for IR Inspector chain view; both
+  consume the same identity channel).
+
+**Why this krama matters:** The debugger is not a single feature; it
+is the cumulative product of every step holding. Step 3 (loc-tag) is
+load-bearing for click-to-source; step 4 (identity) for breakpoints;
+step 7 (match) for live highlighting. A working click-to-source with
+no loc-completeness is a brittle special case that breaks on the
+first uncovered IR shape. A breakpoint mechanism without identity is
+indistinguishable from "stop at time t." The whole krama is the
+contract; partial implementations are not partial debuggers — they
+are debuggers that lie in proportion to the gaps.
+
+**Confirmed by:** 2026-05-07 architecture conversation. The DWARF /
+sourcemap analog is the same krama: parse → tag-with-loc → emit →
+identity → match → render → break. Production debuggers (gdb, Chrome
+DevTools, MSVC) all enforce every step. None ship with steps missing
+because the resulting tool would not be called a debugger.
+
+**REF:** parseStrudel.ts:175-188 (step 1); parseStrudel.ts:729-731
+(step 2 — site of the silent-drop bug, see P33); collect.ts:247
+(step 3); engine/irInspector.ts:51 (step 5); StrudelEngine.ts:362-373
+(step 6); engine/NormalizedHap.ts (step 7 — where irNodeId enrichment
+lands); MusicalTimeline.tsx (step 8); engine/timelineCapture.ts (step
+9 reverse-step / scrub already buffers snapshots).
+
+**STATUS (2026-05-08):** **All 9 steps LANDED.** Debugger v2 substrate is complete in main as of `dc00749`.
+
+- **Steps 1-3** (debugger v1 — main `aded68f`):
+  - Step 1 (parse with loc on every IR node) — preserved by parser; validated via PV36 clause 1 + W7 outermost-loc audit (PR #95).
+  - Step 2 (wrap unknowns) — landed by PV37 wrapper construction (PR #96); silent-drop bug at parseStrudel.ts:729 ELIMINATED (P33 closed).
+  - Step 3 (loc-tag every produced event) — landed by `withWrapperLoc` helper threaded through 20+ collect arms (PR #95).
+- **Step 4** (debugger v2 — PR #102): assign IR-node identity. `assignNodeId(ir, position)` in collect.ts:160 (FNV-1a content-hash; leaf-only assignment per DEC-NEW-1 — wrapper arms preserve via `{...e, ...}` spread). PV38 clause 1 enforced.
+- **Step 5** (publish): `publishIRSnapshot` extended with `IRSnapshotInput = Omit<IRSnapshot, 'irNodeIdLookup' \| 'irNodeLocLookup' \| 'irNodeIdsByLine'>` (PR #102 + PR #104 wave α0). Three `ReadonlyMap` lookups built in `enrichWithLookups`; PV33 immutability enforced at the type level.
+- **Step 6** (run): unchanged — Strudel's repl drives `wrappedOutput` per `StrudelEngine.ts:195-211`.
+- **Step 7** (match): two boundaries close.
+  - queryArc boundary — `normalizeStrudelHap` consumes `findMatchedEvent(loc, begin, lookup)` (PR #102 wave γ).
+  - onTrigger boundary — `HapStream.emit` enriches the fired hap with `irNodeId` via the same `findMatchedEvent` (PR #103 wave α). Single-strategy match per P50; no fallback ladder.
+- **Step 8** (render): both surfaces consume the identity channel.
+  - musician timeline — `MusicalTimeline.activeKeys` rewritten from cycle-derived to hap-driven; HapStream subscription drives the glow (PR #103).
+  - developer Inspector — `IRInspectorPanel` chain rows pulse on hap fire and render breakpoint markers when registered (PR #104 wave γ). `data-irinspector-pulsed` + `data-breakpoint-active` attributes.
+- **Step 9** (break): scheduler-level breakpoints land via `BreakpointStore` (per-engine, keyed by content-addressed irNodeId) + hit-check at `wrappedOutput` AFTER the pulse emit and BEFORE `await webaudioOutput` (PR #104 wave α + δ). DEC-AMENDED-1: pause via `repl.scheduler.pause()` — NOT `stop()` (Strudel `cyclist.mjs:112-116` preserves cycle position for true inspect-and-resume; `stop()` rewinds to cycle 0). Resume reachable via Inspector header button + Monaco "Debugger: Resume" command (R-1; Cmd-Shift-P even when Inspector collapsed).
+
+**Behavioural guarantee post-v2:** the DWARF / Chrome-DevTools analog for live coding is in main. Click-to-source resolves anywhere; live highlighting glows the actually-firing event; gutter-click or chain-row-click sets a breakpoint that pauses the scheduler at the correct cycle and survives unrelated edits (irNodeId is content-addressed). The remaining v2 surface — cheap scrub UI (drag the playhead with cycle-derived glow at scrub position) — is split to phase 20-08 per user scope decision; audio-coordinated scrub explicitly deferred indefinitely.
+
+**Phase 20-10 (2026-05-09) — step 2 strengthened for whitelisted param methods.**
+For the 10 methods `s/n/note/gain/velocity/color/pan/speed/bank/scale`,
+`applyMethod` constructs a typed `Param` IR tag (semantics-honest)
+BEFORE the `default:` arm's `wrapAsOpaque` runs. Methods outside the
+whitelist still fall through `default:` to `wrapAsOpaque` (PV37 —
+representation-honest, semantics-deferred). Both paths converge at
+collect: `case 'Param':` merges value into ctx.params and spreads into
+the body event's top-level fields (s/gain/velocity/color); `case
+'Code':` walks `via.inner` with no semantic effect. The whitelist is
+expandable — same `applyMethod` arm shape; same `Param` tag. PK13's
+step 2 narrative is unchanged ("Wrap unknowns"); the strengthening adds
+a typed-arm short-circuit ABOVE the wrap fallback for the 10 named
+methods. PV37 unchanged; PV39 added as the semantics-completeness
+sibling. Cross-ref: hetvabhasa P52 (silent-semantics-after-PV37 trap
+class).
+
+**Phase 20-11 (2026-05-09) — step 2 (parser → IR) + step 7 (collect → events) — track-identity layer.** Step 2 strengthens further: parseStrudel main path now wraps every `$:` track with `Track('d{N}', expr, {loc: $:-line range})` (auto-numbered per Tidal convention) and synthetic `Track('d1', expr)` (no loc, no userMethod) for non-`$:` files. Multi-`$:` produces an outer `Stack` of Tracks. The `case 'p':` arm (previously a 20-04 Chesterton pass-through) now wraps with `Track(name, body, {userMethod: 'p', loc: callSiteRange})` for explicit user-typed track names; non-string args fall back to the PV37 `wrapAsOpaque` path. Step 7 strengthens: collect's `case 'Track'` arm spreads `{...ctx, trackId: ir.trackId}` (outer-then-inner walk; inner explicit `.p()` wins over outer synthetic `d{N}` per CONTEXT pre-mortem #1); `makeEvent` populates `evt.trackId` via conditional spread (omitted when undefined to preserve the pre-20-11 fallback path for hand-built fixtures). Downstream consumers (`groupEventsByTrack`, `MusicalTimeline`) read `evt.trackId` first; inference from `evt.s` becomes pure fallback. PK13's step 2 narrative grows the "wrap" set: PV37 wraps unknowns, PV39 wraps param-bearing methods, PV40 wraps `$:` blocks and `.p()`. All three are the same shape (typed wrapper + loc + back-pointer). Cross-ref: vyapti PV40 (track-identity-parser-assigned); hetvabhasa P53 (groupEventsByTrack-evt.s-fallback trap class).
+
+---
+
+## PK14 — Stacked-PR merge resolution: `dist/*` conflicts are build artifacts, not real divergence
+
+**Claim:** When a downstream branch (B based on A) needs to merge `origin/main` after A landed, `git merge` will report conflicts in `packages/editor/dist/*`. These are build-artifact conflicts (minified output diverges between branches even when source is identical). Source files auto-merge cleanly. Canonical resolution:
+
+```bash
+# After `git merge --no-commit --no-ff origin/main` reports dist conflicts:
+git checkout --ours packages/editor/dist/
+pnpm --filter @stave/editor build
+git add packages/editor/dist/
+# Source files were auto-merged; verify they look right:
+git diff --staged packages/editor/src/   # should be empty if A's source landed identically
+# Run tests on the merged state BEFORE committing:
+pnpm --filter @stave/editor exec vitest run
+# Commit the merge with the default message:
+git commit --no-edit
+```
+
+**Why this sequence works:**
+1. `--ours` takes our (B's) dist as the merge base for the conflicted files.
+2. The rebuild regenerates dist from merged source (which is now A's source + B's source); the regenerated dist is consistent with the merged source state, not stale.
+3. `git add packages/editor/dist/` stages the rebuilt artifacts.
+4. Tests verify the merge didn't break source-level behavior.
+
+**Counter-pattern.** Trying to manually resolve the dist conflicts (editing the merge markers in minified JS) is futile — minified output isn't human-merge-friendly. Trying to `--theirs` is wrong because their dist was built from THEIR pre-merge source, not the merged state. The rebuild is the only correct resolution.
+
+**When this fires.** Anytime a PR queue is opened in dependency order (A → B → C → D) and predecessors merge to main while downstream branches are still local. Each downstream branch will need this resolution when bringing main forward. Phase 20-11 wave-δ saw it 4 times in one session (20-12 vs main after 20-11 merged; followups vs main after 20-12 merged; etc.).
+
+**Step ordering (atomic per merge):**
+1. `git checkout <downstream-branch>`
+2. `git fetch origin`
+3. `git merge --no-commit --no-ff origin/main` — observe conflict report
+4. If conflicts are only in `packages/editor/dist/*`: apply the recipe above
+5. If conflicts include source files: investigate each — likely a genuine downstream/upstream divergence that needs hand-merge
+6. `git push` once tests green
+
+**Cross-ref:**
+- AnviDev §2 commits: rebuild after merge is a maintenance step, not a "fix"
+- `feedback_viz_bugs.md` editor-`dist/` staleness reminder — same family
+
+---
+
+## PK15 — MusicalTimeline slot-map session lifecycle
+
+**Lifecycle ordering (per-render, in `MusicalTimeline.tsx`):**
+
+1. **File-switch reset** (`snapshot.source !== lastSourceRef.current`):
+   `slotMapRef.current = new Map()`, `hasHadEventsRef.current = new Set()`.
+   Different workspace file → wipe all session state.
+
+2. **Transport-transition reset** (`prevCycleNullRef.current !== cycleIsNull`):
+   Same clear as above. Fires on BOTH edges of play↔stop. Hot-reload mid-play
+   is NOT a transition (both prev and curr non-null) → no reset, slots
+   preserved (D-04 audition workflow).
+
+3. **Slot derivation** (always seed from IR top-level + event-group slot keys):
+   `currentSlotKeys = [...irSlots.map(s => s.slotKey),
+                       ...groups.map(groupSlotKey)]`,
+   then `stableTrackOrder(slotMapRef.current, currentSlotKeys)`.
+   IR top-level walk includes commented `$:` lines (parser emits them as
+   empty-body Tracks), so source position is captured in the slot map even
+   for silent rows.
+
+4. **Visibility set update**: `for g in groups: hasHadEventsRef.add(groupSlotKey(g))`.
+   Tracks WHICH SLOTS have ever produced events this session.
+
+5. **orderedTracks build**: iterate `slotMap.entries()` sorted by slot index,
+   filter by membership in `hasHadEventsRef`, map each surviving slot to
+   `{trackId: displayLabel, events: groupBySlotKey.get(slotKey)?.events ?? []}`.
+
+**Three behaviours this enforces (the conflict resolution):**
+- *Mid-play comment* — slotKey still in `hasHadEvents` from prior eval; row
+  renders as ghost in its source-order slot. (D-04 audition.)
+- *Stop + play after comment* — stop edge clears `hasHadEvents`; the next
+  play's events repopulate the set only for ACTIVE rows. Commented row is
+  not in the set → invisible. Slot map still has its slot (from IR-side
+  seed), so uncommenting later restores the row IN POSITION, not at the
+  bottom.
+- *`.p("name")` rename* — outer `$:` Track's `loc.start` (= `dollarPos`) is
+  unchanged; events carry the same `dollarPos` → same slotKey → same slot.
+  Display label changes via the separate `slotDisplay` map.
+
+**Common violations:**
+- Adding state (color, collapsed flag, etc.) keyed by display `trackId`
+  instead of `slotKey` → state lost on `.p()` rename. Currently `trackMeta`
+  Y.Doc has this issue; see PV47.
+- Using `slotMap.size > 0` as a proxy for "mid-session" (the gate-fix bug
+  in commit `0e68482`) → fresh seed never gets IR-side slots → uncomment
+  appends at end. Use `hasHadEvents` membership for visibility, not
+  `slotMap.size` for sessionness.
+- Not resetting on BOTH transport edges (stop-only reset, commit `c926042`)
+  → edit-while-stopped doesn't take effect on play. Always reset on
+  `prevCycleNullRef !== cycleIsNull`.
+
+**REF:** Phase 20-12.1 + follow-up commits on
+`fix/20-12.1-pause-resets-slot-map`. PV47 (source-anchored slot identity),
+PV45 (Y.Doc render hygiene), P64 (slot retention diagnostic walk).
+
+## PK16 — Strudel engine-init + no-`$:` parse pipeline ordering (Phase 20-14)
+
+Two related execution-order dependencies validated in Phase 20-14.
+
+**(a) Engine init — sound registration before snapshot, aliasBank after manifests.**
+
+```
+StrudelEngine.init() ordering (after evalScope + miniAllStrings + transpiler):
+1. initAudio()
+2. registerSynthSounds() / registerZZFXSounds() / registerSoundfonts()
+3. await samples('github:…/Dirt-Samples')        ← existing
+4. await Promise.all([ 6 b-cdn sample manifests ]) ← 20-14 α-2
+5. await aliasBank(tidal-drum-machines-alias.json) ← 20-14 α-3
+6. loadedSoundNames = Object.keys(soundMap.get()) ← snapshot
+7. analyser tap + wrappedOutput install
+```
+
+**Why the order is load-bearing:** `aliasBank` (step 5) walks the
+already-registered `soundMap` suffixes to emit aliased keys. Run it BEFORE
+the manifest fetches (step 4) and there are no suffixes to alias → aliases
+silently absent, `.bank("RolandTR909")` no-ops. The `loadedSoundNames`
+snapshot (step 6) must be AFTER 4+5 or autocomplete misses the new banks.
+Verified empirically (α-3 BEFORE/AFTER `soundMap` key-count gate: Δ must
+be ≥ 0 — a drop means aliasBank replaced rather than merged the map, which
+would be a PLAN-LEVEL stop).
+
+**(b) no-`$:` parse pipeline — prelude-strip is the first stage.**
+
+```
+parseStrudel(code), no-$: branch:
+1. stripParserPrelude(code) → { body, offset }   ← 20-14 γ (skip comments,
+                                                     samples/useRNG/set*)
+2. splitRootAndChain(body) → root + chain
+3. parseRoot(root, offset)  (bare-string arm, note/n/s, stack, …)
+4. applyChain(chain)        (whitespace/comment-tolerant walker — PV49)
+```
+
+**Why prelude-strip is stage 1:** every later stage assumes its input
+starts at the musical expression. Leave the prelude in and `parseRoot`'s
+anchored regexes fail on the leading `// "Title"` / `samples({…})` lines →
+whole program → Code-fallback. The offset returned by stage 1 threads
+through 3+4 so loc stays valid against the ORIGINAL source. Extends PK15
+(μ-α parse cycle) — same shape as μ's pre-parse normalisations, one stage
+earlier.
+
+**Common violation:** adding a new boot-side-effect call (e.g. `setcpm`,
+gap #135) WITHOUT adding it to stripParserPrelude's skip set → that whole
+class of programs regresses to Code-fallback. The skip set must be
+cross-referenced against the α-6 `settingPatterns` audit, not
+hand-maintained ad hoc.
+
+**REF:** PK15 (MusicalTimeline slot-map lifecycle — sibling parse-cycle
+krama), PV49 (the stage-4 walker invariant), P67 (stage-3 Code
+discrimination); `feedback_strudel_init.md` (the evalScope→mini→synths
+ordering this extends); `packages/editor/src/ir/parseStrudel.ts`,
+`packages/editor/src/engine/StrudelEngine.ts`. Ground Truth:
+20-14-{RESEARCH,α-SUMMARY,γ-SUMMARY}.md.

--- a/.anvi/vyapti.md
+++ b/.anvi/vyapti.md
@@ -1,0 +1,1503 @@
+# Vyāpti Catalogue — struCode
+
+> Project-specific structural regularities (invariants). Load at session start.
+> **Maintenance:** At every 10th entry, review and prune.
+
+## Universal Vyāptis
+
+### UV1: Container Ownership
+**Statement:** Wherever a visual element is placed inside a container, the container owns the element's available dimensions.
+**Causal status:** STRUCTURAL
+**Scope:** CSS layout, component trees, Monaco view zones.
+**Breaks when:** Child has fixed/absolute positioning; child is off-DOM (clientWidth = 0).
+**Implication:** Never hardcode sizes in child components.
+
+### UV2: Framework Prototype Sovereignty
+**Statement:** Wherever a framework initializes by writing to prototypes, it will overwrite pre-installed methods.
+**Causal status:** CAUSAL
+**Scope:** Any framework using `X.prototype.method = fn` during init.
+**Implication:** Install interceptors AFTER framework init, or inside its init hook.
+
+### UV3: Pipeline Argument Transformation
+**Statement:** Wherever a build pipeline processes method calls, it may transform arguments before the handler receives them.
+**Causal status:** CAUSAL
+**Scope:** Transpilers, macro systems, middleware pipelines.
+**Implication:** Test through the real pipeline. Handle both raw and transformed argument types.
+
+### UV4: Async Construction
+**Statement:** Wherever a constructor defers setup to a callback, post-constructor calls may execute before setup completes.
+**Causal status:** CAUSAL
+**Scope:** Any framework with deferred initialization.
+**Implication:** Post-setup operations go inside the setup callback.
+
+### UV5: Method Chain Identity
+**Statement:** Wherever a method returns a new instance (not `this`), properties on the pre-call object are absent on the post-call object.
+**Causal status:** STRUCTURAL
+**Scope:** Immutable/functional APIs, fluent APIs that clone.
+**Implication:** Tag the RETURN VALUE, not `this`.
+
+### UV6: Observation Without Mutation
+**Statement:** Wherever you modify system state to observe it, you change the behavior you're trying to observe.
+**Causal status:** CAUSAL
+**Scope:** Audio routing, message queues, network streams.
+**Implication:** Design observation as passive side-taps, not re-routing.
+
+## Project-Specific Vyāptis
+
+### PV1: Strudel Pattern Methods Return New Instances
+**Statement:** Wherever a Strudel Pattern method is called (`.s()`, `.gain()`, `.viz()`, etc.), the return value is a NEW Pattern instance, not the original.
+**Causal status:** STRUCTURAL — Strudel's immutable Pattern architecture.
+**Scope:** All Pattern prototype methods.
+**Breaks when:** `.p()` which returns `this`.
+**Confirmed by:** `_pendingViz` set on Pattern A, `.viz()` returned Pattern B, `.p()` called on B with no `_pendingViz`. (2026-03-23)
+**Implication:** Any property tagging during method interception must be on the return value.
+
+### PV2: Strudel injectPatternMethods Fires on Every evaluate()
+**Statement:** Wherever `repl.evaluate()` is called, `injectPatternMethods` runs first and reassigns all Pattern.prototype methods.
+**Causal status:** CAUSAL — `evaluate()` calls `injectPatternMethods()` internally.
+**Scope:** Every call to `repl.evaluate()`.
+**Confirmed by:** `.viz()` installed before evaluate was overwritten silently. (2026-03-23)
+**Implication:** Interceptors must be installed inside the `.p` setter trap, not before `evaluate()`.
+
+### PV3: superdough Audio Routes Through Orbits
+**Statement:** Wherever a Strudel pattern produces audio, it routes through a superdough orbit (default orbit 0). Each orbit has its own GainNode chain.
+**Causal status:** STRUCTURAL — superdough architecture.
+**Scope:** All audio output.
+**Breaks when:** N/A — always holds.
+**Confirmed by:** Orbit reassignment moved audio away from default chain. (2026-03-23)
+**Implication:** Per-track audio isolation requires passive taps on orbit outputs, not orbit reassignment.
+
+### PV4: Monaco View Zone Container is Off-DOM at Mount Time
+**Statement:** Wherever a Monaco view zone is created, its container div has `clientWidth = 0` at the time `changeViewZones` fires — the div hasn't been added to the DOM yet.
+**Causal status:** STRUCTURAL — Monaco's view zone lifecycle.
+**Scope:** All view zone creation.
+**Confirmed by:** `container.clientWidth` returned 0, `editor.getLayoutInfo().contentWidth` returned correct value. (2026-03-22)
+**Implication:** Use `editor.getLayoutInfo().contentWidth` for initial width, never `container.clientWidth`.
+
+### PV5: p5 setup() Runs on Next requestAnimationFrame
+**Statement:** Wherever `new p5(sketch, container)` is called, `setup()` executes on the next animation frame, not synchronously.
+**Causal status:** CAUSAL — p5's internal scheduling.
+**Scope:** All p5 instance creation.
+**Confirmed by:** `resizeCanvas()` after `new p5()` was a no-op — canvas hadn't been created yet. (2026-03-23)
+**Implication:** Post-setup operations must be inside the setup callback or a wrapped setup function.
+
+### PV6: Theme Ownership Per Root Component
+**Statement:** Wherever a top-level (root-of-tree) component reads CSS custom properties (`var(--*)`), that component MUST own its theme application by calling `applyTheme(containerRef.current, theme)` in a `useEffect`. CSS variables do not propagate from a sibling root — they propagate from a DOM ancestor that explicitly sets them.
+**Causal status:** STRUCTURAL — CSS custom property inheritance only goes through the DOM tree, not through React component composition.
+**Scope:** Every top-level Stave component (`LiveCodingEditor`, `StrudelEditor`, `VizEditor`, future `WorkspaceShell`).
+**Breaks when:** A component is mounted as a sibling of a themed component instead of nested inside it. The CSS variables defined on `LiveCodingEditor`'s container do NOT reach a sibling `VizEditor`.
+**Confirmed by:** `VizEditor` rendered without theme application — borders, text, surface colors all unstyled until `applyTheme()` was added to its mount effect. (2026-04-08)
+**Implication:** Every new top-level component gets a `theme?: 'dark' | 'light' | StrudelTheme` prop and a mount effect that calls `applyTheme()`. Don't rely on a parent provider — themes are owned at the root, not provided.
+
+### PV7: Editor / Preview Separation
+**Statement:** Wherever a code editor and a runtime preview coexist, they must be modeled as independent views with a one-way data dependency (preview reads from editor's file content). They must NOT be modeled as a single component with `previewMode` state.
+**Causal status:** STRUCTURAL — composition only works when concerns are fully separated.
+**Scope:** Every authoring surface — pattern editors, viz editors, markdown editors, future shader/control editors.
+**Breaks when:** A user wants to preview file A while editing file B (impossible if preview is glued to its own editor). When a file has zero previews open OR multiple previews open simultaneously (impossible if `previewMode` is per-editor-group state).
+**Confirmed by:** `VizEditor` v0.1.0+ has `previewMode: 'panel' | 'inline' | 'background' | 'popout'` per `EditorGroupState` — this works for one editor but doesn't compose with pattern editors and can't support "preview viz A while editing pattern B." (2026-04-08, this is the motivation for Phase 10.2.)
+**Reference system:** VS Code's markdown / markdown preview. Open `README.md` → it's just an editor. `Cmd+K V` → opens a sibling preview view that watches the file. The preview is a *view*, not a *mode of the editor*.
+**Implication:** Phase 10.2 refactors all 3 current editor components (`StrudelEditor`, `LiveCodingEditor`, `VizEditor`) along this seam: `EditorView` (Monaco only) + `PreviewView` (file-extension-aware) + `PreviewProviderRegistry` mapping extensions to providers.
+
+### PV8: Preview Providers Need a Shared Audio Bus
+**Statement:** Wherever multiple preview views participate in a live system (e.g., a pattern preview produces audio, a viz preview consumes it), they must NOT each own their own audio context. They must publish/consume through a singleton audio bus at the workspace level.
+**Causal status:** CAUSAL — `AudioContext` instances are expensive and per-context state can't be shared across them.
+**Scope:** Pattern preview (Strudel/SonicPi) → viz preview (Hydra/p5).
+**Breaks when:** Each preview creates its own engine — pattern audio plays on context A, viz tries to read from context B and gets silence.
+**Implication:** Phase 10.2 introduces `WorkspaceAudioBus` as a singleton. Pattern previews call `bus.publish({ hapStream, analyser, scheduler })` when they start playing. Viz previews call `bus.consume()` (or subscribe) and re-mount their renderer with the new components. There is exactly one audio bus per workspace.
+
+### PV9: Mount Effect Deps Are Input Identity, Not Derived Object Identity
+**Statement:** Wherever a React mount effect depends on a derived object (compiled output, transformed config, memoized computation), its dep array must reference the STABLE INPUT that produced the object, not the object itself. Derived objects have unstable identity across pure re-computations.
+**Causal status:** STRUCTURAL — JavaScript pure functions return new object references on every call even with identical inputs; React `useEffect` dep comparison is `Object.is`.
+**Scope:** Every `useEffect([derivedObject])` where `derivedObject` is produced by a pure transformation of component inputs.
+**Breaks when:** The parent re-renders for any reason (state change elsewhere, sibling update), the derivation re-runs, a new object reference is passed in, the effect re-fires and tears down + rebuilds the imperative instance the effect manages. Observable as "my pause/toggle/state-change appears to do nothing" because the instance is destroyed before the effect's side effect (noLoop, pause, update) can be visibly applied.
+**Confirmed by:** `createCompiledVizProvider.render()` built `compilePreset(preset)` on every call. CompiledVizMount's `useEffect([descriptor])` fired on every re-render. Stop click looked broken because p5 was destroyed + recreated on the same microtask as the pause call. (2026-04-11)
+**Implication:** When a component receives a derived object as a prop and needs to act on it in an effect, either (a) memoize the derivation at the producer level with `useMemo([INPUTS])`, or (b) do the derivation INSIDE the effect's component with `useMemo([INPUTS])` there. Never dep on the raw derived object unless the producer guarantees ref stability via its own memoization.
+
+### PV10: stave.* Live Getters Over Container-Size Ref
+**Statement:** Wherever a user-authored p5 sketch needs to match its canvas to a preview pane (not the browser window), the sketch MUST read container dimensions via `stave.width` / `stave.height` live getters over a ref that's maintained by the renderer — NOT via p5's built-in `windowWidth` / `windowHeight` (which track `window.innerWidth`/`innerHeight`, the entire browser).
+**Causal status:** STRUCTURAL — p5 `windowWidth`/`Height` are mirror globals of window, not container-aware. A preview pane is a sub-rect of the browser window.
+**Scope:** Every user-authored p5 sketch running inside `CompiledVizMount`.
+**Breaks when:** User writes `createCanvas(windowWidth, windowHeight)` — the canvas is created at browser size (e.g., 1920×1080) and only AFTER setup does `P5VizRenderer.mount`'s post-mount `resizeCanvas(size.w, size.h)` clamp it to the container. This works only if (a) `size.w/h` are correct at mount time (containers can have `clientHeight: 0` if parent layout hasn't resolved) and (b) p5's setup is truly synchronous (not always). Mismatch produces either an oversized canvas clipped by container overflow or a tiny canvas from a 0-height fallback.
+**Confirmed by:** User reported "the canvas isn't following the preview area's dims." Fix: threaded `containerSizeRef: RefObject<ContainerSize>` through `P5SketchFactory` (4th arg), maintained it in `P5VizRenderer.mount`/`resize`, exposed as live getters on the `stave` namespace. Seed Piano Roll uses `createCanvas(stave.width, stave.height)` which always matches the live container. (2026-04-11)
+**Implication:** Every injected runtime context for user-authored code must expose container-aware dimensions when the code runs inside a bounded sub-rect. Never rely on the host environment's "window" globals when the host IS nested inside something smaller.
+
+### PV13: VizRenderer Owns Its Own Draw Loop
+**Statement:** Wherever a `VizRenderer` implementation supports `pause()`, the renderer MUST own the loop (rAF, polling timer, event chain) that drives its visible output. There is exactly ONE source of draw ticks per renderer instance, and `pause()` cancels it synchronously. Flag-only pauses are forbidden — a `paused = true` assignment that doesn't also cancel a loop is a no-op for any library that runs a default loop independently.
+**Causal status:** STRUCTURAL — JavaScript loops are independent unless explicitly chained. A library's internal rAF loop has no knowledge of host-side flags; the host's only handle on it is to not start it (turn off the library default) or to cancel it explicitly.
+**Scope:** Every `VizRenderer` implementation in `packages/editor/src/visualizers/renderers/`. Currently: `P5VizRenderer`, `HydraVizRenderer`. Future: any new renderer (shader, three.js, OffscreenCanvas, etc.).
+**Confirmed by:** Issue #6 (HydraVizRenderer pause was a no-op because hydra ran its own `autoLoop:true` rAF). Issue #3 / P17 (P5VizRenderer had a parallel issue with deferred async setup creating orphan canvases that bypassed pause). Both fixed by taking ownership of the relevant loop / lifecycle.
+**Implication:** Adding a new renderer requires answering three questions UP FRONT before merging:
+  1. What loop drives the visible output? (rAF, polling, event listener, library internal)
+  2. Can `pause()` cancel that loop synchronously?
+  3. Can `destroy()` cancel any deferred async setup chains the library schedules during construction?
+If the answer to (2) or (3) is "no without taking control," the renderer must be restructured to own the loop / neutralize the deferred chain BEFORE shipping. The corresponding unit test pattern lives in `HydraVizRenderer.test.ts` (mock the loop primitive, fire callbacks manually, assert pause cancels and resume re-arms). See P17 + P19.
+
+### PV14: Component-Local State Doesn't Survive Layout-Shape Remount
+**Statement:** Wherever a React parent renders different element-tree shapes for different layout states (e.g., `oneGroup ? <Direct/> : <SplitPane><Wrapper><Child/></Wrapper></SplitPane>`), the child component's local state (useState, useRef created inside) MUST NOT be the source of truth for anything that should survive the layout transition. React reconciliation will fully unmount and remount the child whenever the parent's element type at the child's tree position changes — no key trick rescues this; the type itself differs. State that must persist belongs in the lowest stable parent, not in the leaf.
+**Causal status:** STRUCTURAL — React's reconciliation algorithm walks the parent's element children by type+position. A different element type at the same position is treated as a brand new tree, regardless of what's inside.
+**Scope:** Every component below a parent that branches its render output structurally. Specifically in this codebase: VizEditorChrome (selectedSource), CompiledVizMount (descriptor memo + rendererRef), and any future leaf component below `WorkspaceShell`'s `renderTabContent` IIFE-vs-SplitPane branch.
+**Breaks when:** A user gesture flips the layout shape — the most common in this codebase is "open the first preview tab" which transitions from one group to two groups, switching the IIFE branch to the SplitPane branch in `WorkspaceShell.tsx:1698-1702`. Other triggers: drag-drop into a new quadrant, closing the next-to-last group, opening a popout window (some of these may be guarded by `key` props but the IIFE/SplitPane branch is not).
+**Confirmed by:** Issue #3 — the chrome's `selectedSource` state was being wiped to `default` whenever Preview was clicked, because the act of opening the preview tab transitioned the shell from 1 group to 2 groups, switching the render path. Confirmed by Playwright probe inspection: `chrome buttons=1 selects=1 values=["default"]` after Preview click, even though the user had selected "drum" before clicking. Fix: lifted the audio start/stop dispatch from the chrome (which had stale state) to the shell's `onTogglePausePreview` handler (which reads the open preview tab's `sourceRef` from the shell-owned `groups` Map — survives the remount). 2026-04-11.
+**Implication:** When designing a new chrome / leaf component, audit: "does this component live below `renderTabContent`? If yes, does it have local state that the user expects to persist across layout changes? If yes, that state belongs in the shell, not in the chrome." The shell's `groups` Map and other root-level state are the canonical persistence layer. Chrome components should be DERIVED from shell state via props, not the source of truth. See P20.
+
+### PV12: Destroy Must Neutralize Deferred Work, Not Just Cancel Active Work
+**Statement:** Wherever a host integrates with a library that uses DEFERRED initialization (async setup chains, RAF-queued construction, microtask-awaited lifecycle hooks), the host's "destroy" handler must NOT assume that the library's destroy method cancels work scheduled for the future. Calls to `instance.remove()` / `dispose()` / `cleanup()` typically only cancel work that's IN PROGRESS — async chains still awaiting microtasks, RAF callbacks bound to instance methods, and `window.addEventListener('load', ...)` callbacks all survive destroy unless the library explicitly cancels them.
+**Causal status:** STRUCTURAL — JavaScript microtasks and RAF queues are ordered by scheduling time, not by which object scheduled them. Once a callback is on the queue, only its scheduler can revoke it.
+**Scope:** Every host-managed lifecycle for a library that schedules work via `requestAnimationFrame`, `setTimeout`, `await`, `MutationObserver`, or load event listeners. Specifically: p5.js (PK2 / PV5 / P3 / P17), Web Audio API (deferred AudioContext state changes), Hydra (async shader compilation). Future renderers must be audited against this invariant.
+**Breaks when:** Destroy runs BETWEEN the library's "schedule setup" call and the actual setup callback firing. Most common trigger in Stave: React StrictMode dev double-invoke runs `effect → cleanup → effect` synchronously, while p5's setup chain awaits the next animation frame.
+**Confirmed by:** P5VizRenderer's `destroy()` had to be augmented with `hitCriticalError = true` plus no-op overrides of `setup`/`draw`/`preload`/`createCanvas` before calling `instance.remove()`. Without these, p5's `#_setup()` would run the unconditional `createCanvas(100, 100, P2D)` AFTER our remove() call, appending an orphan canvas that nothing could pause. (2026-04-11)
+**Implication:** Every renderer's `destroy()` must (1) read the library's source to find every deferred-work mechanism it owns, (2) actively neutralize each one before calling the library's destroy, (3) document the audit in code comments. Adding a renderer without doing this audit re-opens this entire bug class. The audit checklist: "Does the library schedule any callback that survives destroy? If yes, override or no-op the callback's target before destroy."
+
+### PV11: Single-Source-at-a-Time Playback via Coordinator
+**Statement:** Wherever a project has multiple audio sources that should not play simultaneously (user expects DAW-style "hit play on one, everything else stops"), there must be a module-level coordinator that all sources register with. Starting a new source notifies the coordinator, which invokes the `stop` callback on every other registered source.
+**Causal status:** CAUSAL — audio sources live in disconnected module graphs (class instances for pattern runtimes, module-level singletons for built-in example sources). There's no shared React tree to thread state through. Only a module-level coordinator can enforce the cross-cutting invariant.
+**Scope:** All playback sources in Stave: `LiveCodingRuntime` instances (one per pattern tab), `sampleSound`, `drumPattern`, `chordProgression` (module singletons), future additions.
+**Breaks when:** Any source bypasses the coordinator (calls its own audio graph directly without `notifyPlaybackStarted`). The cacophony of multiple simultaneous sources returns for that path.
+**Implication:** Every new playback source added to the project must (1) register on construction with `registerPlaybackSource(id, stop)`, (2) call `notifyPlaybackStarted(id)` inside its start path AFTER marking itself playing, (3) call `notifyPlaybackStopped(id)` inside its stop path, (4) unregister on disposal. Stop callbacks MUST be idempotent (safe to call on an already-stopped source) and must not throw. See `src/workspace/playbackCoordinator.ts`.
+
+### PV15: Live Source-Position Tracking Uses Editor Decorations, Not Indices
+**Statement:** Wherever a consumer anchors UI elements (view zones, annotations, overlays) to positions in user-editable source code, the anchor MUST be a Monaco `IEditorDecorationsCollection` on the relevant text range — NOT a positional index into a scanned list. Decorations track text edits (insertions above, indentation changes, content growth/shrinkage) for free. Index-based anchors go stale on every edit that isn't a direct mutation of the tracked object's own line.
+**Causal status:** STRUCTURAL — Monaco's decorations are first-class text anchors maintained by the model's edit engine. Any positional mapping reconstructed from a secondary source is an eventual-consistency shadow, not a truth.
+**Scope:** Inline viz zones (`viewZones.ts`), active-hap highlights (`useHighlighting.ts`), future overlays that reference source text.
+**Breaks when:** The user edits unrelated code above the tracked line — inserts, deletes, or reshuffles. The positional scanner produces a new list; the stored index dereferences to the wrong entry. Stored afterLines drift into other blocks.
+**Confirmed by:** Inline viz zones drifted across `$:` blocks as the user inserted new patterns above. Fix: Monaco decoration on the `.viz("<name>")` source line with `stickiness: 1`; re-anchor reads the decoration's current line and walks source structure from there. Positional scanner deleted. Issue #29, commit `f7a752e`, 2026-04-15.
+**Implication:** Any new source-anchored UI in the editor must plant a decoration at mount. Never store "line N" as an index; always store a decoration ID and read the current line back each time you need it.
+
+### PV16: Internal Bookkeeping Mutations Must Not Fire User-Observable Subscribers
+**Statement:** Wherever a module performs self-initiated bookkeeping mutations on a shared reactive store (Yjs, Zustand, Redux, etc.), those mutations MUST be tagged with a distinct transaction origin, and observers MUST filter their user-facing subscriber notifications on that origin. Firing user-subscribers from internal maintenance work enables reentrancy during active mount/cleanup cycles and duplicates downstream reactions that were already handled by the code doing the maintenance.
+**Causal status:** STRUCTURAL — reactive stores dispatch observer events synchronously on commit. If a maintenance routine commits mid-mount, the sync observer dispatch can reenter the mount via a user-subscribed remount effect.
+**Scope:** All Yjs mutations in `WorkspaceFile.ts` and future store modules. Specifically: `pruneZoneOverrides` (internal) vs. `setZoneCropOverride` (user-driven).
+**Breaks when:** An internal transaction triggers a subscriber that re-invokes the caller or one of its callers. Inline viz zones duplicated until page refresh; the invisible orphan set was created by a remount reentering `addInlineViewZones` before its outer assignment completed.
+**Confirmed by:** Issue #30, commit `1d4f69b`. Fix: `PRUNE_ZONE_OVERRIDES_ORIGIN` Symbol passed to `doc.transact`; `observeDeep` skips when `events[0].transaction.origin` matches.
+**Implication:** When adding a new bookkeeping / reconciliation routine that touches a shared store, (1) define a private `Symbol` origin, (2) pass it to every `transact` inside the routine, (3) update the observer to skip that origin, (4) add a regression test asserting subscribers are NOT called by the routine. User-driven paths remain unaffected because they use the default origin.
+
+### PV17: Async-Mounted Ref Consumers Need a Ready Flag in Effect Deps
+**Statement:** Wherever a component subscribes to a bus / store whose `subscribe()` fires the callback SYNCHRONOUSLY once with current state AND the callback consumes a ref populated by an async child mount (Monaco, third-party widgets, etc.), the subscribe effect MUST include a `ready` state flag in its deps. The flag flips inside the async mount handler; the effect re-subscribes when it flips; the re-subscribe's sync initial fire redelivers the payload with the ref now populated.
+**Causal status:** STRUCTURAL — ref assignment in an async callback does not trigger re-render. Without a state-change trigger, the subscribe callback's stale guard result is final.
+**Scope:** `EditorView` + any future component that subscribes to `workspaceAudioBus` alongside a ref-bearing child. Also applies to consumers of `VizPresetStore`, `workspaceFileStore`, and any future subscribe-fires-sync store.
+**Breaks when:** A second consumer mounts while the bus already has a payload (split editor group, popout window opened mid-playback, late-joining subscriber). The first consumer escapes the race because it mounted before any publish.
+**Confirmed by:** Issue #22, commit `98f2fbb`. `editorReady` state added to `EditorView`; flipped in `handleMonacoMount`; added to the bus-subscribe effect deps.
+**Implication:** Any new ref-bearing component that subscribes to a sync-firing store must (1) define a `ready` state initialised false, (2) flip it true inside the ref-populating callback, (3) list it in the subscribe effect's dep array. The comment should explain the race so the pattern survives refactors.
+
+### PV18: useCallback Dep Arrays Must Reflect Every Read Identifier
+
+**Statement:** Wherever a `useCallback` returns a render function (or any function the closure-deps interpretation of React applies to), its dep array MUST list every prop and state value the function body reads. Missing a dep silently bakes in a stale snapshot.
+**Causal status:** STRUCTURAL — React caches the function reference between renders by dep-array equality. The closure captures values lexically; subsequent renders that change those values without changing the deps return the same cached function with stale captures.
+**Scope:** Every `useCallback` returning a render function in the editor package. High-risk file: `WorkspaceShell.tsx`'s `renderGroup`, `renderTabContent`.
+**Breaks when:** A new prop is added to a component whose render flow goes through a memoized renderer, and the dev forgets the dep array.
+**Confirmed by:** P29 (this session).
+**Implication:** Either keep `react-hooks/exhaustive-deps` lint enabled and respect it, or pull renderers out of useCallback — there's no middle ground.
+
+### PV19: Per-Instance Configuration Lives With the Instance, Not in Global Settings
+
+**Statement:** Wherever a configuration affects ONE pinned/active resource (this backdrop, this preview, this crop), its UI surface and its persistence MUST be co-located with that resource. Global settings modals are only for cross-project preferences.
+**Causal status:** SEMANTIC — users mentally model "this thing's settings" vs "my IDE preferences" differently. Mixing them confuses scope (does changing the value affect every project? this one? this session?).
+**Scope:** Every per-instance backdrop control (opacity, quality, crop, blur). Per-zone overrides (inline viz crop). Future: per-pattern viz settings.
+**Breaks when:** Quality lives in BOTH the chrome and the Settings modal, both writing the same localStorage key — users see two UIs for one value, can't tell which scope they're editing.
+**Confirmed by:** This session — Editor Settings had backdrop opacity / quality / blur AND the chrome had quality. Resolved by moving everything into the BackdropPopover (anchored to the indicator, the visible representation of the instance) and stripping the Settings rows.
+**Implication:** When adding a new control, ask "does this affect this instance, or all instances forever?" Per-instance → contextual UI (popover, chrome, right-click). Cross-project → Settings.
+
+---
+
+### PV20: Zone Overrides Must Carry Content Identity
+
+**Statement:** Every zone override (crop, height) stored in the Yjs doc MUST include a content hash of the block it was set for. Without content identity, overrides keyed by position-based trackKeys survive block reordering and apply to the wrong block.
+
+**Causal status:** STRUCTURAL — anonymous `$:` blocks have no stable identity. Position-based keys (`$0`, `$1`) are reassigned on every code scan. Content hashes are the cheapest stable identifier that doesn't require language-level analysis.
+
+**Scope:** All zone overrides in `WorkspaceFile.ts` — `setZoneCropOverride`, `setZoneHeightOverride`, `pruneZoneOverrides`.
+
+**Breaks when:** A new override type is added without including `contentHash`, or the hash computation changes without migrating existing overrides.
+
+**Confirmed by:** P35 (this session).
+
+---
+
+### PV21: Yjs Transaction Origins Control Subscriber Notification Scope
+
+**Statement:** Every Yjs `doc.transact()` call that mutates shared state MUST use an appropriate transaction origin. Observer callbacks MUST check the origin and skip notification when the mutation is internal bookkeeping (prune, height-resize) rather than user-visible state change.
+
+**Causal status:** STRUCTURAL — Yjs observers fire on every mutation regardless of intent. Without origin-based filtering, internal writes trigger subscriber cascades (remount, re-render) that undo the mutation's effect.
+
+**Scope:** All zone override mutations. Currently three origins: `STRUCT_ORIGIN` (crop writes → triggers remount), `PRUNE_ZONE_OVERRIDES_ORIGIN` (prune → silent), `HEIGHT_RESIZE_ORIGIN` (drag resize → silent).
+
+**Breaks when:** A new mutation type uses the wrong origin, or a new subscriber doesn't check origins.
+
+**Confirmed by:** P34 (this session).
+
+---
+
+## PV22 — Event-store subscribers must defer React state updates
+
+**Invariant:** Any subscriber registered against a module-level event store (`subscribeLog`, `subscribeToFileList`, Y.Map observers, the runtime `onError` chain) MUST NOT call React `setState` synchronously during emit. Use `queueMicrotask` (or a higher-level scheduler) to break the call stack before touching React state.
+
+**Why:** Event-store emits happen from inside arbitrary call sites — engine error callbacks, Monaco marker-commit handlers, CRDT observers firing during React commits. A synchronous subscriber that `setState`s interleaves with whatever React phase the emitter was called from. Best-case: harmless wasted re-render. Worst-case: mid-commit error in a sibling subtree tears down the whole tree because React has no recovery path in commit.
+
+**Span:**
+- `packages/editor/src/engine/engineLog.ts` — fixed: listener fan-out wrapped in `queueMicrotask`.
+- `packages/editor/src/engine/HapStream.ts` — should audit; subscribers fire from scheduler ticks.
+- `packages/editor/src/workspace/WorkspaceFile.ts` Y.Map observers — already deferred via React's own state batching, but explicitly queueing would be safer.
+
+**Status:** PARTIAL — only engineLog enforces it. Other stores should be audited.
+
+## PV23 — Friendly-error fuzzy-match requires DocsIndex parity across runtimes
+
+**Invariant:** Every runtime Stave exposes MUST have a committed `DocsIndex` in `packages/editor/src/monaco/docs/data/<runtime>.json` (OR hand-curated in `strudelDocs.ts`) validated by `validateDocsIndex`. `formatFriendlyError(err, runtime, { index })` uses the index's keys as its Levenshtein corpus; no index = no fuzzy suggestions for that runtime.
+
+**Why:** The whole "Did you mean X?" UX is predicated on having a canonical symbol dictionary to match against. A runtime wired into `emitLog` without a paired DocsIndex silently degrades to raw error messages.
+
+**Span:** Strudel, Sonic Pi, p5, Hydra all present and validated. Any new runtime (Tidal, FoxDot, Hydra extensions) must ship a DocsIndex before getting hooked into the engine-log bridge.
+
+**Status:** ENFORCED for current 4 runtimes.
+
+---
+
+## PV24 — Every IREvent must carry source-range provenance when produced from known source
+
+**Invariant:** Any IREvent whose producer was a recognized parser leaf (Strudel mini-notation atom, Sonic Pi note, future Tidal/FoxDot note) MUST carry a populated `loc: SourceLocation[]`. Two paths produce IREvents and both must honor this:
+
+1. **Live audio path** — `HapStream.emit` extracts loc from `hap.context.locations`; BufferedScheduler forwards it onto the IREvent; normalizeStrudelHap also extracts it for `queryArc` results.
+2. **IR-derived path** — `parseStrudel` and `parseMini` track char offsets from the user's source code, attach them as `Play.loc`; `collect.ts` propagates them onto produced events.
+
+**Why:** Inspector click-to-source, future Monaco highlighting of active sub-sections, the bidirectional editing thesis, and the Transform Graph debugger ALL depend on every event mapping back to its source range. A single producer that drops loc creates a class of "events I can't trace" — a hole that propagates through every downstream UI feature.
+
+**Span:**
+- `packages/editor/src/engine/HapStream.ts` ✓
+- `packages/editor/src/engine/BufferedScheduler.ts` ✓
+- `packages/editor/src/engine/NormalizedHap.ts` ✓
+- `packages/editor/src/ir/parseMini.ts` ✓
+- `packages/editor/src/ir/parseStrudel.ts` ✓
+- `packages/editor/src/ir/collect.ts` ✓ (propagates Play.loc → event.loc)
+- Future: parseSonicPi, parseTidal, etc. — must thread baseOffset and attach Play.loc.
+
+**Status:** ENFORCED for current Strudel + BufferedScheduler paths. Container nodes (Seq, Stack, Cycle, FX) don't carry loc yet — deferred until a consumer needs container highlighting.
+
+**Confirmed by:** PR #59 (BufferedScheduler/normalizeStrudelHap), PR #65 (parseStrudel + parseMini + collect).
+
+---
+
+## PV25 — Parser pipelines preserve absolute offsets at every hop
+
+**Invariant:** From the user's source code through to leaf IR nodes, the parser MUST preserve absolute character offsets. Specifically:
+
+- No `.trim()` followed by use of the trimmed string as a positional reference
+- No `chunks.join('\n')` of separately-positioned strings into a single buffer
+- Slice-producing helpers (extractTracks, splitArgs, extractParenContent) return `{ slice, offset }` shapes when downstream parsers need loc, not raw strings
+- Recursive parser calls thread `baseOffset` through every level
+- Regex matches use `match.index` to compute offset of inner content
+
+**Why:** Source-range tracking is invariant-by-construction — once a single hop drops the offset, all downstream attribution is lost. P39 documents the cost of retrofitting this onto a non-offset-aware parser.
+
+**Span:** `parseStrudel`, `parseMini`. Future parsers (parseSonicPi, parseTidal) inherit this invariant from day one.
+
+**Status:** ENFORCED in IR parsers as of PR #65. Future parsers must follow.
+
+**Breaks when:** A new parser case adds a `.trim()` or string-concat without preserving offset alongside it.
+
+**Update (Phase 19-07):** Stage transitions are now PV25's primary enforcement surface. The 4-stage pipeline (RAW → MINI-EXPANDED → CHAIN-APPLIED → FINAL) creates 3 stage seams; each is a P39-class risk surface. Codified in `packages/editor/src/ir/__tests__/parseStrudelStages.test.ts`:
+- T-05.a/b: per-stage loc probes for RAW + MINI-EXPANDED (PR-A).
+- T-10.b1: MINI-EXPANDED → CHAIN-APPLIED universal loc-equality across 6 fixtures (PR-B).
+- T-10.b: PK12 dot-inclusive convention probe across method chains.
+- T-05.c + T-09: FINAL parity sentinel (1 + 19 fixtures) — byte-equal to today's `parseStrudel(code)`.
+
+**Caveat at stage transitions:** synthetic-from-stage anchors (e.g., RAW's outer Stack carrying `[0, code.length]` for tab visualization) are deliberately exempted from cross-stage loc preservation per P47. Real anchors (every Cycle/Play/Seq/etc. inside tracks) are preserved per the invariant.
+
+---
+
+## PV26 — Curated friendly-error hints must reproduce live before shipping
+
+**Invariant:** A `commonMistakes` entry (per-symbol or `globalMistakes`) MUST be backed by a captured live error message before merging. The detection regex matches against THAT message, not against an inferred-from-docs hypothesis. Tests assert the hint fires on the actual message.
+
+**Why:** Friendly hints fail silently. A wrong regex still passes a unit test fed a fabricated error string but never fires for users. The empty-state degradation is invisible — no failing build, no thrown exception.
+
+**Span:** All 4 runtime indexes (Strudel, Sonic Pi, p5, Hydra). Strudel/Hydra have proven seeded hints; p5/Sonic Pi have empty `globalMistakes: []` slots awaiting observed failures.
+
+**Status:** ENFORCED — PR #57 dropped a speculative p5 hint that didn't reproduce.
+
+**Breaks when:** A maintainer adds a hint based on plausibility ("users probably hit this") without browser-side verification. The unit-test layer can't catch this.
+
+
+
+## PV27 — Schema evolution at observation-only stores via publisher-set alias
+
+**Invariant:** When extending the schema of an observation-only store (a single-slot snapshot like `IRSnapshot`, where the latest publish replaces the previous), prefer adding a NEW required field for the richer data and **populating any legacy field as an alias of the new one at the publisher**. Do NOT use a getter — the snapshot must remain a plain serializable object so `structuredClone`, JSON serialization, and tests work uniformly. The alias is set once from the new field and never derived elsewhere.
+
+**Why:** Existing readers of the legacy field continue to compile and run with zero migration churn. New readers can opt into the richer field. The single source of truth lives at the publisher (one site to verify the alias contract). Drift is detected by either a tsc-level type check (legacy field still required) or a single grep audit (`grep -rn "snap\\.ir\\b"` after the change).
+
+**Span:** `IRSnapshot` (extended `passes[]` while keeping `ir` as alias of `passes[passes.length-1].ir` in PR #68). Future evolutions of `engineLog`, `IRSnapshot`, and any future single-slot publish stores follow the same pattern.
+
+**Status:** ENFORCED at the `IRSnapshot.ir` field via `publishIRSnapshot` callers in `StrudelEditorClient.tsx`. New publishers must derive both fields from a single computed value to prevent drift.
+
+**Breaks when:** Two independent code paths set the legacy and new fields separately — drift becomes possible. Or a getter is used and a downstream `structuredClone` strips it. Or readers cache the legacy field across publishes (the alias is per-snapshot, not stable across them).
+
+**Implication:** When adding a richer schema variant, the PR's verify step includes an alias-drift assertion: `snap.ir === snap.passes[snap.passes.length - 1].ir`. Any new reader site of the legacy field must continue to type-check and pass tests in the same PR.
+
+
+## PV28 — `Fast` in our IR scales ctx.speed; does not re-play the body
+
+**Invariant:** Our `Fast(n, body)` arm in `collect.ts` scales `ctx.speed` so the body's events are time-compressed into `[0, 1/n)` of the cycle. It does NOT re-play the body N times. Strudel's `_fast(n)` re-plays — body events appear N times across `[0, 1)`. **Wrapping a body in `Fast(n, Seq(body × n))` does NOT reproduce Strudel's `fast(n)` for multi-event bodies.**
+
+**Why:** This is consistent with how the rest of our IR threads `ctx.speed` (Slow, Stack-internal scaling, etc.). It is, however, divergent from Strudel's user-facing semantic of `.fast()`. The divergence is invisible for single-event bodies (one event scaled vs. one event repeated yields the same observable). It IS visible for multi-event bodies — desugars that wrapped multi-event bodies in `Fast(n, Seq(body × n))` collapsed in Phase 19-03 (the `ply` case).
+
+**Span:** `collect.ts` `Fast` arm; any future operator that desugars to `Fast(n, ...)` over a multi-event body. Currently includes `Slow` (symmetric) and any prospective `chop`/`ply`/`stutter`-style transforms.
+
+**Status:** ENFORCED at the implementation level (`Fast` arm uses `ctx.speed`). NOT YET DOCUMENTED in user-facing surfaces. New operators that need re-playing semantics must use a dedicated tag (e.g., `Ply` per Phase 19-03), not a `Fast` desugar.
+
+**Breaks when:** A desugar wraps a multi-event body in `Fast(n, ...)` and expects re-playing semantics. Single-event bodies will pass parity by coincidence; multi-event bodies will collapse into `[0, 1/n)`. This was the exact failure mode that forced `Ply` to a new tag in Phase 19-03 W4.
+
+**Implication:** Future Tier 4 / Tier 5 operators with re-playing semantics (`chop`, `stutter`-equivalents, `repeat`, anything that "plays N copies in original duration") need either (a) a dedicated tag with explicit collect re-play, OR (b) a fix to `Fast` to add re-play semantics — but that's a behavioral change to existing patterns and would need its own migration. Default: dedicated tag.
+
+**Confirmed by:** Phase 19-03 W4 — the `Fast(n, Seq(body × n))` desugar for `ply` was probed empirically and produced 12 events in `[0, 1/3)` instead of `[0, 1)`. Pivoted to a `Ply` tag.
+
+
+## PV29 — Phase prioritization is governed by the 5-axis substrate progression
+
+**Invariant:** Every phase that touches the IR pipeline must advance one of the five substrate axes — **Code, Stages, Time, Editing, Sound source** — and each axis has a sequencing constraint relative to the others. Phases that don't advance an axis are detours, not necessarily wrong but worth being explicit about. Phases that violate an axis's sequencing constraint produce wasted infrastructure (e.g., a 4-tab Inspector on a 60%-modeled IR is less useful than a 1-tab Inspector on a 95%-modeled IR).
+
+**Sub-axis decomposition (added 2026-05-06):** An axis MAY decompose into sub-axes (e.g., axis 5 → 5a/5b/5c/5d) when an external thesis or codebase realization surfaces a substrate that BELONGS in the parent axis but is paradigmatically distinct from sibling sub-axes. Sub-axes use letter suffixes; existing axis numbers (1–5) are NEVER renumbered to preserve catalogue cross-reference stability. Each sub-axis carries its own "what honest means" definition, status, ratchet phase, and sequencing constraint within the parent axis. The decomposition mechanism itself is sanctioned within PV29 — surfacing a new sub-axis is a recognized form of substrate-axis maturation, not a thesis revision. See `feedback_substrate_subaxis_split.md` for application protocol.
+
+**Why:** The destination is "one IR, five views, all editable, all parity-verified" — not a sequencer plus a debugger plus a DAW, but a substrate that makes all three emerge. The Ableton-class capability ("any sample → IR → code → audio with provenance") is the **emergent property** of the five substrates being honest, not a separate roadmap item to chase. Without the axes-as-lens, phase decisions drift toward feature-completeness over substrate-honesty, which produces visually richer Inspectors with diagnostically weaker substrates.
+
+**Span:** All Phase 19-* (Pattern IR pipeline + Bidirectional DAW + Tier 4 expansion), Phase 20 (Transform Graph), Phase 22 (Audio Analysis + Vocals), Phase 23 (Layer 3 timbre). Phases outside this span (Phase 11 library polish, PM-* persistence) advance orthogonal concerns and don't trip this invariant.
+
+**Status:** ENFORCED at planning time. `/anvi:discuss-phase` and `/anvi:plan-phase` should consult `artifacts/stave/CLOSED-LOOP-PLAN.md` to confirm the next phase advances an axis and respects sequencing.
+
+**Breaks when:** A phase is planned for feature parity with a reference system (e.g., "match Ableton feature X") instead of for substrate progression. Or a downstream phase ships before its upstream substrate is honest enough to support it (e.g., bidirectional editing before sufficient Tier 4 coverage produces round-trip drift on every desugar). Or two phases get sequenced in parallel when they have a hidden axis-dependency (e.g., streaming timeline parallel to parser decomp — the timeline scrubs through one undifferentiated blob without the stages).
+
+**Implication:** When planning the next phase, ask the substrate question first: which axis does this advance, what's its current honesty %, and is the upstream-axis honesty sufficient? If the axis is at 60% and a downstream phase is being considered, advance the upstream axis first. Coverage before decomposition; decomposition before scrubbing; scrubbing before bidirectional editing; bidirectional editing before audio-in.
+
+**Confirmed by:** Session ending 2026-05-04. Phase 19-03 (Tier 4 first half) advanced axis 1 from ~60% to ~85% — the deliberate-substrate-progression framing emerged at the end of this session when the user reframed Stave-as-debugger to Stave-as-instrument. Codified in `artifacts/stave/CLOSED-LOOP-PLAN.md` and ROADMAP.md's substrate-progression header.
+
+**2026-05-07 reframe.** PV29's 5-axis structure stands as long-range
+vision, but **immediate phase prioritization is governed by the
+debugger thesis** (PV36 / PV37 / PV38, see
+`memory/project_debugger_thesis.md`). Axis 4 ("Editing is honest") is
+narrowed to "Observation is honest" for the v1 substrate; the
+edit-direction work (bidirectional DAW second half, Phase 20
+Transform Graph as edit surface, Phase 22 audio→IR, Phase 23 Layer-3
+timbre) is deferred until the debugger v1 + v2 ships. PV29 still
+applies as the long-range axis lens; PV36-38 are the immediate
+ratchets. When a phase is being prioritized today: ask the debugger
+question first ("does this advance loc-completeness, opaque-wrapper,
+or hap-identity?"), the axis question second.
+
+**Sub-axis decomposition confirmed by:** Session 2026-05-06. SonicPiWeb's SynthDef encoder thesis (`~/Documents/projects/sonicPiWeb/artifacts/THESIS_BROWSER_SYNTHDEF_ENCODER.md`, April 2026, 246-byte byte-verified POC) surfaced during Phase 19-08 planning. Axis 5 decomposed into 5a (audio in / Phase 22), 5b (statistical timbre / Phase 23), 5c (synthesis architecture / Phase 24 — encoder), 5d (offline transformation / Phase 25 — CDP-class). Existing axes 1–4 unchanged. CLOSED-LOOP-PLAN.md revised end-to-end with sub-axis status, full IR taxonomy across 6 layers, FMOD-class adaptive audio (Phases 25–28) + external integration (Phases 29–34) added. Sub-axis decomposition mechanism worked WITHOUT cascading catalogue rework — every existing PV/PK/P entry that referenced "axis 5" remained semantically valid; the sub-axis breakdown lives in the strategic doc, not in catalogue numbering.
+
+
+## PV30 — Narrow-tag parity tests assert divergence as contract, never weaken to count-only
+
+**Invariant:** When a forced narrow tag (e.g., `Swing` in 19-04 D-03; future `Inside`-deferred shapes) deliberately diverges from a desugar-via-not-yet-existing-primitive reference, the parity test MUST encode the divergence as a four-clause contract:
+
+1. **Our IR is correct on its own claim** — count + per-event `(begin, s/note, gain, …)` set match what our collect arm SHOULD produce given the tag's documented narrow semantics.
+2. **Reference's diverging count** — the parity test asserts the reference (Strudel) produces a specific event count under the same input. This LOCKS the divergence point — if Strudel changes, the test fails and we re-evaluate.
+3. **Strict inequality with reference** — the test explicitly asserts `ours !== reference` on the divergence axis. Counting tests that "happen to be equal under specific inputs" silently weaken when the inputs change; explicit `!==` codifies "we know we differ."
+4. **Migration trigger comment** — a top-of-block comment names the future primitive (e.g., `Inside`, `randrun`) whose arrival flips this contract from divergence to tight parity.
+
+**Why:** Without all four clauses, a parity test for a narrow tag becomes ambiguous: a future change that ACCIDENTALLY brings our IR into alignment with the reference reads as a passing test, but it isn't proof we got the semantics right — it's coincidence. Worse, a test that asserts only "count matches" weakens to a tautology when the reference under-emits. The four-clause shape forces the test author to state what they ARE asserting and what they explicitly are NOT.
+
+**Span:** Any forced narrow tag whose semantics intentionally differ from a desugar reference. Currently: `Swing` (19-04 — diverges from `pat.inside(n, late(seq(0, 1/6)))` because `Inside` primitive deferred). Future candidates: any tag added before its underlying primitive (per D-03 / 19-03's "ratchet a primitive in only when its first user demands it AND it pays double" rule).
+
+**Status:** ENFORCED at parity-harness review. New narrow tags failing the four-clause contract get rejected from PR review.
+
+**Breaks when:** A reviewer accepts a narrow-tag parity test that only checks count or only checks "our IR produces N events" without asserting divergence from reference. The test becomes a regression-blocker for accidental alignment but provides zero forward signal about what "right" means.
+
+**Confirmed by:** Phase 19-04 W3 Swing (`signal.mjs:392`-derived divergence; the `Inside` primitive deferred per D-03; parity test encodes (a) our 6-event swung output, (b) Strudel's 12-event late-stack output, (c) `expect(ours.length).not.toBe(reference.length)`, (d) migration comment naming `Inside`). RESEARCH §1.3 anticipated this pattern; W3 implementation crystallized it as the project-level invariant.
+
+---
+
+## PV31 — `userMethod` distinguishes co-tag aliases (Stack-from-layer ≠ Stack-from-jux)
+
+**ORIGIN:** Phase 19-05 D-08 (exact-token taxonomy locked at the
+discuss-phase) + W4 (per-component loc + userMethod at layer/jux/off
+desugars) + W7 round-trip subset assertions. Surfaced concretely when
+the round-trip test on `s("bd").layer(x => x.gain(0.5))` asserted
+`Stack.userMethod === 'layer'` and the symmetric test on
+`s("bd").jux(rev)` asserted `Stack.userMethod === 'jux'` — two Stack
+tags with identical structural shape but different user-typed method
+names. Same pattern surfaced for `Degrade-from-degrade` vs
+`Degrade-from-degradeBy`.
+
+**Invariant:** When two parser paths produce the same IR tag from
+different user methods (Stack from `.layer(...)` and Stack from
+`.jux(...)`; Degrade from `.degrade()` and Degrade from
+`.degradeBy(p)`; etc.), the tag's `userMethod` field MUST carry the
+EXACT user-typed method name (D-08 exact-token taxonomy). Canonicalization
+or aliasing (e.g., normalizing `.degradeBy(0.5)` to `userMethod:
+'degrade'`) is forbidden at the parser layer. Round-trip fidelity is
+the load-bearing property — when 19-06's projection renders the tree
+row label, users see THEIR OWN VOCABULARY, not a normalized canonical.
+
+**Why:** Without this invariant, the Inspector's projected tree
+collapses onto a normalized vocabulary that doesn't match what the
+user typed. A user who writes `.degradeBy(0.5)` sees `degrade` in the
+tree row — confusing because the user knows they typed `degradeBy`,
+and click-to-source would land at `.degradeBy(...)` while the row
+says `degrade`. The mismatch breaks the cognitive bridge between
+source and tree. Canonicalization is a 19-06+ display concern (search,
+grouping by canonical kind) and can be a derived map; the parser-layer
+field stays semantically simple: "what string did the user write at
+this method's call site?"
+
+**Span:** Every parser path that constructs a non-Play tag.
+Specifically:
+- Smart-ctor calls via `tagMeta(method, callSiteRange)` — `method` is
+  whatever string `extractNextMethod` returned (the literal user-typed
+  token).
+- Literal-construction sites at desugars (parseStrudel:317 layer,
+  parseStrudel:425 jux, parseStrudel:487 off, parseStrudel:186 root
+  stack) — `userMethod` is hardcoded to the user-method string per
+  case (`'layer'`, `'jux'`, `'off'`, `'stack'`).
+- parseTransform's bare `fast(n)` / `slow(n)` direct constructions
+  — `userMethod: 'fast'` / `'slow'`.
+- parseMini synthetic constructions — `userMethod: undefined` (no
+  method-typed user vocabulary in mini-notation; the implicit-IR
+  principle PV28 handles the projection).
+
+**Status:** ENFORCED at parity-harness review. T-10 round-trip subset
+exercises 5 representative tags (Late, Pick, Struct, Stack-from-layer,
+Stack-from-jux) PLUS a nested-composition case to ensure inner tags
+also preserve their userMethod (e.g., `.every(2, x => x.late(0.125))`
+→ outer `Every.userMethod === 'every'`, inner
+`Late.userMethod === 'late'`). New parser paths must add a round-trip
+assertion before merge.
+
+**Breaks when:** A parser path canonicalizes the method name (e.g.,
+maps `'degradeBy'` → `'degrade'` "for cleaner display") or omits
+userMethod entirely on a desugar's outer Stack ("we don't know what
+user method produced it" — they DO know; the case statement is
+exactly the spelling). Either failure makes Inspector display in
+19-06 lose round-trip fidelity. Detection: round-trip subset test
+fails on the alias-distinguished pair.
+
+**Confirmed by:** Phase 19-05 W7 round-trip subset (Late, Pick,
+Struct, Stack-from-layer, Stack-from-jux all green); W7 nested
+composition (`every(2, x => x.late(0.125))` — both layers preserve
+userMethod); D-08 explicit lock in CONTEXT. The Inspector projection
+in 19-06 (#76) consumes this invariant directly — without it, the
+projection is structurally impossible to make round-trip-clean.
+
+## PV32 — Implicit-IR principle: IR vocabulary stays internal; user-facing surfaces speak the user's language
+
+**ORIGIN:** Phase 19-03 D-02 ("a new tag earns its keep when (i) it
+carries a semantic axis no existing primitive has, AND (ii) it is
+named after a method the user types") established the principle at
+the modeling layer — narrow tags only when forced AND named after a
+method the user types, so the Inspector tree row label reads as the
+user's code, not as compiler IR jargon. Phase 19-06 (PR #78)
+extended the same principle to the presentation layer — render-time
+projection translates `userMethod` to user-facing labels so
+`.layer(f, g)` shows as `layer` (not `Stack`), `.jux(rev)` shows as
+`jux` (not `Stack > FX, FX`), and mini-notation tags render as
+source symbols (`~`, `<>`, `?`, `@N`, `*N`, `{}`, `[]`). Two
+independent layers (modeling + presentation) consistently applying
+the same rule = invariant promotion criteria met.
+
+**Invariant:** The Pattern IR is internal infrastructure. Any
+user-facing surface that exposes IR shape (Inspector tree, error
+messages with IR-tag references, future bidirectional editing
+projections, code synthesis tiers) MUST translate IR vocabulary to
+the user's vocabulary by default. IR-shape-as-rendered is permitted
+only behind an explicit "developer view" toggle or in code-paths
+where the consumer is provably another IR-aware layer (parser,
+collect, toStrudel, transform passes).
+
+**Why:** Strudel users author Strudel patterns. They type `.layer(f, g)`,
+`.jux(rev)`, `.off(t, f)`. They do not type `Stack` or `FX(pan=-1, ...)`.
+Forcing users to learn IR vocabulary to debug their Strudel violates
+the layering thesis (project_thesis_v2.md / project_llvm_mlir_lessons.md):
+IR is the substrate, but the user-facing view is the source-language
+projection. LLVM users don't see SSA when they read C; they see C.
+Without this invariant, every IR-shape change risks user-visible churn,
+which means IR shape decisions become hostage to UX considerations
+(the inverse of the desired layering).
+
+**Span:** Every user-facing surface that consumes IR. In current
+codebase:
+1. `IRInspectorPanel.tsx` — projects via `irProjection.ts` per 19-06
+   D-01..D-06; raw IR available behind `aria-pressed` toggle
+   (`localStorage` key `stave:inspector.irMode`)
+2. Error messages / friendly errors — current FES code does not
+   surface IR vocabulary today; future additions must check this
+   invariant
+3. Code synthesis tiers (Phase 19-07+) — must emit user-method
+   names, not IR-tag names, when reconstructing source from IR
+4. Bidirectional editing (Phase 20+) — DAW edits round-trip through
+   IR but the editing surface speaks DAW vocabulary, not IR
+5. Transform Graph (Phase 20) — node labels speak user vocabulary;
+   "show IR shape" reveals the structural decomposition
+
+**Test gate:** Any new user-facing component consuming IR MUST
+include a unit test asserting the user-facing rendering uses
+user-method labels (or domain-vocabulary equivalents), not raw IR
+tag names. The pattern is established by `irProjection.test.ts` in
+`packages/app/src/components/__tests__/`.
+
+**Breaks when:** A future surface renders `node.tag` directly without
+first checking `userMethod` (or domain-equivalent). Detection
+signal: a screenshot or DOM inspection of the surface shows IR-tag
+names like `Stack`, `FX`, `Late`, `Choice` in default user view.
+Real fix: insert a projection helper at the rendering boundary,
+mirroring `projectedLabel` from `irProjection.ts`.
+
+**Confirmed by:** Phase 19-03 D-02 (modeling layer — narrow tags
+only when user-named); Phase 19-04 (Tier 4 second half — `Pick`,
+`Struct`, `Swing`, `Shuffle`, `Scramble`, `Chop` all named after
+user methods; rejected `Rearrange` umbrella tag for Shuffle+Scramble
+per D-02 rule even though arms were 90% identical); Phase 19-05
+(`userMethod` field populated at every parser site, exact-token
+taxonomy preserved per D-08 — PV31); Phase 19-06 (presentation
+layer — projection rules consume `userMethod` at render time;
+30-row truth-table verified by 53 unit tests + 33 Playwright dual-mode
+probes). Two independent applications of the same rule across two
+layers, both shipping clean = invariant. Future phases inherit it.
+
+
+## PV33 — Captured snapshots are immutable post-push (Object.freeze applied at push time)
+
+**Claim:** Once an IRSnapshot enters the `timelineCapture` ring buffer
+via `captureSnapshot()`, it MUST be treated as immutable by every
+downstream consumer. The buffer applies `Object.freeze(snap)` and
+`Object.freeze(snap.passes)` defensively at push time; consumers
+(IR Inspector UI, future replay tools) read but never mutate.
+
+**Why:** Pin-by-reference (D-07) means UI state holds a snapshot
+REFERENCE for arbitrary durations after capture. If any code path
+later mutated the snapshot in place (e.g., to attach derived metadata),
+the pinned view would reflect post-pin mutations — breaking the
+"frozen at the moment of capture" UX promise. Defense-in-depth: the
+freeze catches bugs at the mutation site instead of letting them
+silently corrupt the timeline.
+
+**Test gate:** any new consumer of `getCaptureBuffer()` or the
+IRSnapshot returned via `subscribeIRSnapshot` MUST treat the snapshot
+as `Readonly`. New unit tests adding entries to the buffer and then
+attempting in-place mutation should `expect(...).toThrow(TypeError)`
+in strict mode or no-op silently in non-strict — both are acceptable
+because the freeze is applied via try/catch.
+
+**Breaks when:** a future code path republishes a captured snapshot
+after structural mutation, or mutates `snap.passes[*].ir` in place
+to attach inspection metadata. Detection signal: pinned IR Inspector
+view changes after capture without an explicit unpin/pin cycle.
+Real fix: clone-then-mutate (deep copy at the mutation site), never
+mutate in place.
+
+**Confirmed by:** Phase 19-08 PR-A (3 unit tests in `timelineCapture.test.ts`:
+freeze-snap, freeze-passes, freeze-throw-safe try/catch); Phase 19-08
+PR-B (probe (g) — held reference survives FIFO eviction without
+data corruption — relies on the snapshot being read-only after capture).
+
+
+## PV34 — External-store reads must yield a fresh array reference each render
+
+**Claim:** When a React component subscribes to an external mutable
+ring buffer (e.g., `timelineCapture`'s internal `entries` array) and
+re-derives memoized values from that buffer, the hook MUST return a
+FRESH array reference (e.g., via `[...getBuffer()]`) on each render.
+Returning the live internal reference defeats `useMemo` because the
+dep array sees a stable reference even when the contents have mutated.
+
+**Why:** FIFO eviction (`entries.shift()`) and similar in-place
+mutations preserve the array reference but change its length and
+contents. A `useMemo([entries, ...])` that derives, say,
+`pinnedInBuffer = entries.some(e => e.snapshot === pinnedSnapshot)`
+will skip recomputation across an eviction → cached `true` persists
+forever after the pinned entry is gone. UX symptom: "ghost marker
+never appears."
+
+**Test gate:** any new subscription hook that surfaces an external
+mutable collection to React MUST expose its dep-array contract in
+the docstring AND have a unit/integration probe that triggers an
+in-place mutation (eviction, splice, in-place sort) and asserts a
+downstream useMemo recomputes.
+
+**Breaks when:** an author subscribes via `useState`+`subscribe`
+pattern but returns `getBuffer()` directly. Detection signal: tests
+that depend on derived state crossing a buffer-mutation boundary
+fail intermittently or only on full-suite runs (not in isolation).
+Real fix: shallow-clone at the boundary (`return [...getBuffer()]`)
+OR migrate to `useSyncExternalStore` with an explicit
+`getSnapshot()` that returns a stable-but-reference-changing value.
+
+**Confirmed by:** Phase 19-08 PR-B T-15 probe (g) — the ghost marker
+was invisible because `useCaptureBuffer` returned the live buffer
+reference; downstream `useMemo([entries, pinnedSnapshot])` saw a
+referentially stable dep across `entries.shift()` evictions and
+skipped recomputation. Fix: `return [...getCaptureBuffer()]`. Cost:
+one O(n) copy per render, n ≤ 500. Probe (g) flipped from FAIL to
+PASS on the same line of test code.
+
+
+## PV35 — Audience-classification gate for any "debug / inspect / trace / timeline" feature
+
+**ORIGIN:** Phase 19-08 (Streaming timeline, capture & replay) shipped a
+tick-per-eval strip inside the IR Inspector. User reaction at close-out:
+"the timeline is not useful — I was hoping for multi-track / DAW / NLA
+treatment." The CONTEXT.md inherited the framing "scrub the trace to
+see the audible bug in time" verbatim from `IR-DEBUGGER-NORTH-STAR.md`
+without classifying whether the audience for that scrub was the **IR
+developer** (eval-archaeology, IR correctness across re-evals) or the
+**musician** (find the wrong note in time across bars/beats). The
+discuss-phase never surfaced the question; the wrong primitive shipped.
+This is the second-order failure beneath PV32 (implicit-IR principle):
+PV32 says user-facing surfaces hide IR vocabulary, but PV32 alone
+doesn't catch features that LEAK IR vocabulary because they were never
+classified as user-facing in the first place.
+
+**Invariant:** Before any phase whose name contains `debug`, `inspect`,
+`trace`, `timeline`, `playhead`, `scrub`, `breakpoint`, or `replay`
+enters discuss-phase, the audience MUST be classified as one of:
+
+- **IR developer surface** — vocabulary is IR-native (snapshot, pass,
+  event[], publishIRSnapshot, IRNode). Lives inside the IR Inspector
+  panel. Audience is "Mrityunjay debugging IR-pipeline correctness."
+  PV32 does not apply (this is the developer console, the one place
+  IR vocabulary is allowed).
+
+- **Musician surface** — vocabulary is musical (voice, bar, beat,
+  note, sample, region). Lives in the editor surfaces (Code, Viz,
+  future DAW, future Studio). Audience is "Mrityunjay-or-anyone
+  writing music." PV32 applies in full force; no IR vocabulary may
+  appear in chrome, controls, status text, tooltips, or error copy.
+
+The audience classification MUST be recorded in CONTEXT.md as a locked
+decision (`D-AUDIENCE: developer | musician`). It governs every
+subsequent UX decision — vocabulary, placement, default visibility,
+keybindings, what the playhead measures, what J/K-equivalents step
+through, what a "tick" represents.
+
+A feature CAN be both, but only by being two surfaces: the same data
+layer (capture buffer, scheduler accessor) feeding two distinct UI
+components, each PV32-clean for its own audience. Bolting both
+audiences onto one component is the trap.
+
+**Why:** Vocabulary leaks when audience is unclassified. The strip in
+19-08 calls its data points "ticks" (IR vocabulary — `IRSnapshot.ts` +
+buffer index), pins "snapshots" (IR vocabulary), steps "events" (IR
+vocabulary). A musician asking "find the wrong note at bar 3 beat 2"
+finds none of their vocabulary on the surface and concludes (correctly)
+the surface isn't for them. Meanwhile a developer asking "what did the
+IR look like 3 evals ago" gets exactly what they need. Two audiences,
+one surface, neither served well unless the surface is honestly
+positioned as serving one and not the other. PV32 prevents IR
+vocabulary from leaking ONTO a musician surface — but only if the
+surface was known to be a musician surface at scope time. Audience
+classification is the upstream gate that makes PV32 enforceable.
+
+**Test gate:** Every CONTEXT.md for a debug/inspect/trace/timeline/
+playhead/scrub/breakpoint/replay phase MUST contain a section titled
+`Audience` with one of two labels. Discuss-phase MUST NOT skip this
+question. If both audiences are claimed, the phase MUST split into
+two surfaces (data layer shared, UI components separate) before
+plan-phase begins.
+
+**Breaks when:** A phase inherits its framing from an upstream design
+doc whose phrasing reads user-facing but whose mechanics are
+developer-facing (or vice versa), and the inheriting phase doesn't
+re-classify. Detection signal: at phase close-out, the user says
+"this isn't useful for what I expected" while tests pass and goal
+sentence is technically satisfied. The framing was satisfied; the
+audience-mental-model wasn't.
+
+**Confirmed by:** Phase 19-08 close-out conversation (2026-05-06). User
+identified the strip as not-useful for music debugging; tracing back
+showed CONTEXT.md never asked the audience question. The phase
+satisfied its goal sentence verbatim and still missed the user-need
+because the goal sentence itself was audience-ambiguous. Reframe
+plan: rename `IRInspectorTimeline` to `IRInspectorEvalHistory`,
+collapse-by-default, document audience as developer in CONTEXT;
+build the musician timeline as a separate phase with `D-AUDIENCE:
+musician` locked at discuss-phase.
+
+**REF:** Phase 19-08 reframe (issue TBD); CONVENTIONS.md §Authoring
+contract; PV32 (this is its upstream gate).
+
+## PV36 — Loc-completeness contract: every IR node and every collect-produced event carries source-range provenance, and no transform may strip it
+
+**ORIGIN:** 2026-05-07 disparity-catalog conversation. User narrowed the
+project's primary objective to "fully fledged debugger with breakpoints
+end-to-end." The standard-practice analog (DWARF / source maps) requires
+*every observable instruction* to carry `(file, line, column)` so the
+runtime can map any pause-point back to source. Today: `Play.loc` is set
+when the parser sees a literal mini atom (parseStrudel.ts:175-188);
+non-Play tags get `loc` only via the PRE-01/P39 thread (signature-level —
+attribution to the produced node is "deferred" per RESEARCH §2 Subtlety
+C); collect arms preserve `loc` for `Play` (collect.ts:247) but not
+uniformly for events produced by `Stack`, `Seq`, `Every`, `Late`, `Fast`,
+etc. The deferral was acceptable under the editing thesis (where
+round-trip parity, not loc, was load-bearing). Under the debugger thesis
+it is the single most load-bearing channel: a missing `loc` ANYWHERE in
+the chain is a region the debugger cannot point at.
+
+**Invariant:** Every `PatternIR` node in a parsed tree, and every
+`IREvent` returned from `collect`, MUST carry a `loc: SourceLocation[]`
+(non-empty) that resolves to a contiguous range in the user's source.
+Specifically:
+
+1. **Parser-side:** every `applyMethod` arm that constructs a new IR
+   node MUST attach `loc` (via `tagMeta(method, callSiteRange)` or
+   literal-construction with the same shape — see PK12). Includes the
+   `default:` arm once it is fixed (see PV37).
+2. **Collect-side:** every collect arm that produces events from a
+   tagged child node MUST propagate the parent's `loc` onto produced
+   events (or merge with the child's `loc` into a multi-range
+   provenance). The `event.loc = ir.loc` pattern at collect.ts:247
+   becomes the canonical shape; arms missing it are bugs.
+3. **Stripping prohibited:** no transform may remove `loc`. `fast` /
+   `every` / `jux` duplicate events → duplicates inherit `loc`.
+   `degradeBy` drops events → loc leaves with the events. The contract
+   is identical to the existing `Play.loc` rule (PV24), now elevated
+   to apply across every tag.
+4. **Multi-range when synthetic:** desugars (`layer`, `off`, `chunk`)
+   that produce structural nodes from compound source ranges MUST
+   carry the call-site range as `loc[0]` and may carry inner argument
+   ranges as additional entries. The first entry is the source the
+   user clicked when click-to-source resolves.
+
+**Why:** Without this contract, the debugger has dark regions — events
+that fire at runtime but cannot be highlighted in the source. Every dark
+region is a place a breakpoint can never be set, an inspector chain
+can never render, a click-to-source can never resolve. The DWARF-class
+debuggers don't model the source language; they require *only* this loc
+channel. If we don't enforce it as an invariant, drift is silent: a new
+collect arm shipped without loc-propagation degrades the debugger by one
+event class with no test failing today.
+
+**How to apply:** When adding any new IR tag or any new `applyMethod`
+arm, the loc-attribution review check fires: did this construction call
+`tagMeta`? If literal-constructed, does it carry the same `[start, end]`?
+When adding any new collect arm, the loc-propagation review check
+fires: does the produced event carry `ir.loc` (or the parent chain's
+loc when the IR node is synthetic)? Catalogue gap-check (`/anvi:rq`)
+on every debugger-adjacent phase: enumerate IR tags vs collect arms vs
+loc-attribution coverage; surface uncovered paths before plan-phase.
+
+**Confirmed by:** Phase 19-05 PRE-01 / P39 thread for parser-side loc;
+Phase 19-08 reverse-step on the `loc` test in IRInspectorEvalHistory;
+2026-05-07 click-to-source slice γ (5 successive fix commits) — every
+fix-up was a missing-loc-channel discovery on a different IR shape.
+
+**REF:** parseStrudel.ts:175-188 (Play.loc); parseStrudel.ts:281
+(applyChain callSiteRange); collect.ts:247 (Play loc propagation);
+artifacts/stave/IR-DEBUGGER-NORTH-STAR.md (read-only debugger contract);
+PV24 (Play.loc precedent); PK12 (loc.start convention).
+
+**STATUS: VALIDATED 2026-05-08 (PR #95).** Phase 20-03 landed all three
+clauses end-to-end: parser-side via the existing PRE-01/P39 thread plus
+W7 outermost-loc audit (zero drift across 26 recognised arms);
+collect-side via the new `withWrapperLoc(events, wrapper)` helper at
+collect.ts threaded through 20+ collect arms (Seq, Stack, Choice, Every,
+Cycle, When, FX, Ramp, Loop, Elongate, Fast, Slow, Late, Degrade, Chunk,
+Struct, Swing, Ply, Chop) plus Pick multi-range upgrade and
+`_collectRearrange` signature extension for Shuffle/Scramble; stripping
+prevention enforced by dev-only `console.warn` at `collect()` boundary
+(NODE_ENV-guarded); contract test sweeps 14-fixture corpus + 25 per-shape
+probes in `parity.test.ts`. Editor vitest 1274 → 1327 (+53). Click-to-source
+reduced from 5-commit regex-fallback cascade to one-line
+`countLines(snapshot.code, evt.loc[0].start)` (slice-γ commits reverted).
+PR #95 merged into main at `aded68f`.
+
+## PV37 — Unrecognised chain methods MUST wrap as opaque `Code`-with-loc, never silently drop
+
+**ORIGIN:** 2026-05-07 diagnostic of `note("c4 e4").s("sawtooth").release(0.3).viz("pianoroll")`
+on user's `pattern.strudel`. `applyMethod`'s `default:` arm at
+parseStrudel.ts:729 silently `return ir` for any unrecognised method —
+`.s`, `.n`, `.note`, `.bank`, `.scale`, `.release`, `.attack`, `.sustain`,
+`.decay`, `.shape`, `.amp`, `.detune`, `.octave`, `.tremolo`, `.lfo`,
+`.legato`, `.unison`, `.coarse`, `.fine`, `.add`, `.sub`, `.mul`, `.div`,
+`.range`, `.outside`, `.inside`, `.zoom`, `.compress`, and any future
+Strudel addition. Effect: the user's typed code silently degrades into
+"the IR has no representation of this region." Audio still plays
+(Strudel runtime applies the method); the debugger cannot point at it.
+For the editing thesis this was a round-trip data-loss bug; for the
+debugger thesis it is a more fundamental observability bug.
+
+**Invariant:** Every chain method `applyMethod` does not recognise MUST
+wrap the receiving IR in an opaque `Code`-with-loc node that captures
+(a) the source range of the entire `.method(args)` call site and (b) a
+back-pointer to the inner IR so transformable inner regions remain
+inspectable. Specifically:
+
+1. **No silent drop.** The `default:` arm of `applyMethod` may not
+   `return ir` unmodified. It must wrap.
+2. **Loc preserved verbatim.** The wrapper carries the call-site range
+   (the `[start, end]` `applyChain` already computes — parseStrudel.ts:271).
+3. **Inner remains inspectable.** The wrapped IR is reachable through
+   the `Code` node so the inspector renders the chain history with the
+   opaque region marked but the inner Play events still discoverable.
+4. **Round-trip honest.** `toStrudel` on the wrapper re-emits the
+   original method-call source verbatim; round-trip survives unrecognised
+   methods losslessly without modeling them.
+5. **Inspector contract:** opaque regions render as `[opaque: .release(0.3)]`
+   in chain history with their source range clickable. Breakpoints set
+   inside the call site resolve to the wrapper.
+
+**Why:** Without wrapping, the IR's "I don't model this" is
+indistinguishable from "this didn't exist." The debugger has no way to
+tell the user "you typed `.release(0.3)`; I see it but I can't inspect
+inside it." Wrapping preserves the typed source as a first-class
+artefact in the IR even when the IR doesn't structurally model the
+method's behaviour. This is the MLIR-opaque-op pattern: dialects keep
+ops they don't understand; the textual form passes through. It's also
+the gdb-on-stripped-libraries pattern: the debugger names the function
+even when it can't step inside.
+
+**How to apply:** When auditing `applyMethod`, the `default:` arm is
+the gate — it must wrap, never `return ir`. When adding a new method
+arm, the question shifts from "is this method important enough to
+recognise?" to "would breakpoints set on this method-call's source
+range work without recognition?" If the answer is "they should work via
+the wrapper alone" — the wrapper is sufficient and the method can stay
+in `default:`. If the answer is "we want stepping INSIDE this method"
+— add a typed arm. The wrapper makes coverage gradual instead of
+all-or-nothing.
+
+**Confirmed by:** 2026-05-07 disparity audit. The categorical answer
+about Strudel coverage gaps (~25 chain methods uncovered) collapses
+under this invariant: each gap becomes "opaque but visible" instead of
+"invisible." The full-coverage roadmap line item shrinks from "model
+every Strudel method" to "wrap unrecognised methods + opportunistically
+upgrade to typed arms when stepping inside is needed."
+
+**REF:** parseStrudel.ts:729 (silent-drop `default:` arm — bug to fix);
+parseStrudel.ts:271 (callSiteRange already computed); collect.ts (Code
+walk arm); PV36 (loc-completeness — wrapper supplies loc to otherwise
+loc-less regions); P33 (the hetvabhasa entry diagnosing the silent-drop
+trap class).
+
+**D-03 expansion (2026-05-07 — phase 20-04 discuss-ratified).** Clause 1
+("no silent drop") applies to BOTH `applyMethod`'s `default:` arm AND
+every typed arm's parse-failure branch. Each typed arm's `return ir` on
+parse failure is a P33 instance; the fix is identical:
+`wrapAsOpaque(ir, method, args, callSiteRange)`. ~10 distinct edited
+sites in `parseStrudel.ts:303-727` (the 14-arm FX group at line 618
+collapses 14 arms into one shared edit). Two intentional NON-wrap sites
+preserved: `ply` line 546 (n=1 valid no-op per CONTEXT D-02 from 19-03)
+and `p` line 727 (track-assignment pass-through, consumed externally).
+Recognised arms keep their typed shape on the success path; failure
+branch wraps. Pattern-as-arg gaps in typed arms (e.g. `.fast("<2 3>")`,
+`.gain("0.3 0.7")`) become opaque-but-visible instead of silent-drop —
+the runtime still applies them via Strudel dispatch; the IR carries
+their source range for the debugger. P33 trap class fully eliminated
+once 20-04 lands.
+
+**D-06 (2026-05-07) — Double-wrap is allowed.** Chain `.foo(1).bar(2)`
+where neither method is recognised produces nested wrappers — the second
+method's wrapper carries the first's wrapper as `via.inner`. This is
+correct behaviour, not a bug. Round-trip works (each wrapper re-emits
+its own `.method(args)`); inspector renders nested opacity; collect's
+recursion in the `Code-with-via` arm naturally appends each wrapper's
+range innermost-first. No special handling required. Considered for
+elevation to its own vyapti and rejected — too narrow a property to
+warrant its own number.
+
+**Wrapper construction shape (locked at 20-04 plan-phase):**
+- New free function `wrapAsOpaque(inner, method, args, callSiteRange)`
+  in `parseStrudel.ts` (NOT an `IR.code` overload — IR.code is called
+  from 8+ parse-failure sites that never carry `via`).
+- `via.inner` is REQUIRED at the type level (not optional). Every
+  wrapper has a receiver.
+- `via.args` is a RAW string (whitespace preserved) for round-trip
+  byte-fidelity. `toStrudel` emits `${gen(via.inner)}.${via.method}(${via.args})`.
+- `code: ''` on wrapper path is structurally sufficient; `toStrudel`
+  branches on `via` and never reads the empty `code`.
+- `userMethod` field intentionally NOT used on wrappers — it carries
+  PV31 co-tag-alias semantics (Stack-from-layer ≠ Stack-from-jux) which
+  the wrapper is structurally distinct from.
+
+**STATUS: VALIDATED 2026-05-08 (PR #96).** Phase 20-04 landed all five
+invariant clauses + the D-03 expansion + D-06 double-wrap + wrapper
+construction shape locks. 24 wrap call sites in `parseStrudel.ts`
+(default arm + 23 typed-arm failure branches; FX 14-arm group collapsed
+to one shared edit). Two intentional non-wrap sites preserved with
+inline comments: `ply(n=1)` no-op (parseStrudel.ts:546) and `p`
+track-assignment passthrough (parseStrudel.ts:727). Consumer wiring
+landed atomically across `collect.ts` (Code arm walks via.inner via
+`withWrapperLoc` from PV36), `toStrudel.ts` (re-emits
+`${gen(via.inner)}.${via.method}(${via.args})` byte-equivalent),
+`serialize.ts:220-223` (validator block carries `via` through round-trip
+— closes the silent-strip regression site documented in 20-04 RESEARCH §0).
+Inspector chrome split: developer surface renders `[opaque: .release(0.3)]`
+chip with tree expansion via new pure-helper module
+`packages/app/src/components/IRInspectorChrome.ts`; musician surface
+renders `[unmodelled]` (label-only — no method name leak per PV32).
+24-fixture full corpus contract test in `parity.test.ts`. Editor vitest
+1327 → 1369 (+42); App vitest 154 → 166 (+12). P33 silent-drop trap
+class fully ELIMINATED. PR #96 merged into main at `aded68f`.
+
+**Phase 20-10 (2026-05-09) — sibling layer codified.** PV37 governs
+REPRESENTATION completeness (every typed character lands in IR — opaque
+wrapper + raw source range). PV39 (added Phase 20-10) governs SEMANTICS
+completeness (every param-bearing chain method's effect lands on
+downstream events — typed `Param` IR tag + collect-time merge into
+ctx.params + body-event spread). Two layers, same span, sibling
+invariants. Removing either reopens its layer's silent-drop class. PV37
+unchanged.
+
+**Phase 20-11 (2026-05-09) — track-identity layer codified.** PV37 governs
+REPRESENTATION (every typed character lands in IR; Code-with-via fallback
+for unknowns). PV40 (added Phase 20-11) governs IDENTITY (every `$:` /
+`.p()` track has a parser-assigned trackId on its events). The Track
+wrapper applies the PV37 model to the `$:` boundary — wraps the source
+range, round-trips through serialize, never drops. PV37 + 20-10's PV39
+(semantics) + PV40 (track identity) form a three-layer span:
+representation, semantics, identity. Removing any reopens its layer's
+silent-drop class. PV37 unchanged.
+
+**Phase 20-12 (2026-05-10) — `freq` Param promotion preserves PV37.** D-06
+extended the SEMANTICS whitelist (PV39's typed-arm set) by adding `freq` to
+the `note`/`n` numeric-coercion family at `parseStrudel.ts:839-848`. The
+PV37 fallback path is unchanged: numeric `.freq(440)` lands as a typed
+`Param` (PV39 SEMANTICS path); non-numeric `.freq("<200 800>")` falls
+through to `wrapAsOpaque` (PV37 REPRESENTATION path). SINGLE decision per
+call site (P50 — no compound discriminator added; the typed-arm parse-
+failure branch already wraps per the D-03 expansion above). PV37 model
+intact across the 20-10 → 20-12 axis-extension; the chrome's channel-4
+(bar Y = pitch via `extractPitch(evt.params.freq)`) reads only when the
+runtime delivers a numeric value, so the opaque path stays Y-flat (correct
+per PV41 percussive-leaf default).
+
+## PV38 — Every observable runtime hap maps to an IR-node identity (engine ↔ IR identity channel)
+
+**ORIGIN:** 2026-05-07 debugger-architecture conversation. Today
+StrudelEditorClient.tsx:357 publishes a static IR snapshot from
+`collect(parseStrudel(code))`; StrudelEngine.ts:368 emits runtime haps
+from `pattern.queryArc()` via `normalizeStrudelHap`. These are two
+parallel pipelines that never reconcile. For breakpoints to work, when
+a hap fires, the engine must answer "which IR node produced this?" —
+otherwise the inspector cannot render the chain, the editor cannot
+highlight, and the scheduler cannot match a breakpoint condition to a
+specific source range.
+
+**Invariant:** Every NormalizedHap that StrudelEngine emits MUST carry
+either (a) a stable `irNodeId` referencing the IR node that produced
+it, or (b) sufficient `(time, value, loc)` for a deterministic
+hap→IRNode lookup against the published snapshot. The chosen mechanism
+must be byte-stable across `query()` calls within a snapshot's
+lifetime: querying the same arc twice produces haps with the same
+`irNodeId`s. Specifically:
+
+1. **ID source:** at `collect`-time, every produced `IREvent` is
+   assigned an `irNodeId` (stable hash of `loc` + position-in-output,
+   or sequential index — TBD at plan time). The IRSnapshot exports a
+   lookup table `id → IREvent`.
+2. **Engine-side carry:** `normalizeStrudelHap` enriches each hap with
+   the matching `irNodeId` by structural lookup against the snapshot
+   (matching by hap.context.locations + hap.whole.begin). When
+   no match is found (hap from a runtime-only path), the hap is
+   tagged with `irNodeId` absent (the type field is `irNodeId?`) and
+   the inspector renders it as "runtime only" (the same opaque-but-visible
+   treatment PV37 gives source regions the parser doesn't model).
+3. **Inspector contract:** clicking a hap in the timeline / piano roll
+   resolves through `irNodeId → IREvent → loc → source range`.
+   Breakpoints register conditions over `irNodeId` (or over loc, with
+   the snapshot translating loc → set of `irNodeId`s).
+4. **Runtime safety:** the channel is observation-only. Adding it does
+   not modify scheduling, audio routing, or hap value semantics.
+   Identity comes from `loc` already on the IR, not from a new mutation.
+
+**Why:** A breakpoint debugger is fundamentally "stop when a specific
+*program point* is reached." In our world, the program point is an IR
+node; the runtime executes via Strudel's PatternScheduler which emits
+haps. Without an identity channel between hap and IR node, the
+breakpoint condition language collapses to "stop at time t" or
+"stop on a hap whose value matches X" — neither is a *source-level*
+breakpoint. The DWARF analog: every emitted CPU instruction has
+`(addr → file:line)`. Our analog: every emitted hap has
+`(hap → IR node → file:line)`.
+
+**How to apply:** At engine-IR boundary review time (any change to
+NormalizedHap, IREvent, IRSnapshot, or PatternScheduler emission),
+the question fires: does the hap-to-IR-node mapping still hold? When
+adding a new IR tag whose collect arm produces events with novel
+shape, the audit fires: do the produced events carry irNodeId? When
+adding a runtime feature that produces haps outside the IR (e.g.
+direct Strudel patterns not routed through our parser), the
+"runtime-only" tag is the explicit acknowledgement, surfaced in the
+inspector.
+
+**Confirmed by:** 2026-05-07 categorical analysis of debugger
+requirements. This is the single property all source-level debuggers
+share: gdb (CPU addr → DWARF), Chrome DevTools (V8 stack frame →
+sourcemap), MSVC (IL offset → PDB). Without it, no breakpoint debugger
+exists.
+
+**Path correction (2026-05-08, phase 20-05):** earlier drafts of clause
+2 cited `hap.value.context.locations` — the actual Strudel API is
+`hap.context.locations` (`@strudel/core/hap.mjs:25-29` constructs context
+as a top-level Hap field, NOT inside `value`). Verified at three
+points: our `extractLoc` at NormalizedHap.ts:38-53; the test fixture
+at NormalizedHap.test.ts:80; and Strudel's `withLoc` at
+`@strudel/core/pattern.mjs:558-568`. PV38 clause 2 corrected in
+the same PR that lands the engine-side carry (phase 20-05 wave γ).
+
+**REF:** StrudelEngine.ts:368 (normalizeStrudelHap call site, the
+boundary that grows the channel); engine/NormalizedHap.ts (where
+irNodeId would land); engine/irInspector.ts:51 (publishIRSnapshot —
+where lookup table joins the snapshot); engine/timelineCapture.ts
+(reverse-step / scrub already buffers snapshots; needs hap-id wiring);
+PV36 (loc-completeness — the source-range half of this channel);
+PV37 (opaque wrapper — defines what runtime-only haps look like in
+the inspector).
+
+**VALIDATED (2026-05-08):** All 4 clauses enforced end-to-end across
+debugger v2 sub-phases:
+- Clause 1 (id source at collect): phase 20-05 PR #102 — `assignNodeId`
+  at Play leaf in collect.ts:160, FNV-1a content-hash of
+  `${loc.start}:${loc.end}:${tag}:${position}`. Wrapper arms preserve
+  via existing `{...e, ...}` spread (DEC-NEW-1 leaf-only assignment).
+- Clause 2 (engine-side carry): phase 20-05 PR #102 wave γ
+  (queryArc boundary via `normalizeStrudelHap` + `findMatchedEvent`)
+  + phase 20-06 PR #103 wave α (onTrigger boundary via
+  `HapStream.emit` enrichment). Both consume the same single-strategy
+  `findMatchedEvent` (loc[0] key + whole.begin tie-break; miss →
+  `irNodeId` absent per PV37 alignment; NO fallback ladder per P50).
+- Clause 3 (inspector contract): phase 20-06 PR #103 wave β
+  (MusicalTimeline rewrite) + phase 20-07 PR #104 wave γ (Inspector
+  chain-row click + breakpoint marker). `IRSnapshot.irNodeIdLookup` +
+  `irNodeLocLookup` + `irNodeIdsByLine` (added 20-07 α0) compose the
+  lookup surface.
+- Clause 4 (observation-only safety): all 3 sub-phases preserve. The
+  hit-check in `wrappedOutput` (StrudelEngine.ts:219) skips audio
+  dispatch on pause but does not mutate hap value semantics.
+
+## PV39 — Param-bearing chain methods MUST inject their effect into ctx.params before projection reads it (semantics-completeness pair-of PV37)
+
+**Status:** ENFORCED 2026-05-09 (Phase 20-10).
+
+**ORIGIN:** Issue #108 — user pasted a multi-voice fixture with
+`note(...).s("sawtooth")`, `s("hh*8")`, etc. The MusicalTimeline rendered
+all events on a single `$default` track because chained `.s(...)` calls
+landed in the IR via `wrapAsOpaque` (PV37 — representation honest) but
+never wrote their effect into ctx.params. `collect.makeEvent` saw
+`evt.s = null`; `groupEventsByTrack`'s `evt.s ?? '$default'` fallback
+collapsed three distinct synth voices and four drum stems into one
+bucket. PV37 closed the REPRESENTATION layer in 20-04 (no silent-drop);
+this phase closes the SEMANTICS sibling.
+
+**Invariant:** Every param-bearing chain method (the 10-method whitelist
+below) MUST construct a typed semantic IR tag (`Param`) at the parser
+arm, AND MUST merge its effect into ctx.params at the collect arm before
+walking the body. Specifically:
+
+1. **Parser arm.** `applyMethod`'s switch in `parseStrudel.ts` has a
+   typed `Param` arm for the 10 whitelisted methods. The arm reads the
+   raw arg string, constructs `IR.param({ key, value, rawArgs, body,
+   loc, userMethod })`, and short-circuits BEFORE `wrapAsOpaque`. Methods
+   outside the whitelist still fall through to `default:` and wrap as
+   `Code-with-via` — PV37 unchanged.
+2. **Whitelist (Phase 20-10 starter set):** `s`, `n`, `note`, `gain`,
+   `velocity`, `color`, `pan`, `speed`, `bank`, `scale`. Expandable —
+   the next param phase adds `release/attack/sustain/decay/crush/distort/
+   shape/amp/detune/octave/tremolo/lfo/legato/unison/coarse/fine`.
+3. **Collect arm.** `collect.ts` `case 'Param':` merges `value` into a
+   per-event slot table (literal arg → constant; pattern-arg → walk
+   sub-IR once, find slot covering body event's begin time). Body event
+   gets the slot value spread into `params: { ...e.params, [key]: v }`
+   AND, for the four shorthand keys (`s`, `gain`, `velocity`, `color`),
+   spread into the top-level event field per `makeEvent`'s destructure.
+4. **Body-event spread preserves PV36 + PV38.** The Param walk
+   re-emits body events with `loc` and `irNodeId` intact (they come from
+   the body sub-IR's Play leaf, not from the Param wrapper's call site).
+   Slot events are NOT included in the output — the sub-IR is a VALUE
+   PROVIDER, not an event producer.
+5. **D-05 last-typed-wins.** When two `.<key>(...)` calls chain
+   (`.gain(0.3).gain(0.7)`), the OUTER call's value overwrites the inner
+   on the merge step. Locked empirically by α-1 probe vs Strudel runtime;
+   pinned in `parity.test.ts` describe `'20-10 wave γ — Param-shadow
+   merge direction parity'`.
+
+**Span:** parser arm in `parseStrudel.ts:applyMethod` (typed `Param`
+case before `default:`/`wrapAsOpaque`); collect arm in `collect.ts:case
+'Param':` (merge into ctx.params before walking body). Both must change
+together; partial change reopens the silent-drop class for the affected
+keys.
+
+**Pair-of:** PV37 (representation completeness — opaque-wrap covers
+typed characters but discards effect). Same span, sibling layer.
+Removing PV39 reopens semantics-silent-drop (P52); removing PV37
+reopens representation-silent-drop (P33).
+
+**Catcher:**
+- `parity.test.ts` "20-10 wave α — issue #108 regression" — asserts
+  `evt.s` populated for every chained `.s` invocation in the user
+  fixture (root-cause assertion).
+- `parity.test.ts` "20-10 wave γ — Param-shadow merge direction parity"
+  — pins D-05 vs Strudel runtime for both numeric and string keys.
+- `integration.test.ts` "20-10 wave γ — Param sub-IR slot-table
+  semantics" — 11-test corpus pinning event-count, per-cycle alternation,
+  silence handling, numeric coercion, body-atom loc, last-typed-wins
+  shadow, PV37 preservation, sub-IR-spread loc/irNodeId survival
+  (PV36+PV38), and pattern-arg atom loc inside mini-string (PV25).
+
+**Wrong fix (P52 trap):** "Read `via.method` and `via.args` in
+`collect.ts case 'Code'`." This couples the opaque wrapper to method-
+specific semantics; turns PV37's clean fallback into a switch over
+method names; does NOT generalize when the method's argument shape needs
+structural introspection (e.g. pattern-args). The right fix is to
+PROMOTE the method to a typed semantic IR tag (Param) at the parser arm
+— representation honesty (PV37) + effect honesty (PV39) = full
+observation completeness.
+
+**REF:** `.planning/phases/20-musician-timeline/20-10-PLAN.md` §0;
+`packages/editor/src/ir/parseStrudel.ts:applyMethod` typed Param arm;
+`packages/editor/src/ir/collect.ts:case 'Param':` (lines 347-417);
+`packages/editor/src/ir/PatternIR.ts` Param tag + IR.param constructor.
+
+**Phase 20-10 (2026-05-09).** Wave α landed Param IR tag + parser arm
++ collect arm + α-6 regression test (issue #108 fixture). Wave β
+landed toStrudel + serialize + Inspector chrome (developer / musician
+projection split). Wave γ landed nested-pattern-arg corpus + Strudel
+runtime parity + catalogue codification + manual γ-4 gate. P52 trap
+class introduced. Closes #108 at the IR-collect level; γ-4 manual gate
+verifies user-visible render.
+
+## PV40 — Track identity is parser-assigned, never inferred from event content
+
+**Status:** ENFORCED 2026-05-09 (Phase 20-11).
+
+**ORIGIN:** Phase 20-08 / γ-4 manual gate session — duplicate `$:` blocks
+collapse into a single timeline row. Two `$: stack(s("hh*8")...)` blocks
+producing events with identical `evt.s = 'hh'` were bucketed together by
+`groupEventsByTrack`'s 3-level fallback `evt.trackId ?? evt.s ?? '$default'`
+because `evt.trackId` was undefined for parser-derived events. The user's
+authored intent (two distinct tracks) was lost at the consumer because the
+parser never asserted it. CONTEXT §0 (`20-11-CONTEXT.md`).
+
+**Invariant:** Track identity (the `trackId` on every `IREvent`) MUST come
+from the parser via the `Track` wrapper IR tag, set at `parseStrudel.ts`
+from the `$:` block index (auto-numbered `d{N}`) or the `.p("name")`
+argument. Downstream consumers MUST NOT infer track identity from event
+content (`evt.s`, `evt.note`, etc.) — those are FALLBACK keys when the
+parser-assigned `trackId` is absent (hand-built IR fixtures only).
+
+**Span:** parser at `parseStrudel.ts:97-130` (`extractTracks`-loop wraps
+each `$:` track with `Track('d{N}', ..., {loc: $: range})`; non-`$:` files
+get a synthetic `Track('d1', ..., {loc: undefined, userMethod: undefined})`;
+the `case 'p':` arm wraps with explicit `Track('name', ..., userMethod:
+'p')`); collect at `collect.ts` (`case 'Track'` spreads `ctx.trackId`;
+`makeEvent` reads it via conditional spread); presentation at
+`MusicalTimeline.tsx` + `groupEventsByTrack.ts` (read `evt.trackId` first;
+sample-fallback only fires for hand-built fixtures).
+
+**Catcher:** `parity.test.ts` describe block `"20-11 wave γ — duplicate-$:
+regression (closes 20-08-residual / CONTEXT §0)"` (γ-6 — 7 tests pinning
+root cause + symptom + .p() override + nested .p() inner-wins +
+synthetic-d1 + .p()-on-stack-arg + two-$: with shared .p()-name merge).
+Plus app-side `groupEventsByTrack.test.ts` describe `"20-11 — duplicate
+$: blocks no longer collapse"` (γ-6 PART B — 3 tests pinning consumer-
+side bucket distinction).
+
+**Pair-of:** PV37 (wrap-never-drop, REPRESENTATION) + PV39 (SEMANTICS) —
+same span, sibling layer. PV37 closed REPRESENTATION for unrecognised
+methods; PV39 closed SEMANTICS for param-bearing methods; PV40 closes
+IDENTITY for `$:` blocks and `.p()`. Three layers, same span: removing
+any reopens its layer's silent-drop class.
+
+**REF:** `.planning/phases/20-musician-timeline/20-11-PLAN.md` §3-§5;
+`case 'Track'` arm in `collect.ts`; `parseStrudel.ts:97-130` main path;
+`toStrudel.ts:24-35` Track gen arm.
+
+## PV41 — Bar visual identity is a 5-channel contract; bars carry NO text labels
+
+**Status:** ENFORCED 2026-05-10 (Phase 20-12).
+
+**ORIGIN:** Phase 20-11 design debate — reviewers reflexively asked "how does the user know which sample plays at this bar?" The naive answer ("label the bar with `evt.s`") works for a single bar-wide selection but fails for the steady-state view where 1/16 cells are ~30px wide and ~12px tall. The lock came out of `20-11-DESIGN-DEBATE.md` ("no bar labels EVER") and the 5-channel substitute was specified in `20-12-CONTEXT.md` D-01..D-05.
+
+**Invariant:** Every event-bearing visual surface in the chrome carries identity through exactly five channels. No channel is optional; no sixth channel (especially not on-bar text labels) may be added without retiring this invariant.
+
+**The five channels:**
+1. **Row header rail** — chevron + track name + swatch dot (per-track identity).
+2. **Row color** — track palette slot OR user override via swatch popover; persisted in `trackMeta` Y.Map (`evt.color ?? meta.color ?? paletteForTrack(...)` precedence).
+3. **Bar opacity** — `clamp(evt.gain ?? 1, 0.15, 1)` (gain semantically dominates; floor 0.15 keeps `gain(0)` bars visually present per RESEARCH §G.3).
+4. **Bar Y position** — auto-fit pitch from `evt.note ⊕ evt.params.note ⊕ evt.params.n ⊕ evt.params.freq` for melodic leaves; flat baseline for percussive leaves; flat baseline for collapsed rows.
+5. **Hover tooltip** — full chain summary via native `title=` attribute (pointer-events: none, screen-reader friendly, zero CSS cost).
+
+**Span:** `MusicalTimeline.tsx` event render (β-3 opacity, β-4 Y-as-pitch, β-5 tooltip), `TrackHeaderRow` (β-1 chevron + swatch + name), `TrackSwatchPopover` (β-6 commit). Future event-bearing surfaces (piano-roll lane, automation lane, structure view from 20-13) inherit this contract.
+
+**Catcher:**
+- `MusicalTimeline.test.tsx` `"20-12 β-3 — bar opacity = clamp(gain, 0.15, 1)"` (4 cases — channel 3).
+- `MusicalTimeline.test.tsx` `"20-12 β-5 — hover tooltip extension"` (4 cases — channel 5; PV32 vocabulary lock cross-check).
+- `MusicalTimeline.test.tsx` `"20-12 β-1 — track header rail"` (3 cases — channel 1).
+- `MusicalTimeline.test.tsx` `"20-12 γ-2 — color persistence"` (4 cases — channel 2 + 3-source precedence).
+- `pitch.test.ts` (29 cases) covers the channel-4 input lattice (`note` string / midi / `n` / `freq` Hz).
+- Manual gate `20-12-MANUAL-GATE.md` visual checks #1, #6, #8, #11 cover the perception-side gate (a label appearing on any bar is a BLOCKS-PR violation).
+
+**Pair-of:** P54 (label-trap-at-typical-zoom) — names the trap that violating PV41 lands in. PV35 (musician-vocabulary discipline) — same audience target; PV41 is the visual-substrate sibling of PV35's textual discipline. PV40 (parser-assigned identity) — provides channel-1's `trackId` source.
+
+**REF:** `.planning/phases/20-musician-timeline/20-12-CONTEXT.md` §3 D-01..D-05; `20-12-RESEARCH.md` §C.5 + §G.3; `20-11-DESIGN-DEBATE.md` "no bar labels EVER" lock; `MusicalTimeline.tsx:868-874` (channel-2 precedence chain); `MusicalTimeline.tsx:812-815` (channel-3 clamp); `MusicalTimeline.tsx:822-853` (channel-4 pitch-to-Y); `MusicalTimeline.tsx:859` (channel-5 native title).
+
+## PV42 — Events span the same cycle window the chrome displays
+
+**Statement.** When the chrome shows a fixed cycle window of length N, the IR-projection events fed to it must span the same `[0, N)` cycle range — not `[0, 1)`. Otherwise the right edge of the timeline is permanently empty for static viz, and any chrome-side identity match against runtime hap events drifts past the first window pass.
+
+**Scope.** Every consumer of `IRSnapshot.events` that maps event begin → x via a window of length N must agree with the producer about N. Concretely: `MusicalTimeline.tsx`'s `WINDOW_CYCLES = 2` (timeAxis.ts) and the `StrudelEditorClient.tsx` `collectCycles(finalIR, 0, TIMELINE_WINDOW_CYCLES)` call must use the same constant. App and editor packages can't import each other; the constant is duplicated with a synced-comment.
+
+**Type.** STRUCTURAL — about the contract between event producer (engine) and event consumer (chrome). A misalignment doesn't fail the pipeline; it produces a silently-broken UX (empty cycle column, dead highlighting after wrap).
+
+**Implication for design.** Any new chrome view that displays multiple cycles must:
+1. Decide its own window length N.
+2. Either use `collectCycles(ir, 0, N)` at its data source, or fold incoming events modulo N at the consumption point.
+3. Document the N-coupling at both sites with a cross-reference comment.
+
+If a future feature wants a scrollable-multi-cycle timeline (e.g., 20-13 structure-view), N becomes dynamic and the constant duplication breaks. At that point N becomes a parameter passed from chrome to data layer (a hook accepting `windowCycles`, or a coordinator that owns the constant).
+
+**Pair-of:** P57 (window-vs-monotonic identity matching) — P57 names the trap when the consumer fails to adapt to the monotonic-runtime convention; PV42 is the contract that defines what the consumer's window IS.
+
+**Breaks when:**
+- Engine collects only `[0, 1)` while chrome displays `[0, 2)` → cycle 1 column empty (Phase 20-12 pre-hotfix).
+- Engine collects `[0, 4)` while chrome displays `[0, 2)` → cycle 2-3 events render off-screen and are wasted.
+- Chrome compares hap-begin (∈ [0, ∞)) to event-begin (∈ [0, N)) without modulo → P57 triggers.
+
+**Origin.** Codified Phase 20-12 hotfix wave (2026-05-10) when `IRSnapshot.events` switched from single-cycle to multi-cycle. Required by the angle-bracket alternation pattern `<a b c d>` whose per-cycle shape was invisible in single-cycle collection.
+
+**REF:** `MusicalTimeline.tsx:56` (WINDOW_CYCLES import); `musicalTimeline/timeAxis.ts:29` (constant definition); `StrudelEditorClient.tsx:380-388` (TIMELINE_WINDOW_CYCLES use); commit `af7b6e5`.
+
+## PV43 — Chrome surfaces must adopt the global theme tokens (no mockup-literal opt-out)
+
+**Statement.** Every chrome surface — every panel, modal, popover, timeline, inspector, and inline overlay — must derive every color from the project's CSS-variable theme tokens (`--bg-app`, `--text-primary`, `--border-subtle`, etc.). A surface that hardcodes mockup-literal colors silently breaks light mode, system mode, and any future theme variant. Inline-styles MAY include the mockup value as a `var(--token, FALLBACK)` fallback for isolated mounts (storybook, unit tests without globals.css), but the token MUST come first.
+
+**Scope.** All `.tsx` files under `packages/app/src/components/` whose render output ships color, background, border, or shadow declarations. Includes JSX `style={{...}}` literals AND any `styles` constant object. Excludes:
+- Per-event computed colors (palette + custom-pick) — those are SEMANTIC color (track identity), not chrome-color.
+- Boolean-state outlines that intentionally use accent tokens (active-note, focus rings).
+- Embedded canvas/SVG painted by p5/Hydra — those are user-content, not chrome.
+
+**Type.** STRUCTURAL — about the contract between component implementations and the theme system. Theme switches at runtime via `setEditorTheme`; surfaces that opted out of the theme remain dark-mode-locked and become invisible in light mode.
+
+**Implication for design.** Any new chrome component:
+1. Imports its colors via `var(--token, fallback)` form, not literal hex/rgba.
+2. Picks tokens from globals.css (`.anvi/` audit if uncertain which token applies — chrome and panel and elevated all serve different roles).
+3. Carries the original mockup value as the `var()` fallback ONLY if needed for isolated rendering; otherwise omit.
+
+**Pair-of:** P54 (label-trap-at-typical-zoom) — same family of "self-contained visual unit" traps where the implementer thought their surface was an island. PV41 (5-channel identity contract) — channels 1-5 reference the theme tokens for color where applicable; PV43 is the substrate PV41 stands on.
+
+**Breaks when:**
+- A new chrome panel ships with `background: '#0d0d1a'` instead of `var(--bg-chrome)` → invisible in light mode.
+- A modal hardcodes `color: 'white'` (or `rgba(255,255,255,...)` without a `var()` wrap) → dark-on-white in light mode.
+- A popover's border color uses a fixed hex not in the token map → visible only in dark mode.
+
+**Origin.** Codified Phase 20-12 wave-δ (2026-05-10) when MusicalTimeline.tsx's "no external theme dependency — the tab is a self-contained visual unit" comment (added Phase 20-02 DV-08) was discovered to make the entire timeline invisible in light mode. The original opt-out was justified at the time by the mockup being dark-only; theme support landed in PR #92 across the rest of the IDE without round-tripping back to the timeline.
+
+**Audit discipline (Phase 20-12 wave-ε refinement, 2026-05-11).** The PV43 audit MUST enumerate every component rendered inside the panel tree, not just the entry-point file. Wave-δ converted `MusicalTimeline.tsx` but missed `Ruler.tsx` (a sibling component rendered inside the same tab). Manual gate Check #17 caught it: the body adopted the theme but the ruler stayed dark — a dark island above a light timeline. Wave-ε ε-1 closed the gap. Generalisation: when codifying a "all chrome surfaces must X" invariant, the catcher list must include the recursive surface enumeration, NOT just the surface where the invariant was first noticed.
+
+**REF:** `MusicalTimeline.tsx:1021-1024` (post-fix theme-aware comment, wave-δ); `Ruler.tsx:148-217` (post-fix sibling, wave-ε); `globals.css:11-101` (token definitions for both modes); `EditorSettingsModal.tsx:148` (canonical pattern: `background: 'var(--bg-overlay)'`); commits `c1c5e4b`, `3540a9e`.
+
+---
+
+## PV44 — Chain methods with runtime-dependent semantics need live-canvas regression, not IR-only tests
+
+**Claim:** Any IR tag whose behavior depends on the host runtime's interpretation of the source (Strudel's transpiler + eval, not just our parser's view of the AST) MUST have at least one live-canvas regression test — Playwright against the dev server — in addition to IR-level unit tests. IR tests are blind to the transpiler stage.
+
+**Why:** Phase 20-11 wave-γ shipped a `Track` IR tag + `.p()` parser arm + 17 IR-level unit tests covering parse / collect / toStrudel / round-trip. Every test passed. Wave-δ booted the dev server and `.p("kick")` immediately crashed with `TypeError: k.includes is not a function`. The IR side handled the source correctly; Strudel's transpiler rewrote `"kick"` to `mini("kick")` (a Pattern) BEFORE the runtime saw it. The IR tests had no visibility into that rewrite. Only the live canvas exposed the gap.
+
+**Confirmed by:** Wave-δ γ-7 gate run (2026-05-12). The bug was structurally invisible to unit tests; Playwright caught it on first run.
+
+**Test gate:** For every chain-method IR tag whose argument is a string OR can be transformed by Strudel's transpiler:
+1. Unit test the parser arm + collect arm + toStrudel arm (existing γ practice).
+2. ADD a Playwright spec that pastes the canonical user fixture into the live editor, evaluates it, and asserts the rendered DOM matches expectation.
+3. Capture `consoleErrors` and `pageerror` events. Any `TypeError` from the external runtime is a P62 candidate; investigate before merging.
+
+**Breaks when:** A new chain method ships with full IR test coverage but no Playwright probe, and the method's argument shape interacts with Strudel's transpiler (string literals, label statements, mini-notation, backticks, etc.). Crash or silent-drop surfaces in user reports, not CI.
+
+**REF:** Wave-δ summary `20-11-WAVE-δ-SUMMARY.md` "Why the wave finished green" §5; Playwright spec `packages/app/tests/wave-delta-gate.spec.ts`.
+
+---
+
+## PV45 — Yjs read paths are doc-write-free during React render
+
+**Claim:** Any Yjs sub-store accessor (`getX`, `subscribeToX`, `useX`) called from a React render or from a `useSyncExternalStore.getSnapshot` / `subscribe` callback MUST be doc-write-free. Lazy sub-store creation lives on the WRITE path only. Readers return a shared frozen sentinel when the sub-store doesn't exist yet.
+
+**Why:** A Y.Doc write during render triggers `observeDeep` callbacks; those callbacks fire `useSyncExternalStore` subscribers; subscribers re-evaluate `getSnapshot` (which might write again) and call `setState` on OTHER components mid-render of the originating component. React warns `Cannot update a component while rendering a different component`. In future React versions this becomes a hard error. Phase 20-11 wave-δ surfaced this via Playwright when MusicalTimeline → `getTrackMeta` → `ensureTrackMetaMap` wrote to the doc on first call per file.
+
+**Confirmed by:** F-4 fix commit `2ef4697` (2026-05-13). Splitting `ensureTrackMetaMap` into `getTrackMetaMap` (read-only) + `ensureTrackMetaMap` (write-allowed) eliminated the warning across all 5 Playwright wave-δ fixtures.
+
+**Test gate:** For every new `getX` / `subscribeToX` helper that accesses a lazily-created sub-store:
+1. Code review the body — does it call `parentMap.set(...)` on any branch? If yes, the path is write-capable and unsafe for render.
+2. Document the read-only contract in the function's JSDoc (`SAFE during React render`).
+3. Pair with an `ensureX` helper for the write path; route writers through it.
+4. The frozen sentinel returned for "doesn't exist yet" must be ref-stable across calls (allocating `{}` each read tears StrictMode).
+
+**Breaks when:** A new sub-store is added (e.g. `Y.Map<unknown>` keyed by some id) and the access helper lazily allocates on first read. Symptom: React warning on first cold-load of any file with the new sub-store. Won't show on subsequent renders (the map exists by then) — easy to dismiss as flaky if the dev never boots clean.
+
+**REF:** P63 (hetvabhasa) for the failure-mode catalogue; `WorkspaceFile.ts` `getTrackMetaMap` vs `ensureTrackMetaMap` split.
+
+---
+
+## PV46 — Transport-state accessors MUST gate on the engine's own play/stop state
+
+**Invariant:** any accessor exposed to React/UI for a "current playhead /
+cycle / time" value must short-circuit to `null` (or whatever the "no live
+transport" sentinel is) when the underlying engine reports
+`isPlayingState === false`. The accessor reads through to scheduler state
+only after that gate.
+
+**Why this matters:** consumers downstream wire transport-state edges
+(`null → number` = play start, `number → null` = stop). A scheduler that
+retains its last `.now()` value across stop (most engines do — Strudel's
+`@strudel/core` is one) breaks the edge entirely unless the accessor
+explicitly returns `null` on the stopped state.
+
+**Where it lives:** `packages/editor/src/workspace/runtime/LiveCodingRuntime.ts`
+`getCurrentCycle()` (and any sibling accessor that adds in the future). The
+gate is one `if (!this.isPlayingState) return null` at the top of the method.
+
+**Breaks when:** a new engine class is added without copying the gate;
+a new scheduler-state accessor is exposed without the gate; a refactor
+"simplifies" the gate away because the inner `Number.isFinite` looked
+sufficient.
+
+**Pre-mortem signal:** "edge feature works in jsdom (test sets state
+directly) but fails in browser" → suspect a missing engine-state gate.
+
+**REF:** P65 (hetvabhasa) for the failure mode; Phase 20-12.1 follow-up
+commit `667615d` for the fix; `LiveCodingRuntime.ts:641-650` for the
+current implementation.
+
+---
+
+## PV47 — Timeline slot identity is source-anchored, NOT display-derived
+
+**Invariant:** the MusicalTimeline slot map's KEY is anchored to a
+property of the source code that doesn't change when the user renames /
+relabels the row (`.p()` argument, color, collapsed flag, etc.). The
+display label is read from a separate field at render time and may
+freely change.
+
+The canonical anchor is `dollarPos` — the source character offset of
+the outermost `$:` Track wrapper. This offset is stable across:
+- Adding/removing `.p("name")` on the same line (only the body changes;
+  `$:` stays where it is).
+- Editing the body's expression (the `$:` token doesn't move; the
+  trailing content can change arbitrarily).
+- Commenting/uncommenting via the parser's empty-Track path (the line
+  itself stays in source; the `$:` token re-emerges at the same offset).
+
+**Why this matters:** before this invariant, the slot map was keyed by
+event `trackId`, which flips to the user's `.p()` name (inner-wins).
+Renaming a row → new trackId → new slot at the bottom → user sees their
+row "move". The user's mental model is "rename keeps position"; the slot
+map must enforce that.
+
+**Where it lives:**
+- Event field: `IREvent.dollarPos` (`packages/editor/src/ir/IREvent.ts`).
+- Threading: `collect.ts` Track arm — `dollarPos: ctx.dollarPos ?? ir.loc?.[0]?.start`
+  (OUTER-WINS, distinct from `trackId` which is inner-wins).
+- Slot derivation: `MusicalTimeline.tsx` `groupSlotKey()` and
+  `collectTopLevelSlots()` — `slotKey = "$" + dollarPos` if defined,
+  else fall back to trackId for hand-built/non-`$:` fixtures.
+
+**Breaks when:** future code uses `event.trackId` as a Map key for any
+state that should survive `.p()` renames (color, collapsed, layout,
+trackMeta Y.Doc, etc.). Such state is currently still keyed by
+display trackId — when the user reports "my color got reset after I
+added `.p()`", that's the next vyapti to enforce (re-key trackMeta
+on slotKey).
+
+**Pre-mortem signal:** a feature that "remembers" something per-row
+loses its memory when the user adds `.p("name")` → check if the
+identity used is slotKey or display trackId.
+
+**REF:** Phase 20-12.1 follow-up commit `109a9f8` (rename-in-place);
+`MusicalTimeline.tsx` `collectTopLevelSlots` + `groupSlotKey`. Pairs
+with P64 (slot retention class — adjacent neighbour).
+
+---
+
+## PV48 — Workspace packages exporting compiled `dist/` need watch-mode in dev
+
+**Invariant:** when developing against a workspace package (`@stave/editor`,
+any future split) whose `package.json` exports point to `./dist/*`, the
+package's build script must be running in watch mode (`tsup --watch`)
+during interactive iteration. Otherwise the app's HMR runs against the
+LAST-BUILT artifact, source edits are silently discarded by the runtime
+even though they're saved on disk.
+
+**Where it lives:** `packages/editor/package.json` `scripts.dev` =
+`tsup --watch`. Every workspace package with a dist export should have
+the equivalent.
+
+**Breaks when:** a contributor edits `packages/editor/src/...`, sees
+unit tests pass, refreshes the browser, sees old behaviour, and iterates
+on a hypothesis that doesn't match the running code. Hours burned.
+
+**Workflow enforcement:** the dev start-up command for the project should
+spawn BOTH the app dev server AND every workspace package's watch script.
+Today this is manual. Future fix: a root `pnpm dev` script that runs both
+in parallel (e.g. via `concurrently` or `turbo dev`).
+
+**Pre-mortem signal:** "I changed code in `packages/<name>/src/` and the
+browser shows old behaviour" → check if `pnpm --filter <name> dev` is
+running.
+
+**REF:** P66 (hetvabhasa); `feedback_viz_bugs.md` for prior occurrence.
+
+## PV49 — Strudel-source walkers must tolerate inter-element whitespace AND inline line-comments
+
+**Invariant:** every walker that scans Strudel source for a delimiter
+(method-chain `.`, comma-separated args, top-level statements, `$:`/label
+prefixes) must skip arbitrary whitespace INCLUDING newlines AND whole-line
+or trailing `// …` comments between elements. The upstream Strudel
+transpiler does (it's real JS); shared/community code is formatted on that
+assumption (one method per line, a `// label` before each `stack()` voice).
+A walker that only `.startsWith('.')` after a single `.trim()` silently
+truncates the chain at the first newline.
+
+**Span (≥3 modules — this is why it's a vyapti, not a one-off):**
+`applyChain` (fixed Phase 20-14 γ cluster-B), `stripParserPrelude` (built
+already tolerant), the `stack()`/comma arg-splitter (gap #137 — NOT yet
+tolerant), `extractTracks` label scan (gap #138). Same requirement, four
+call sites.
+
+**Breaks when:** a chain/arg/statement spans multiple physical lines or
+carries an interleaved `//` comment; the walker stops early; the tail of
+the expression vanishes into Code-fallback. Real-world incidence is high
+(Bakery stress test 2026-05-15: comment-between-stack-args was 1/10).
+
+**Implication for design:** extract ONE shared
+`skipWhitespaceAndLineComments(src, pos) → pos` primitive and route all
+four walkers through it. Do not hand-roll the skip per walker — divergent
+implementations are how `applyChain` ended up newline-intolerant while
+`stripParserPrelude` was tolerant. Offset arithmetic must stay additive
+(consumed prefix length adds to the element's base offset) so loc fidelity
+holds.
+
+**Out of scope of the invariant:** `${…}` template interpolation is real
+JS, not whitespace — Code-fallback is the correct behavior there, not a
+walker bug.
+
+**REF:** P67 (Code-discrimination — the same parser surface); Phase 20-15
+roadmap (the shared-walker substrate is α-wave); gaps #136/#137/#138;
+`packages/editor/src/ir/parseStrudel.ts` (`applyChain`,
+`stripParserPrelude`). Ground Truth: 20-14-γ-SUMMARY.md vyapti candidate.
+
+## PV50 — Per-evaluate engine-owned accumulators reset at `evaluate()` entry, top-of-function
+
+**Invariant:** any state the engine accumulates across one
+`evaluate()`/render pass (e.g. `lastAliasResolutions` from the Strategy-A
+alias intercept, Phase 20-14 β) MUST be (1) owned as an instance field on
+the engine — not module-global, not React state — and (2) reset as a
+top-of-function statement at `evaluate()` entry, NOT inside a helper the
+error path can skip.
+
+**Why instance-owned:** module-global leaks across engine instances /
+files / hot-reloads; React state can't be read synchronously from the
+audio callback. The accumulator is engine lifecycle state, so the engine
+owns it. Single source of truth.
+
+**Why top-of-function reset:** if the reset lives in a helper that runs
+mid-`evaluate()`, an eval-error path (parse throw, transpile throw) that
+returns before reaching the helper leaves the PREVIOUS pass's accumulator
+live. The next consumer (friendly-error builder, β-5) reads stale data
+and reports resolutions that didn't happen this pass. The reset must be
+unconditional and first.
+
+**Breaks when:** the accumulator is reset lazily / conditionally, or
+stored where a second instance or a render can see it. Detection: a
+per-pass diagnostic (alias hint, event count, timing) reports values from
+the WRONG pass after an eval error or instance switch.
+
+**REF:** PV45 (Yjs read paths doc-write-free during render — sibling
+"where does per-pass state live" invariant), β-2/β-5 of Phase 20-14;
+`packages/editor/src/engine/StrudelEngine.ts` (`wrappedOutput`,
+`lastAliasResolutions`, `evaluate()` entry). Ground Truth:
+20-14-β-SUMMARY.md.

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,545 @@
+# Roadmap: Stave (stave.live)
+
+## Overview
+
+Stave is a renderer-agnostic, engine-agnostic live coding platform delivered as an
+embeddable React component library (@stave/editor). The architecture decouples five
+independent islands — Language, Visualization, Synthesis, DAW, and Control — connected
+by an Entity-Component bus. Any engine, any viz renderer, any synth backend plugs in.
+
+Phases 1-6 shipped the foundation (Monaco, highlighting, 7 p5.js visualizers, VizRenderer
+abstraction, per-track data, inline zones). Phase 8 shipped the engine protocol (ECS
+components, LiveCodingEditor, multi-engine support). Phase 9 normalized the hap type
+across engines. Phase F shipped the Free Monad PatternIR with parsers, interpreters,
+and an ECS propagation engine. Phase 10 is in progress (error squiggles, completions,
+hover docs shipped; tokenizer remaining). Sonic Pi Web integration is on a feature branch
+with a working dual-engine demo.
+
+See THESIS_COMPLETE.md for the full platform vision.
+See SONIC_PI_WEB.md for the Sonic Pi browser engine thesis.
+See FULL_TRANSPARENCY.md for the provenance/attribution framework.
+See artifacts/stave/CLOSED-LOOP-PLAN.md for the substrate-progression plan from current state to closed-loop instrument.
+
+## Primary objective — fully fledged source-level debugger (PIVOT 2026-05-07)
+
+Stave's primary objective is a **fully fledged source-level debugger for
+Strudel**, modelled on DWARF / Chrome DevTools / MSVC PDB. The first
+production live-coding debugger with breakpoints, click-to-source on any
+program point, and faithful runtime ↔ source mapping. The
+`IR-DEBUGGER-NORTH-STAR.md` walkthrough is no longer a "read-only slice
+of a larger thesis" — it IS the v1 + v2 deliverable.
+
+**Why pivoted.** Bidirectional editing requires either full Strudel
+coverage or a Roslyn-style CST — both large, ongoing, fragile against
+Strudel upstream churn. Debugging requires a different (smaller)
+property set: every observable event carries source provenance; every
+runtime hap maps to an IR-node identity; the scheduler can pause on a
+condition. Standard practice (gdb on stripped libraries, sourcemaps on
+minified JS) does not require modelling the source language — only the
+debug-info channel needs to be honest. The coverage gap collapses when
+the IR wraps unmodelled fragments as opaque-but-loc-tagged regions.
+
+### v1 + v2 scope
+
+**v1 — Observation honest** (loc-completeness + opaque-fragment
+wrapper). Two phases (20-03 + 20-04). After v1: every typed character
+has a representation in the IR, every runtime event has a source
+range, every visual surface can highlight any program point. Audio
+still plays — the debugger has not yet learned to pause it.
+
+**v2 — Identity + breakpoints** (hap → IR-node identity channel +
+scheduler breakpoints). Two-to-three phases. After v2: gutter-click
+sets a breakpoint condition; scheduler pauses; inspector renders chain
+history at the pause point; user resumes.
+
+### Catalogue support
+
+- **PV36** — Loc-completeness (every IR node + every event carries `loc`; no transform may strip).
+- **PV37** — Unrecognised chain methods wrap as `Code`-with-loc, never silently drop.
+- **PV38** — Every observable hap maps to an IR-node identity.
+- **P33** — Silent-drop in `applyMethod`'s `default:` arm (the trap class fixed by PV37).
+- **PK13** — Source-level debugger projection lifecycle (parse → loc → collect → publish → run → match → render → break).
+- **PV29** — Long-range 5-axis substrate progression remains valid as vision; PV36-38 are the immediate ratchets.
+- **PV35** — Audience-classification gate (developer for IR Inspector chain view; musician for timeline / Monaco-highlight). Both consume the same identity channel (PV38).
+
+### Deferred (long-range vision; not deleted)
+
+| Phase | What | Why deferred |
+|---|---|---|
+| 19 (second half — bidirectional DAW) | Edit DAW → patch IR → re-emit code | Requires full coverage or CST. Both larger than the debugger needs. |
+| 20 (Transform Graph as **edit** surface) | React Flow node patcher; bypass/solo; bidirectional edit nodes → IR → code | Read-only Transform Graph survives as the "stack frames" view for the debugger; the *edit* direction is what's deferred. |
+| 22 (Audio Analysis + Vocals) | Audio → IR with provenance | Audio→IR is a separate substrate from source→IR. Debugger thesis works on source→IR first; audio→IR rejoins later. |
+| 23 (Layer 3 timbre / transparent AI) | Kernel/wavelet representation; normalizing flow synth | Pure synthesis substrate; orthogonal to debugging. |
+| Closed-loop milestone | Any sample → IR → code → audio with provenance | Emerges from 22 + 23 + bidirectional-edit, all deferred. |
+
+See `artifacts/stave/CLOSED-LOOP-PLAN.md` (status: deferred) for the
+long-range substrate vision; `artifacts/stave/IR-DEBUGGER-NORTH-STAR.md`
+(status: feature spec, promoted) for the active debugger contract;
+`memory/project_debugger_thesis.md` for the pivot context.
+
+## Substrate progression — long-range vision (deferred 2026-05-07)
+
+> The five-substrate framing below remains the long-range north-star.
+> Active prioritization is governed by the debugger primary-objective
+> section above. Read this section for "what unlocks once the debugger
+> ships," not for "what to plan next."
+
+Stave is not a sequencer plus a debugger; it is a sequencer where the debugger is
+built into the medium. The destination is **one IR with multiple views** —
+Code, DAW, Viz, Transform Graph, Sound — each editable, each kept honest by
+parity verification. The Ableton-class capability ("any sample → manipulate via
+code → reconstruct with full provenance") emerges once five substrates are
+honest:
+
+| Substrate | Means | Ratchet phase |
+|---|---|---|
+| **Code** is honest | parser models what users actually type, parity-verified | Tier 4 (19-03 ✓ + 19-04 ✓) + mini-notation finish |
+| **Stages** are honest | parser splits into named stages; bugs locate to the stage that introduced them | Phase C (parser decomposition) |
+| **Time** is honest | streaming timeline captures + replays past evals; temporal bugs become observable | Streaming timeline (Model B — partially shipped 19-08) |
+| **Observation** is honest *(was: Editing — narrowed for v1)* | every IR node carries source loc; every runtime event maps back to source | **Phase 20-03 + 20-04 (active)** |
+| **Editing** is honest *(deferred)* | every view is editable; edits round-trip through the IR | Bidirectional DAW (19 second half) + Transform Graph (Phase 20 edit surface) |
+| **Sound source** is honest *(deferred)* | audio→IR closed loop; samples carry provenance through transforms back to source | Audio Analysis + Vocals (Phase 22) + Layer 3 timbre (Phase 23) |
+
+When all six land, "Ableton replacement" is not a roadmap line item — it's the
+emergent capability of the substrate stack. See `artifacts/stave/CLOSED-LOOP-PLAN.md`
+for the detailed sequence, dependencies, decision points, and what unlocks where.
+
+## Phases
+
+**Phase Numbering:**
+- Integer phases (1, 2, 3): Planned milestone work
+- Decimal phases (2.1, 2.2): Urgent insertions (marked with INSERTED)
+- Hyphenated decimal phases (20-03, 20-04): Sub-phases within an existing phase number (e.g. debugger v1 within phase 20)
+
+**Status markers:**
+- `[x]` shipped, `[ ]` open, `[~]` deferred (long-range vision; not actively planned — see header for reason).
+
+Decimal phases appear between their surrounding integers in numeric order.
+
+- [x] **Phase 1: Active Highlighting** - Notes in the Monaco editor light up in sync with the audio scheduler (completed 2026-03-21)
+- [x] **Phase 2: Pianoroll Visualizers** - Rolling pianoroll canvas + inline view zones + toolbar layout wired (completed 2026-03-22)
+- [x] **Phase 3: Audio Visualizers** - Scope, FScope, Spectrum, Spiral, Pitchwheel, Wordfall canvas visualizers (completed 2026-03-22)
+- [x] **Phase 4: VizRenderer Abstraction** - Replace p5-coupled SketchFactory with renderer-agnostic VizRenderer interface (completed 2026-03-22)
+- [x] **Phase 5: Per-Track Data** - Expose per-track PatternSchedulers via monkey-patching Pattern.prototype.p (completed 2026-03-22)
+- [x] **Phase 6: Inline Zones via Abstraction** - Per-pattern .viz("name") opt-in replacing blanket inlinePianoroll prop (REPLANNED 2026-03-23) (completed 2026-03-22)
+- [x] **Phase 8: Engine Protocol** - ECS components, LiveCodingEngine, LiveCodingEditor, DemoEngine, VizDescriptor.requires[] filtering, engine-agnostic viewZones (completed 2026-03-25)
+- [x] **Phase 9: Normalized Hap Type** - NormalizedHap interface, engine-agnostic sketches and highlighting (completed 2026-03-25)
+- [x] **Phase F: Free Monad PatternIR** - PatternIR ADT (15 node types), parseMini, parseStrudel, collect/toStrudel interpreters, ECS propagation engine, StrudelEngine integration (completed 2026-03-28)
+- [ ] **Phase 7: Additional Renderers** - Canvas2D renderer, HydraEngine (visual LiveCodingEngine), Level 1 DAW timeline
+- [ ] **Phase 10: Monaco Intelligence** - Strudel tokenizer, completions, hover docs, error squiggles (10-01 + 10-02 shipped)
+- [x] **Phase 10.1: Viz Editor v0.1.0+** - Tab groups + splits (VS Code-style), multi-model Monaco, VizPreset/IndexedDB, vizCompiler (code→descriptor), hot reload, VizDropdown (grouped, replaces icon bar), preview modes (panel/inline/bg/pop-out), tab dragging between groups, resizable splits, bundled/user ID namespacing with auto-versioning. See artifacts/stave/VIZ-EDITOR-DESIGN.md. INSERTED. (merged via PR #2 on 2026-04-09)
+- [ ] **Phase 10.2: Workspace Shell Refactor** - Single-editor-per-view architecture (markdown-preview model). Split current StrudelEditor/LiveCodingEditor/VizEditor into uniform `EditorView` (Monaco only) + `PreviewView` (file-extension-aware, hot-reloads on change). Preview provider registry. WorkspaceAudioBus singleton (pattern previews publish, viz previews consume). Generic tab/group/split shell that holds any view. Removes per-group `previewMode` state — preview becomes a separate view opened via command. INSERTED 2026-04-08. See artifacts/stave/IDE-SHELL-DESIGN.md §1-3.
+- [ ] **Phase 10.3: IDE Shell** - MenuBar (File/Edit/View/Run/Preferences/Help with dropdowns), FileExplorer (left sidebar, tree view, context menu, drag-drop), VirtualFileSystem (IndexedDB-backed, generalizes VizPresetStore — files/folders/recent/rename/delete/import-export), CommandPalette (Cmd+K / Cmd+Shift+P fuzzy over all actions), StatusBar (BPM/errors/live-mode/active-engine), Settings dialog (themes/hotkeys), ProjectManifest (stave.project.json, .zip export). Built on top of 10.2's workspace shell. INSERTED 2026-04-08. See artifacts/stave/IDE-SHELL-DESIGN.md §4-7.
+- [ ] **Phase 11: Library Polish + Publish** - tsup build, README, publish @stave/editor to npm
+- [ ] **Phase 12: Synth Invariance** - SynthBackend interface, SuperSonicBackend, SuperdoughBackend, MidiBackend
+- [ ] **Phase 13: External Sync** - SyncComponent, LinkBridge (WebRTC), MidiInput
+- [ ] **Phase 14: Recording & Export** - Engine-agnostic Recorder, WAV export, stem export
+- [ ] **Phase 15: Provenance** - SessionLog, Ed25519 signing, WAV metadata embedding
+- [ ] **Phase 16: Collaboration** - Yjs CRDT + WebRTC, cursor presence, shared tempo via Link
+- [ ] **Phase 17: UI Bento Box** - Slider/knob/XY pad controls, MIDI CC mapping, slider() DSL
+- [ ] **Phase 18: Composr Integration** - Replace iframe with <StrudelEditor>, renderStems, per-stem export
+- [~] **Phase 19: Pattern IR pipeline (foundation shipped; bidirectional half DEFERRED 2026-05-07)** - Shipped: Pattern IR types (19-01 ✅), Pass Instrumentation v1 (19-02 ✅), Tier 4 first half — `jux`/`off`/`degrade`/`late`/`chunk`/`ply` (19-03 ✅, PR #69), Tier 4 second half — `layer`/`struct`/`swing`/`pick`/`shuffle`/`scramble`/`chop` (19-04 ✅, PR #73), `loc` + `userMethod` on non-Play tags (19-05 ✅), implicit-IR projection in Inspector (19-06 ✅), streaming timeline + capture buffer (19-07/08 ✅, PRs #86+#87). **Deferred (per debugger thesis 2026-05-07):** bidirectional DAW second half — IRNodeMeta provenance, Poly backward maps, DawVizRenderer interactive editing, BidirectionalBinding, code synthesis tiers, AudioRegion node. Reach after debugger v2 ships. See artifacts/stave/STAVE-STUDIO-DESIGN.md §5-6 (status: deferred), artifacts/stave/IR-TIER-4-FORCED-TAGS.md.
+- [x] **Phase 20-01 / 20-02: Musician Timeline (foundation)** - Bottom drawer + MusicalTimeline slice β shipped (PR #90 + #92, main e683315). Visual polish to Variant A mockup parity shipped (PR open as of 2026-05-07 — feat/musical-timeline-mockup-skin). Audience: musician (PV35-locked). The first user-facing surface that the debugger projection (PK13) renders to.
+- [ ] **Phase 20-03: Loc-completeness across IR (debugger v1 — first half)** — Every `applyMethod` arm constructs IR nodes with `loc` (via `tagMeta` or literal-shape — see PK12). Every collect arm propagates `loc` onto produced events. Click-to-source resolves for *any* event in the timeline / piano roll to its exact source range — including transforms, not just leaf Plays. The `feat/musical-timeline-mockup-skin` branch already carries 5 click-to-source commits (`cc19d5b`, `571898d`, `599826c`, `e71627e`, `eab49d5`) — these become the first slice (slice γ) of this phase, retroactively scoped here. Remaining: extend loc-attribution to all non-Play tag constructions; propagate through every collect arm uniformly; add review-time gap check ("does this construction call `tagMeta`?"). Closes G3 from the IR-vs-Strudel disparity catalog. Codified as **PV36** (loc-completeness contract). See `memory/project_debugger_thesis.md`, `artifacts/stave/IR-DEBUGGER-NORTH-STAR.md`.
+- [ ] **Phase 20-04: Opaque-fragment wrapper (debugger v1 — second half)** — `applyMethod`'s `default:` arm wraps the receiver as `Code`-with-loc node carrying the entire `.method(args)` call-site range and a back-pointer to the inner IR. `toStrudel` round-trips the wrapper verbatim. Inspector renders `[opaque: .release(0.3)]` with the inner IR still inspectable. Removes the silent-drop trap class for ~25 currently-unrecognised chain methods (`.s`, `.n`, `.note`, `.bank`, `.scale`, `.release`, `.attack`, `.sustain`, `.decay`, `.shape`, `.amp`, `.detune`, `.octave`, `.tremolo`, `.lfo`, `.legato`, `.unison`, `.coarse`, `.fine`, `.add`, `.sub`, `.mul`, `.div`, `.range`, `.outside`, `.inside`, `.zoom`, `.compress`). Closes K1/K2/K3 + B1 from the disparity catalog. Codified as **PV37** (wrap-never-drop) + **P33** (silent-drop trap class). After this phase: every typed character has a representation in the IR. The MLIR-opaque-op pattern applied to Strudel chains.
+- [ ] **── Debugger v1 milestone: every typed character has a representation in the IR; click-to-source resolves anywhere ──** (emerges from 20-03 + 20-04 landing together)
+- [ ] **Phase 20-05+: Debugger v2 (engine ↔ IR identity + scheduler breakpoints)** — Every NormalizedHap carries `irNodeId`; runtime → IR-node lookup is byte-stable across `query()` calls within a snapshot's lifetime (PV38). Live source-range highlighting on hap dispatch (Monaco highlights the exact `loc` range when audio plays — reverse direction of click-to-source). Gutter-click registers a breakpoint condition; scheduler pauses; inspector renders chain history at the pause point. Audio-pause UX needs design (silence on break vs hap-by-hap stepping with audio still flowing vs freeze-mode with last grain looping). Two-to-three sub-phases. After v2: stave is the first production live-coding source-level debugger. See `memory/project_debugger_thesis.md` v2 scope.
+- [ ] **Phase 20-10: Param-method promotion — close the silent-semantics gap (closes #108)** — Promote the issue #108 starter-set of chain methods (`s, n, note, gain, velocity, color, pan, speed, bank, scale`) from `Code`-with-via wrappers to a typed `Param` IR tag carrying `{ key; value: string | number | PatternIR; rawArgs; body; loc; userMethod }`. Mirrors 19-03/19-04 typed-method shape. The collect arm injects the resolved value into `ctx.params` before walking the body — `evt.s = "sawtooth"` after `.s("sawtooth")`. Pattern-arg form (`.s("<bd cp>")`) is in scope: inner mini parsed via `parseMini` into a sub-IR; collect queries the sub-IR at `ctx.time` for per-event resolution. `toStrudel` round-trips `.${userMethod}(${rawArgs})` byte-equal — same discipline as Code-with-via. Migrates existing FX-group arms for `gain/pan/speed` to the new tag (single source of truth). PV37 stays intact for the remainder of the silent-drop list (release/attack/sustain/decay/crush/distort/etc.) — those ship in a follow-up phase reusing this substrate. Codifies a NEW vyapti: "param-bearing chain methods MUST inject into ctx.params before projection" — pair with PV37 (PV37 = REPRESENTATION completeness; new = SEMANTICS completeness). After this phase: the user's fixture from #108 produces 7 distinct timeline tracks {sawtooth, sine, square, hh, bd, sd, cp}; Inspector chrome distinguishes Param (sample-bucket / track-defining) from FX (audio-effect chip) per PV35 musician audience. CONTEXT at `.planning/phases/20-musician-timeline/20-10-CONTEXT.md`. Three waves: α parser+collect+IR shape, β toStrudel+Inspector chrome+pattern-arg sub-IR, γ end-to-end fixture + round-trip + chrome snapshot. See issue #108, `memory/project_phase_20_musician_timeline.md` "Architecture notes for the #108 fix".
+- [ ] **Phase 20-11: Track substrate — `$:` → trackId + palette of 32** — Auto-assign `evt.trackId` from `$:` position in the parser (`d1`, `d2`, ... or `.p("name")` if user-typed). `groupEventsByTrack` already prefers `trackId` over `s` (groupEventsByTrack.ts:41); the parser just doesn't populate it today. Two `$:` blocks with identical samples render as two distinct rows (closes the duplicate-`$:`-collapse bug surfaced in 20-10 γ-4). Track color from palette of 32 (Ableton-16, Logic-16, Reaper-unbounded — 32 is the sweet spot). Foundational for 20-12 chrome work. CONTEXT in `.planning/phases/20-musician-timeline/20-11-DESIGN-DEBATE.md`.
+- [ ] **Phase 20-12: Track chrome — collapsible rows, no bar labels, opacity=velocity, Y=pitch** — Replace evt.s-keyed bucketing with proper track chrome. Collapsible rows (collapsed = one glued row; expanded = sub-rows per stack-arg voice; Ableton group-track + drum-rack model). NO labels on bars (12px-wide bars at typical zoom can't fit text); identity via row header (left rail), row color (track-derived), bar opacity (velocity/gain), bar Y position (pitch for melodic voices), hover tooltip (full chain). Strudel's musical primitives — `s`, `note`, `n`, `freq`, `chord` — all participate; melodic voices use Y-as-pitch within a sub-row, not multiple sub-rows-per-pitch. Depends on 20-11. Open questions parked in DESIGN-DEBATE.md (custom-color persistence, collapsed-state persistence, silent-prefix rendering verify). **STATUS 2026-05-10:** chrome SHIPPED LOCAL on `feat/20-12-track-chrome` (17 commits, head 25af931). All 6 D-* decisions verified — PV41 5-channel contract codified, P54 label-trap + P55 popover-order codified. Editor 1515 / App 277. Gated on manual γ-5 visual gate + 20-10 → 20-11 → 20-12 PR sequence. See `20-12-SUMMARY.md`.
+- [ ] **Phase 20-12.1: Pause-resets slot map (INSERTED 2026-05-13)** — Fix the F-1 misdiagnosis surfaced post-merge of #117/#118: the "empty `d2` ghost row with faded label" symptom that F-1 attributed to `extractTracks` is actually `MusicalTimeline.tsx:561` + `stableTrackOrder.ts` retaining the slot of a disappeared trackId across re-evals (D-04 design — Trap 5 fix from Phase 20-01). The current rule "every disappeared trackId stays reserved forever (until file switch)" is right for the A/B audition workflow (comment a `$:` to compare, uncomment to restore row order) but wrong for permanent removal (no clean way to release ghost rows without switching files). Proposed UX rule: **ghost rows persist only during live hot-reload (transport playing); transport stop clears the slot map so the next play snaps to the current IR's tracks.** One-file behavior change to MusicalTimeline.tsx (add a second reset trigger keyed on playing→stopped edge alongside the existing source-change reset at line 554) + amended D-04 catalogue entry + 3 new stableTrackOrder/MusicalTimeline tests covering: (a) stop→play with same IR yields same order, (b) stop→play after commenting `$:` drops the ghost row, (c) hot-reload while playing keeps the ghost row (D-04 unchanged for the audition case). Depends on 20-12. Anticipated traps: P52 (mount-path — does the transport-state seam exist in `props.getHapStream()` / a sibling accessor, or does it need to be added?), P63 (Y.Doc writes during render — slotMap reset must not write to Y.Doc, only to the local ref). See `.planning/phases/20-musician-timeline/FOLLOWUPS.md#F-1` for the original (misdiagnosed) finding and the observation-driven reframe.
+- [ ] **Phase 20-14: Strudel.cc parity (eval-scope mirror + sample/alias layer) (issue #110)** — Any program that runs on strudel.cc/bakery should run on stave with the same audible + visual result. Mirror upstream's REPL bootstrap (read `tidalcycles/strudel` website/src/repl/ init, enumerate every `evalScope` / `samples` / `register*()` call), copy into `StrudelEngine.init()` with config-gated tiers (audio-pure default; Csound / MIDI / OSC opt-in). Add alias layer (`s("piano") → gm_piano`, `s("kick") → bd`) so bare names resolve to registered GM soundfonts. Pin with parity smoke test (10-20 canonical strudel.cc examples → assert IR shape + bar count + event count match). Discovery context: 20-12 manual-gate found `s("piano")` fails because GM names are `gm_*`-prefixed and Dirt-Samples has no `piano` folder. Three waves anticipated: α bootstrap mirror + tier flags, β alias layer + soundMap wrapper, γ parity smoke test corpus + CI gate. Out of scope v1: Bakery UI (sample-pack sharing), Csound bundle by default. **STATUS 2026-05-15:** α/β/γ all SHIPPED LOCAL as stacked PRs #123 → #131 → #133 (closes #110 at γ merge). Upstream moved GitHub→Codeberg (`uzu/strudel` @ SHA `f73b3956`). α loaded the missing manifests + `Pattern.prototype.piano` + 8-flag tier schema; β added the 30-entry hand-curated alias layer + Strategy-A intercept + tier UI (MIDI live, 7 scaffolded → follow-ups #124–#130) + friendly-error integration; γ vendored a 16-tune structural-parity corpus + CI gate + `pnpm parity:refresh`. γ surfaced + fixed 3 parser gaps (prelude strip, bare-string-as-pattern, multi-line chains) → 15/16 corpus tunes now structured (was 0/16). Residual: arpoon recursive-args (#132). See `20-14-{CONTEXT,RESEARCH,PLAN,α/β/γ-SUMMARY}.md`, issue #110.
+
+- [ ] **Phase 20-15: Strudel.cc parity hardening — close the 5 real-world Bakery gaps + recursive args** — A 2026-05-15 stress test of 10 live patterns from strudel.cc's Bakery (Supabase `code_v1` backend) measured **4/10 structurally parsed** — far below the curated corpus's 15/16, because real community code is messier than canonical examples. The misses decomposed into 5 named, reproducible parser-gap classes plus the deferred recursive-args gap from 20-14. This phase closes them. **Gaps:** G1 top-level `let`/`const` bindings + variable references (#134, 2/10, highest frequency, hardest — needs a mini symbol table / inline expansion); G2 `setcpm` and the `set*` family missing from `stripParserPrelude`'s skip set (#135, trivial ~1-line + the α-6 settingPatterns audit as authoritative source); G3 backtick template-literal string args incl. multi-line mini-notation (#136, root-matcher + bare-string arm, `${}`-interpolation → graceful fallback); G4 comment-only lines between `stack()` args (#137, arg-splitter doesn't strip interior `//` lines); G5 named-label `name: pattern` syntax (#138, generalize `extractTracks`'s `$:` regex with `:`-ambiguity false-positive guards — wires named tracks directly into the PR #116/#119 trackId/slot substrate); plus #132 recursive parsing inside `note`/`n`/`s` args (nested mini-with-chain — the arpoon residual). **Three waves:** α cheap-wins + shared substrate (G2 skip-set; extract a shared `skipWhitespaceAndLineComments(src,pos)` walker used by prelude + chain + arg-splitter per the γ-SUMMARY vyapti candidate; G4 consumes it); β root-matcher extensions (G3 backtick + #132 recursive args — same `parseRoot` surface, bundle); γ statement-level (G5 named labels via generalized `extractTracks` + false-positive matrix; G1 binding map + inline expansion — hardest, last). **Verification:** promote the 10-pattern Bakery probe to a permanent regression corpus subset (the 6 failing fixtures vendored alongside the 16 canonical tunes); target ≥9/10 structured; all existing 15/16 + corpus snapshots unchanged. **Out of scope:** template-literal `${}` interpolation evaluation (real JS — Code-fallback is correct), function/arrow-fn bindings, destructuring binds, a full JS parser (the structural matcher stays a matcher). **Inheritable substrate:** the shared whitespace/comment walker (3 existing callers + future splitArgs-style walkers); the binding map (reusable by any future "resolve references" / macro-expansion feature); named-label→trackId wiring (the timeline most wants this — label IS the track name, no `.p()` needed). Depends on 20-14 (α/β/γ merged — builds directly on the prelude/bare-string/chain parser work). See issues #132, #134, #135, #136, #137, #138 + the 2026-05-15 Bakery stress-test note in `memory/project_phase_20_musician_timeline.md`.
+
+- [~] **Phase 20-13: Structure view as toggle (bundled-cycles overview) — DEFERRED 2026-05-09 (speculative)** — Alt view mode that collapses identical consecutive cycles into bundled cells with "cycle X/N" counter tags. Trackers (Renoise pattern matrix) precedent. Default stays Cycle view (linear, live-coding native); Structure view is a toggle for song-overview / composition review. Only collapses where bundling helps — `degrade()`/`shuffle()`/`scramble()`/`sometimes()`/`rand()` produce unique cycles every cycle and render linearly within Structure view automatically. GLOBAL alignment (bundle boundaries = where ANY track changes; not per-row). Mechanics: cycle hash via JSON-stringify after sort, look-ahead N cycles (default 10), scrub-within-bundle advances counter. Out of scope: arrangement-view semantics (drag clips to absolute bars) — Strudel has no absolute-time placement primitive; that's a separate much-larger product question. Status: speculative; ship only on clear demand. CONTEXT in DESIGN-DEBATE.md.
+- [ ] **Phase 20-09: Bake-and-scrub — scrub becomes real seek** — Replace 20-08's preview-only scrub (release snaps the playhead back to the engine's pre-scrub cycle because cyclist exposes no seek-on-resume API per S1) with sample-accurate seek over a pre-rendered audio buffer. After Effects RAM-preview model: bake the active pattern over an N-cycle window via WebAudio's `OfflineAudioContext`, cache the resulting `AudioBuffer` keyed on `(effective-pattern-hash, cycle-range, sampleRate, sample-set-hash)`, and route the 20-08 scrub release path to an `AudioBufferSourceNode.start(when, drop-offset)`. Drop position becomes the actual playback position. Three waves (mirrors 20-08's α/β/γ): α offline-render path (`bakePattern(pattern, cycleRange, sampleRate) → Promise<AudioBuffer>`, no UI, deterministic per RNG-chain seed); β release-path fork (fresh bake → buffer source; stale → fall back to 20-08 preview-only; staleness indicator on timeline); γ live-mode handoff state machine (`live | baking | scrubbing | resuming`). Anticipated trap classes: P11 re-application (AudioWorklet portability to OfflineAudioContext), T13 (state machine via refs not deps), P52 (mount-path: AudioBufferSourceNode mounts on LIVE AudioContext, not offline one — direct-observation gate before commit), new candidate (deterministic seeded RNG per cycle position so two bakes produce identical buffers, per `feedback_strudel_rng_chain.md`). Out of scope v1: sliding-window continuous bake, export-to-wav (the bake produces an AudioBuffer that COULD be encoded — defer), bake-while-editing, cross-pattern transitions. Inheritable substrate: `bakePattern()` is reusable by export-to-wav / A/B audition / offline analysis (axis 5d roadmap); the transport-mode state machine is the substrate any future "loop this cycle" / "audition before commit" feature builds on. Depends on 20-08, Phase 7 (AudioWorklet), Phase F (PatternIR cache key).
+- [~] **Phase 20 (Transform Graph as edit surface) — DEFERRED 2026-05-07** - React Flow node patcher (visual free monad), bypass/solo toggles, bidirectional (edit nodes → IR → code). The read-only Transform Graph survives as the **chain-history "stack frames"** view for the debugger; the *edit* direction is what's deferred. See STAVE-STUDIO-DESIGN.md §4.
+- [ ] **Phase 21: Indian Classical** - Tala Circle VizRenderer, bol notation, tihai verification, layakari via fast() slider
+- [~] **Phase 22: Audio Analysis + Vocals — DEFERRED 2026-05-07** - Audio→IR with provenance. Re-enters after debugger v2 ships. Originally the upstream half of the Ableton-replacement loop. See STAVE-STUDIO-DESIGN.md §6-7 (status: deferred), artifacts/stave/CLOSED-LOOP-PLAN.md (status: deferred).
+- [~] **Phase 23: Transparent AI / Layer 3 timbre — DEFERRED 2026-05-07** - Kernel/wavelet representation; normalizing flow synth; training-data attribution. Pure synthesis substrate; orthogonal to debugging. Re-enters after debugger ships. See STAVE-STUDIO-DESIGN.md §3, artifacts/stave/CLOSED-LOOP-PLAN.md (status: deferred).
+
+- [~] **── Closed-loop milestone: any sample → IR → code → audio with provenance ── DEFERRED 2026-05-07** (emerges from 19 second half + 20 edit + 22 + 23, all deferred until debugger v2 ships)
+
+## Phase Details
+
+### Phase 1: Active Highlighting
+**Goal**: Characters in the Monaco editor that generated a playing note are visually highlighted at the exact moment audio plays, and clear when the note ends.
+**Depends on**: Nothing (HapStream already implemented)
+**Requirements**: HIGH-01, HIGH-02, HIGH-03, HIGH-04, HIGH-05
+**Success Criteria** (what must be TRUE):
+  1. Playing a Strudel pattern causes the source characters to glow with accent-colored background and outline in Monaco
+  2. The highlight fires at the exact moment the corresponding audio plays (not when the note is scheduled ahead of time)
+  3. The highlight clears automatically when the note's audio duration expires
+  4. Multiple simultaneous notes (chords) each get independent highlight and clear cycles without interfering
+  5. The decoration uses CSS class `strudel-active-hap` with the correct design token colors from tokens.ts
+**Plans:** 2/2 plans complete
+Plans:
+- [x] 01-01-PLAN.md — useHighlighting hook + tests + CSS fix
+- [x] 01-02-PLAN.md — Wire hook into StrudelEditor + visual verification
+
+### Phase 2: Pianoroll Visualizers
+**Goal**: Users can see a rolling pianoroll displaying all playing notes in real time, both as a full panel below the editor and inline beneath individual pattern lines, with a toolbar that controls layout and visualizer selection.
+**Depends on**: Phase 1
+**Requirements**: PIANO-01, PIANO-02, PIANO-03, PIANO-04, PIANO-05, PIANO-06, PIANO-07, UI-01, UI-02, UI-03, UI-04
+**Success Criteria** (what must be TRUE):
+  1. A full-panel pianoroll renders at 60fps with a 6-second rolling window, note blocks colored by instrument type
+  2. Percussion sounds (bd, sd, hh, etc.) appear at fixed positions below the pitch area; pitched notes span MIDI 24-96 on the Y-axis
+  3. An inline pianoroll appears as a Monaco view zone below each `$:` line and re-appears after every evaluate() call
+  4. The VizPicker toolbar lets the user switch between visualizer modes (pianoroll, scope, spectrum, spiral, pitchwheel)
+  5. The layout follows spec: toolbar (40px) + viz-picker (32px) + editor + visualizer panel; vizHeight and showToolbar props work correctly
+**Plans:** 3/3 plans complete
+Plans:
+- [x] 02-01-PLAN.md — Install p5, types, useP5Sketch hook, PianorollSketch factory + stubs
+- [x] 02-02-PLAN.md — VizPanel + VizPicker React components
+- [x] 02-03-PLAN.md — StrudelEditor wiring, inline view zones, visual verification
+
+### Phase 3: Audio Visualizers
+**Goal**: Users can see real-time audio analysis visualizations — oscilloscope, frequency spectrum, waterfall spectrogram, spiral, pitchwheel, and wordfall — all driven by the live AnalyserNode and PatternScheduler.
+**Depends on**: Phase 2
+**Requirements**: VIZ-01, VIZ-02, VIZ-03, VIZ-04, VIZ-05, VIZ-06
+**Success Criteria** (what must be TRUE):
+  1. The Scope visualizer renders a stable time-domain waveform from the AnalyserNode at 60fps, triggered at zero-crossings
+  2. The FScope visualizer renders frequency bars at 60fps with symmetric layout
+  3. The Spectrum visualizer renders scrolling waterfall with log-frequency Y axis
+  4. The Spiral visualizer maps note events to positions on a rotating cycle-based spiral
+  5. The Pitchwheel visualizer shows 12 pitch classes on a circle, with active notes glowing
+  6. The Wordfall visualizer shows vertical pianoroll with note labels
+**Plans:** Completed outside GSD (all 7 sketches implemented in session 2026-03-22)
+
+### Phase 4: VizRenderer Abstraction
+**Goal**: Replace the p5-coupled SketchFactory type with a renderer-agnostic VizRenderer interface. Wrap all 7 existing p5 sketches in a P5VizRenderer adapter. Export VizDescriptor system for extensibility. Zero behavioral change — all existing viz modes work through the new interface.
+**Depends on**: Phase 3
+**Requirements**: REND-01, REND-02, REND-03, REND-04, REND-05, REND-06, REND-07
+**Success Criteria** (what must be TRUE):
+  1. VizRenderer interface exists with mount/resize/pause/resume/destroy methods
+  2. P5VizRenderer adapter wraps all 7 existing SketchFactory sketches without behavioral change
+  3. VizDescriptor type drives VizPicker as a data-driven dropdown (not hardcoded tab bar)
+  4. DEFAULT_VIZ_DESCRIPTORS exported — devs spread and extend without source edits
+  5. StrudelEditorProps uses vizDescriptors/vizRenderer instead of vizSketch
+  6. useVizRenderer hook replaces useP5Sketch with renderer-agnostic lifecycle
+  7. mountVizRenderer shared utility works for both VizPanel and viewZones
+**Plans:** 2/2 plans complete
+Plans:
+- [x] 04-01-PLAN.md — Source refactor: types, P5VizRenderer, mountVizRenderer, useVizRenderer, defaultDescriptors, VizPanel, VizPicker, viewZones, StrudelEditor, index.ts
+- [x] 04-02-PLAN.md — Test migration: create P5VizRenderer/useVizRenderer/defaultDescriptors tests, migrate VizPanel/VizPicker/viewZones tests
+**Canonical refs**: THESIS.md (Section 3-4), memory/project_viz_renderer_plan.md
+
+### Phase 5: Per-Track Data
+**Goal**: Expose per-track PatternSchedulers from StrudelEngine by capturing patterns during evaluate via monkey-patching Pattern.prototype.p. Each $: block gets its own scheduler that queries its Pattern directly via queryArc.
+**Depends on**: Phase 4
+**Requirements**: TRACK-01, TRACK-02, TRACK-03, TRACK-04
+**Success Criteria** (what must be TRUE):
+  1. StrudelEngine.getTrackSchedulers() returns Map<string, PatternScheduler> after evaluate
+  2. Each track scheduler queries its own Pattern directly (no hap filtering)
+  3. Pattern.prototype.p is always restored in finally block, even on error
+  4. Anonymous $: patterns get keys "$0", "$1" etc; named patterns get literal name
+**Plans:** 1/1 plans complete
+Plans:
+- [x] 05-01-PLAN.md — TDD: getTrackSchedulers() with setter-intercept pattern capture
+
+### Phase 6: Inline Zones via Abstraction (REPLANNED)
+**Goal**: Replace the blanket `inlinePianoroll` prop with per-pattern `.viz("name")` opt-in. Register `.viz()` on Pattern.prototype during evaluate(), capture viz requests per track, and refactor viewZones.ts to create zones only for opted-in patterns with the correct viz type resolved from VizDescriptor[].
+**Depends on**: Phase 4, Phase 5
+**Requirements**: ZONE-01, ZONE-02, ZONE-03, ZONE-04
+**Success Criteria** (what must be TRUE):
+  1. `.viz("pianoroll")` chained on a pattern causes an inline zone with pianoroll to appear after that pattern's block
+  2. Patterns without `.viz()` get no inline zone
+  3. Any viz type from DEFAULT_VIZ_DESCRIPTORS works (e.g. `.viz("scope")`, `.viz("spectrum")`)
+  4. Zone appears after the LAST LINE of the pattern block (not after the `$:` line)
+  5. InlineZoneHandle pause/resume lifecycle works (pause on stop, resume on play)
+  6. `inlinePianoroll` prop removed from StrudelEditorProps
+**Plans:** 2/2 plans complete
+Plans:
+- [x] 06-01-PLAN.md — Register .viz() capture in StrudelEngine + refactor viewZones.ts to opt-in + update tests
+- [x] 06-02-PLAN.md — Wire StrudelEditor with vizRequests, remove inlinePianoroll prop, visual verification
+
+### Phase 7: Additional Renderers + Hydra Engine
+**Goal**: HydraEngine (proves visual component), Canvas2D renderer (lightweight), Level 1 DAW timeline (read-only, requires queryable).
+**Depends on**: Phase 8
+**Success Criteria** (what must be TRUE):
+  1. HydraEngine implements LiveCodingEngine with visual component (canvas passthrough)
+  2. VizPicker disables all audio/streaming viz for Hydra, shows "Hydra Output" only
+  3. Canvas2DVizRenderer renders basic pianoroll without p5 dependency
+  4. Level 1 DAW VizRenderer: multi-track timeline, playhead, zoom, requires: ['queryable']
+**Plans:** TBD
+
+### Phase 8: Engine Protocol (COMPLETE — 2026-03-25)
+**Goal**: Define the LiveCodingEngine interface with Entity-Component architecture. Refactor StrudelEngine. Create LiveCodingEditor. Build DemoEngine. Make inline viz engine-agnostic.
+**Depends on**: Phase 5
+**Success Criteria** (all TRUE):
+  1. LiveCodingEngine interface with 5 core methods + ECS components bag
+  2. StrudelEngine implements LiveCodingEngine without behavioral change
+  3. LiveCodingEditor accepts engine prop (not hardcoded to Strudel)
+  4. StrudelEditor is thin wrapper around LiveCodingEditor
+  5. DemoEngine proves interface with streaming + audio + inlineViz (no queryable)
+  6. VizRenderer.mount() accepts Partial<EngineComponents> (component bag)
+  7. VizDescriptor.requires[] filters VizPicker by available components
+  8. viewZones.ts is engine-agnostic (reads inlineViz component, no $: scanning)
+  9. All 140 tests pass, conformance suite added
+**Plans:** 3/3 plans complete (08-01, 08-02, 08-03)
+Plans:
+- [x] 08-01-PLAN.md — LiveCodingEngine interface + StrudelEngine conformance + LiveCodingEditor + StrudelEditor wrapper + exports (5 tasks)
+- [x] 08-02-PLAN.md — VizRenderer component bag + VizDescriptor.requires[] + VizPicker filtering + engine-agnostic viewZones + tests (7 tasks)
+- [x] 08-03-PLAN.md — DemoEngine + conformance tests + integration verification (4 tasks)
+
+**Also shipped (unplanned, on feat/sonic-pi-engine branch):**
+- SonicPiEngine adapter wrapping sonicPiWeb (streaming + audio + inlineViz)
+- Dual-engine demo app (Strudel ↔ Sonic Pi tabs)
+- viz :scope DSL parsing in adapter (stripped before engine sees it)
+- SuperSonic loaded via bundler-proof dynamic import from CDN
+
+### Phase 9: Normalized Hap Type
+**Goal**: Define a normalized Hap interface that engines map their native events to. Viz layer and highlighting become truly engine-agnostic — sketches and active highlighting work with any engine's events without modification.
+**Depends on**: Phase 8
+**Requirements**: HAP-01, HAP-02, HAP-03, HAP-04, HAP-05
+**Success Criteria** (what must be TRUE):
+  1. NormalizedHap interface defined (begin, end, endClipped, note, freq, s, gain, velocity, color) and exported from index.ts
+  2. StrudelEngine maps Strudel haps to NormalizedHap via normalizeStrudelHap() in PatternScheduler.query()
+  3. All 4 queryable sketches (Pianoroll, Spiral, Pitchwheel, Wordfall) consume NormalizedHap — no raw Strudel hap access
+  4. HapStream.emitEvent(event: HapEvent) added — engines emit HapEvents directly without constructing Strudel-specific hap objects. Legacy emit() preserved for backward compat. HapEvent.hap made optional.
+  5. DemoEngine and SonicPiEngine adapter use emitEvent() directly — no fake Strudel hap construction
+**Plans:** 3 plans
+Plans:
+- [x] 09-01-PLAN.md — NormalizedHap type + normalize function + PatternScheduler contract + StrudelEngine wrappers + index.ts export (5 tasks)
+- [x] 09-02-PLAN.md — Migrate all 4 queryable sketches to consume NormalizedHap (5 tasks)
+- [x] 09-03-PLAN.md — HapStream.emitEvent() + HapEvent cleanup + DemoEngine/SonicPiAdapter updates (4 tasks)
+
+### Phase F: Free Monad PatternIR (COMPLETE — 2026-03-28)
+**Goal**: Ship a universal Pattern IR based on free monads — a tree ADT with 15 node types, parsers for mini-notation and Strudel code, interpreters (collect → IREvent[], toStrudel → code string), JSON serialization, and an ECS propagation engine wired into StrudelEngine.
+**Depends on**: Phase 8
+**Success Criteria** (all TRUE):
+  1. PatternIR ADT with 15 node types (Pure/Seq/Stack/Play/Sleep/Choice/Every/Cycle/When/FX/Ramp/Fast/Slow/Loop/Code) and IR.* smart constructors
+  2. collect interpreter walks the tree → IREvent[] with time accumulation, multiplicative speed, FX/Ramp param override
+  3. toStrudel interpreter produces idiomatic Strudel code (mini-notation collapse, stack indentation, method chains)
+  4. JSON round-trip serialization with schema versioning (patternir/1.0)
+  5. parseMini: recursive descent for mini-notation (sequences, rests, cycles, sub-sequences, repeat, sometimes)
+  6. parseStrudel: structural matcher for Strudel code (note/s/stack, $: syntax, method chain walking, Code fallback)
+  7. ECS propagation engine: ComponentBag, System interface with strata, propagate() with stratum ordering
+  8. StrudelEngine.evaluate() runs propagation, exposes ir component on EngineComponents
+  9. 110+ new tests, 281 total passing
+**Plans:** 2/2 plans complete
+Plans:
+- [x] F-01-PLAN.md — PatternIR ADT, collect/toStrudel interpreters, JSON serialization, 77 tests
+- [x] F-02-PLAN.md — parseMini, parseStrudel, propagation engine, StrudelEngine integration, 33 integration tests
+
+### Phase 10: Monaco Intelligence (IN PROGRESS)
+**Goal**: The Monaco editor understands Strudel code — syntax elements get distinct colors, users get completions for functions and note names, hovering a function shows docs, and evaluation errors appear as red squiggles.
+**Depends on**: Phase 4
+**Requirements**: MON-01, MON-02, MON-03, MON-04, MON-05, MON-06, MON-07, MON-08, MON-09
+**Success Criteria** (what must be TRUE):
+  1. Strudel functions (note, s, gain, stack, every, jux, fast, slow, etc.) are highlighted in blue; note names in green; mini-notation operators distinctly colored
+  2. Typing a dot after a pattern value shows a completion list of all chainable Strudel functions with their signatures
+  3. Inside `note("...")` or `s("...")`, completions offer context-appropriate values (note names, oscillator types, percussion names)
+  4. After an evaluate() error, the error location is underlined with red squiggles in Monaco; hovering shows the message
+  5. Hovering a Strudel function name shows a documentation popup with the function signature and an example
+**Plans:** 2/TBD plans complete
+Plans:
+- [x] 10-01 — Eval error squiggles via setModelMarkers
+- [x] 10-02 — Dot completions, note completions, hover docs
+- [ ] 10-03 — Strudel tokenizer / syntax highlighting (TBD)
+
+### Phase 10.1: Viz Editor v0.1.0+ (COMPLETED 2026-04-08)
+**Goal**: Users can author custom visualizations (Hydra shaders, p5 sketches) in a dedicated editor with hot-reload preview, save them to local storage, and reference them by name from pattern code via `.viz("name")`.
+**Depends on**: Phase 4 (VizRenderer abstraction), Phase 8 (engine protocol)
+**Branch**: feat/viz-mode-renderer-convention
+**Success Criteria** (what is TRUE):
+  1. `VizPreset` type + `VizPresetStore` (IndexedDB) — CRUD for user-authored viz presets
+  2. `vizCompiler` compiles code strings → `VizDescriptor` for both hydra and p5 renderers (uses `new Function()` for dynamic eval)
+  3. `VizDropdown` replaces icon-bar `VizPicker` — grouped by renderer, custom presets marked with star, "+ New Viz" entry
+  4. `VizEditor` component with multi-tab Monaco (one model per tab), hydra/p5 syntax highlighting, Ctrl+S save
+  5. N-group split layout via zero-dependency `SplitPane` (resizable dividers, min-size clamping)
+  6. Tab dragging between groups via HTML5 DnD (drop zones outline accent color)
+  7. Four preview modes per group: panel (40% side), inline (150px below), background (canvas behind transparent editor), popout (separate browser window with audio bridge via `usePopoutPreview`)
+  8. Hot reload pipeline: code change → 300ms debounce → recompile → re-mount renderer with current audio components
+  9. User presets seeded into pattern editor descriptor list at app startup (merged with `DEFAULT_VIZ_DESCRIPTORS`)
+  10. Theme tokens applied via `applyTheme()` on container ref (CSS variables resolve correctly when used standalone)
+**Files shipped**: `vizPreset.ts`, `vizCompiler.ts`, `VizDropdown.tsx`, `VizEditor.tsx`, `editor/SplitPane.tsx`, `editor/EditorGroup.tsx`, `editor/PopoutPreview.tsx`, `editor/vizEditorTypes.ts`. LiveCodingEditor wired to merge user descriptors.
+**Lessons (catalogue updates)**:
+  - hetvabhasa: P6 (CSS variables undefined when standalone — must `applyTheme()` on container)
+  - hetvabhasa: P7 (preview shows only background when no scheduler — preview code must have a "demo mode" fallback)
+  - krama: PK5 (viz hot-reload lifecycle — debounce → compile → destroy → mount)
+
+### Phase 10.2: Workspace Shell Refactor (NEXT — INSERTED 2026-04-08)
+**Goal**: Refactor `StrudelEditor`, `LiveCodingEditor`, and `VizEditor` into a uniform single-editor-per-view architecture (markdown-preview model). One workspace shell holds any kind of view; previews are independent views opened via command, not state inside an editor group.
+**Depends on**: Phase 10.1
+**Why**: The current 3-component split (StrudelEditor / LiveCodingEditor / VizEditor) has duplicated tab/preview logic, can't compose (e.g., "edit pattern A while previewing viz B"), and won't accept a menu bar / file explorer cleanly. The refactor unifies them along the seam VS Code already validates: editors are pure code views, previews are first-class sibling views.
+**Success Criteria**:
+  1. `EditorView` component — Monaco only, language-aware (strudel, sonicpi, hydra, p5js, markdown). No embedded preview, no audio engine wiring.
+  2. `PreviewView` component — file-extension-aware. Renders the right preview for the active file via a `PreviewProviderRegistry`.
+  3. `PreviewProvider` registry: `{ extensions, label, render }` entries. Built-in providers: `STRUDEL_RUNTIME`, `SONICPI_RUNTIME`, `HYDRA_VIZ`, `P5_VIZ`, `MARKDOWN_HTML`.
+  4. `WorkspaceShell` — generic tab/group/split layout (refactored from current `EditorGroup`/`SplitPane`). Holds any view, not just viz tabs. Tab drag-and-drop works between any views.
+  5. `WorkspaceAudioBus` singleton — pattern preview views publish `{ hapStream, analyser, scheduler }` when running; viz preview views consume the latest published bus.
+  6. Commands wired: "Open Preview to Side" (Cmd+K V), "Toggle Background Preview" (Cmd+K B), "Open Preview in New Window" (Cmd+K W).
+  7. Existing `StrudelEditor` / `LiveCodingEditor` / `VizEditor` exports preserved as thin compositions over the new primitives (backwards compat for embedders).
+  8. App page rewired to use `WorkspaceShell` directly. The 3-tab top bar (strudel/sonicpi/viz) goes away — all 4 tabs (`pattern.strudel`, `pattern.sonicpi`, `pianoroll.p5`, `pianoroll.hydra`) live in the same shell.
+
+### Phase 10.3: IDE Shell (INSERTED 2026-04-08)
+**Goal**: A real IDE shell on top of the workspace — menu bar, file explorer, command palette, status bar, settings — without forking VS Code or pulling a heavy IDE framework.
+**Depends on**: Phase 10.2
+**Why not port to VS Code web?**: VS Code's file-centric model fights our live-coding UX (`.viz()` inline zones, audio engine sharing, multi-engine bus). Build vs port trade documented in artifacts/stave/IDE-SHELL-DESIGN.md §1. Decision: build lightweight on Monaco; selectively pull `@codingame/monaco-vscode-api` later only if extension support becomes a need.
+**Success Criteria**:
+  1. `MenuBar` — File / Edit / View / Run / Preferences / Help. Each opens a dropdown with keyboard shortcuts shown. Menu items dispatch commands through the same registry as the command palette.
+  2. `FileExplorer` — left sidebar, tree view of `VirtualFileSystem`. Context menu (rename / duplicate / delete / reveal). Drag files into editor groups to open. Folders can collapse/expand.
+  3. `VirtualFileSystem` — generalizes `VizPresetStore` from "presets" to a full IndexedDB-backed FS. Files have `path`, `content`, `language`, `metadata`. Folders are virtual (path prefixes). Supports recent files, rename, delete, import/export.
+  4. `CommandPalette` — Cmd+K / Cmd+Shift+P, fuzzy search over a global `CommandRegistry`. All menu actions, file open, viz commands, settings registered as commands.
+  5. `StatusBar` — bottom strip. Shows BPM, error count, live mode indicator, active engine, current file's git-like status (clean/dirty), language mode.
+  6. `Settings` dialog — themes (dark/light/custom), keybindings, default audio device, default viz config. Persisted to IndexedDB.
+  7. `ProjectManifest` — `stave.project.json` describing files in the workspace, default file bindings, project-level settings. Import/export as `.zip`.
+  8. File types supported: `*.strudel`, `*.sonicpi`, `*.hydra`, `*.p5`, `*.md`, future: `*.wav`/`*.mp3` (sample preview).
+**Out of scope** (deferred to a later phase): real Git integration, multi-workspace, extension API, terminal, debugger.
+
+### Phase PM-1: Local Persistence (COMPLETE 2026-04-12, commits 6a47c03 + b65e98c + 1433fec)
+**Goal**: Browser refresh no longer loses work. The WorkspaceFile store is backed by Yjs + y-indexeddb so all file content persists to IndexedDB locally. No accounts, no cloud, no UI changes.
+**Depends on**: Phase 10.2
+**Success Criteria** (all TRUE, shipped):
+  1. ✅ `WorkspaceFile` store public API unchanged (`createWorkspaceFile`, `getFile`, `setContent`, `subscribe`)
+  2. ✅ File content survives browser refresh — verified via Playwright probe
+  3. ✅ New `seedWorkspaceFile` function for persistence-aware create-or-load
+  4. ✅ Y.Text used for content from day one
+  5. ✅ 763/763 existing tests still pass
+  6. ✅ `initProjectDoc(projectId)` async init with y-indexeddb + `whenSynced` gate
+  7. ✅ No UI changes — shell/tabs/layout/previews work identically
+
+### Phase PM-2: Project Lifecycle + Sidebar (COMPLETE 2026-04-12, commit 4f57aa6 + 303f3b5)
+**Goal**: Users can create, name, switch between, and delete multiple projects.
+**Success Criteria** (all TRUE, shipped):
+  1. ✅ `projectRegistry.ts` — IDB metadata store separate from Y.Doc content
+  2. ✅ `StaveApp` outer wrapper with ProjectSidebar + StrudelEditorClient
+  3. ✅ Switching projects swaps the active Y.Doc atomically (via resetFileStore + switchProject)
+  4. ✅ First-run bootstrap auto-creates "Untitled" project
+  5. Note: initial UX had project list in sidebar — replaced in PM-2.5 with file tree + project switcher modal
+
+### Phase PM-2.5: VS Code-style UX (COMPLETE 2026-04-13, commits 23f55f0 through 371db18)
+**Goal**: Replace project-list sidebar with proper VS Code layout — menu bar, file tree for current project, template picker modal.
+**Success Criteria** (all TRUE, shipped):
+  1. ✅ MenuBar with File / Edit / View / Help (dropdowns close on click-outside or Escape)
+  2. ✅ FileTree: files + folders (folders derived from paths), +/📁 buttons, inline rename, context menu, file-type icons
+  3. ✅ TemplateModal: Unreal-style card grid (Starter, Strudel, Sonic Pi, Hydra, Blank)
+  4. ✅ ProjectSwitcherModal: project list with rename/delete and last-opened timestamps
+  5. ✅ Bidirectional tree↔tab sync (WorkspaceShell forwardRef + onActiveTabChange)
+  6. ✅ Drag-drop files into/out of folders (cascade rename for folders)
+  7. ✅ Resizable sidebar (drag handle, clamped [160, 600], persisted to localStorage)
+  8. ✅ Sidebar height matches editor (588px root = 28 menu + 560 editor)
+  9. ✅ First-run seeds Starter template automatically
+
+### Phase PM-3: Within-folder reordering (NEXT)
+**Goal**: Users can drag files to reorder them within a folder (not just between folders).
+**Needs**: `fileOrder: Y.Map<folderPath, Y.Array<fileId>>` added to the project Y.Doc schema.
+**Plans:** 0/TBD
+
+### Phase PM-2: Project Lifecycle + Sidebar
+**Goal**: Users can create, name, switch between, and delete multiple projects. A new `StaveApp` wrapper renders a `ProjectSidebar` alongside the existing `WorkspaceShell`.
+**Depends on**: PM-1
+**Success Criteria** (what must be TRUE):
+  1. `ProjectRegistry` manages project metadata in a separate IDB store (fast list at startup)
+  2. Create / load / rename / duplicate / delete project operations
+  3. `StaveApp` outer component: `ProjectSidebar` + `WorkspaceShell`
+  4. Switching projects swaps the active Y.Doc atomically
+  5. First-run bootstrap: auto-create "Untitled" project on empty IDB
+**Plans:** 0/TBD
+
+### Phase PM-3: Folders + File Tree
+**Goal**: Files have full paths (`sketches/main.strudel`), folder structure is derived from paths, sidebar shows a file tree with drag-drop reorder and rename cascades.
+**Depends on**: PM-2
+**Plans:** 0/TBD
+
+### Phase PM-4: Snapshots (Version History)
+**Goal**: Named version snapshots stored as binary Y.Doc state in IDB. Auto-snapshot on 60s idle. Explicit "Save Version" button. History sidebar with preview + restore.
+**Depends on**: PM-1
+**Plans:** 0/TBD
+
+### Phase PM-5: Share-by-URL + Export .zip
+**Goal**: Small projects share via base64-in-URL-fragment. All projects export as .zip with stave.json manifest. Import from .zip creates a new project.
+**Depends on**: PM-2
+**Plans:** 0/TBD
+
+### Phase PM-6: Templates Registry
+**Goal**: Hard-coded templates (blank, strudel-starter, hydra-starter, p5-starter, sonicpi-starter). "New Project" dialog shows template picker. User-created and marketplace templates deferred.
+**Depends on**: PM-2
+**Plans:** 0/TBD
+
+### Phase 11: Library Polish + Demo Site
+**Goal**: The @motif/editor package is ready to publish — tested, documented, built correctly — and packages/app is a polished public-facing demo that showcases all features.
+**Depends on**: Phase 10
+**Requirements**: LIB-01, LIB-02, LIB-03, LIB-04, LIB-05, LIB-06, LIB-07, LIB-08, APP-01, APP-02, APP-03, APP-04
+**Success Criteria** (what must be TRUE):
+  1. Vitest test suite passes: WavEncoder header/stereo/mono, noteToMidi conversions, and highlight timing delay are all verified
+  2. `tsup build` produces valid ESM and CJS bundles; `package.json` exports field points to correct outputs; all public types export from index.ts
+  3. Storybook stories exist for StrudelEditor (default, pianoroll, scope, read-only) and each visualizer component in isolation
+  4. The packages/app demo site loads in a browser with play/stop/export working, all visualizer modes switchable, and an examples gallery of 3-5 starter patterns
+  5. README.md contains npm install instructions and a minimal working usage example that an integrator can copy
+**Plans:** TBD
+
+## Progress
+
+**Execution Order:**
+1→2→3→4→5→6→8→9→F→10→10.1→11 (ship staveCoder) → 12-17 (Studio alpha) → 19-20 (multi-view) → 22 (audio input)
+Phase 7 can run in parallel with later phases.
+
+| Phase | Plans | Status | Completed |
+|-------|-------|--------|-----------|
+| 1. Active Highlighting | 2/2 | Complete | 2026-03-21 |
+| 2. Pianoroll Visualizers | 3/3 | Complete | 2026-03-22 |
+| 3. Audio Visualizers | N/A | Complete | 2026-03-22 |
+| 4. VizRenderer Abstraction | 2/2 | Complete | 2026-03-22 |
+| 5. Per-Track Data | 1/1 | Complete | 2026-03-22 |
+| 6. Inline Zones via Abstraction | 2/2 | Complete | 2026-03-22 |
+| 8. Engine Protocol | 3/3 | Complete | 2026-03-25 |
+| 9. Normalized Hap Type | 3/3 | Complete | 2026-03-25 |
+| **F. Free Monad PatternIR** | **2/2** | **Complete** | **2026-03-28** |
+| **10. Monaco Intelligence** | **2/TBD** | **In progress** | - |
+| 7. Additional Renderers + Hydra | 0/TBD | Not started | - |
+| **10.1 Viz Editor** (INSERTED) | **0/TBD** | **Not started** | - |
+| **── staveCoder ships here (v0.1.0 on npm) ──** | | | |
+| 11. Library Polish + Publish | 0/TBD | Not started | - |
+| **── Stave Studio phases below ──** | | | |
+| 12. Synth Invariance | 0/TBD | Not started | - |
+| 13. External Sync (Link, MIDI, OSC) | 0/TBD | Not started | - |
+| 14. Recording & Export (WAV, stems) | 0/TBD | Not started | - |
+| 15. Provenance (session log, signing) | 0/TBD | Not started | - |
+| 16. Collaboration (Yjs CRDT, WebRTC) | 0/TBD | Not started | - |
+| 17. UI Bento Box (sliders, knobs, MIDI CC) | 0/TBD | Not started | - |
+| 18. Composr Integration | 0/TBD | Not started | - |
+| 19. Pattern IR pipeline + Bidirectional DAW | — | **In progress** | - |
+| &nbsp;&nbsp;19-01. Pattern IR types + backward-compat | 1/1 | Complete | 2026-04-15 |
+| &nbsp;&nbsp;19-02. Pass Instrumentation v1 (multi-tab Inspector) | 1/1 | Complete | 2026-05-02 |
+| &nbsp;&nbsp;19-03. Tier 4 JS API — first half (jux/off/degrade/late/chunk/ply) | 1/1 | **Complete** (PR #69 merged) | 2026-05-03 |
+| &nbsp;&nbsp;19-04. Tier 4 JS API — second half (layer/struct/swing/pick/shuffle/scramble/chop) | 12/12 | **Complete** (PR #73 merged) | 2026-05-04 |
+| &nbsp;&nbsp;19-05. `loc` + `userMethod` on every non-Play IR tag (closes Subtlety C from PRE-01) | 13/13 | **Complete** (PR #77 merged) | 2026-05-04 |
+| &nbsp;&nbsp;19-06. Inspector — Strudel-vocabulary tree projection + IR-mode toggle (consumes 19-05's `userMethod`) | 6/6 | **Complete** (PR #78 merged) | 2026-05-04 |
+| &nbsp;&nbsp;19-07. Parser stage decomposition — RAW / MINI-EXPANDED / CHAIN-APPLIED / FINAL (axis 2 advance per PV29; "Phase C" in §Substrate-Honesty) | 19/19 | **Complete** (PR-A: PR #80 merged; PR-B: ready to PR — `feat/parser-stages-chain`) | 2026-05-05 |
+| &nbsp;&nbsp;19-08+. Bidirectional DAW (IRNodeMeta, backward maps, DawVizRenderer, code synthesis) | 0/TBD | Not started | - |
+| &nbsp;&nbsp;20-09. Bake-and-scrub (OfflineAudioContext → AudioBufferSourceNode; closes 20-08 preview-only gap) | 0/TBD | Not started | - |
+| &nbsp;&nbsp;20-10. Param-method promotion — typed `Param` tag for s/n/note/gain/velocity/color/pan/speed/bank/scale; closes #108 silent-semantics gap; codifies semantics-completeness vyapti pair-of PV37 | TBD | **LOCAL** (γ-4 manual gate pending) | - |
+| &nbsp;&nbsp;20-11. Track substrate — `$:` → trackId + palette of 32; closes duplicate-`$:` collapse bug | TBD | **LOCAL** (γ-7 manual gate pending) | - |
+| &nbsp;&nbsp;20-12. Track chrome — collapsible rows, no bar labels, opacity=velocity, Y=pitch; depends on 20-11 | 17/17 | **LOCAL** (γ green; manual γ-5 visual gate pending) | 2026-05-10 |
+| &nbsp;&nbsp;20-12.1. Pause-resets slot map (INSERTED 2026-05-13; re-frames F-1 from parser bug to D-04 retention UX) | 0/TBD | Not started | - |
+| &nbsp;&nbsp;20-13. Structure view (bundled-cycles overview as toggle); speculative, ship-on-demand | 0/TBD | **Deferred** | - |
+| &nbsp;&nbsp;20-14. Strudel.cc parity (eval-scope mirror + alias layer + corpus gate); closes #110 | 19/19 | **LOCAL** (stacked PRs #123→#131→#133; closes #110 at γ merge) | 2026-05-15 |
+| &nbsp;&nbsp;20-15. Strudel.cc parity hardening (5 Bakery gaps #134–#138 + recursive args #132); depends on 20-14 | 0/TBD | Not started | - |
+| 20. Transform Graph (React Flow node patcher, bypass/solo) | 0/TBD | Not started | - |
+| 21. Indian Classical (tala circle, bol, tihai) | 0/TBD | Not started | - |
+| 22. Audio Analysis (audio→IR, AudioRegion, vocals, closed loop) | 0/TBD | Not started | - |
+| 23. Transparent AI (kernel/wavelet Layer 3, attribution) | 0/TBD | Not started | - |
+| **── Project Management System phases below ──** | | | |
+| PM-1. Local Persistence (Yjs + y-indexeddb) | 1/1 | **Complete** | 2026-04-12 |
+| PM-2. Project Lifecycle + Sidebar | 1/1 | **Complete** | 2026-04-12 |
+| PM-2.5. VS Code-style UX (MenuBar, FileTree, Templates, Drag-drop, Resize) | 1/1 | **Complete** | 2026-04-13 |
+| PM-3. Within-folder reordering (fileOrder in Y.Doc) | 0/TBD | **Next** | - |
+| PM-4. Snapshots (Version History) | 0/TBD | Not started | - |
+| PM-5. Share-by-URL + Export .zip | 0/TBD | Not started | - |
+| PM-6. Templates Registry (user-saved, marketplace) | 0/TBD | Basic version shipped in PM-2.5 | - |
+| PM-7. Google OAuth + Cloud Sync (Phase 2) | 0/TBD | Not started | - |
+| PM-8. Marketplace + Lemon Squeezy (Phase 2) | 0/TBD | Not started | - |
+| PM-9. WebRTC Multiplayer (Phase 3) | 0/TBD | Not started | - |
+
+### Phase 12: --help
+
+**Goal:** [To be planned]
+**Requirements**: TBD
+**Depends on:** Phase 11
+**Plans:** 0 plans
+
+Plans:
+- [ ] TBD (run /gsd:plan-phase 12 to break down)

--- a/.planning/phases/20-musician-timeline/20-14-γ-SUMMARY.md
+++ b/.planning/phases/20-musician-timeline/20-14-γ-SUMMARY.md
@@ -299,6 +299,12 @@ note/n arm needs to delegate inner parsing recursively to
 parseExpression when the inner isn't a flat quoted string. Punted
 deliberately — STOP rule: don't add a third workaround.
 
+**Tracked at issue #132** — "parseStrudel: recursive parsing inside
+note/n/s args (nested mini + chain)". Documented in CORPUS-SOURCE.md
+"Known parser-coverage gaps" section. Code-fallback still gates
+structural drift for arpoon (any upstream text change trips a snapshot
+diff); audible behavior unaffected.
+
 ### Skip set + new parseRoot/applyChain semantics — at a glance
 
 - `stripParserPrelude` skip set: `samples | useRNG | setcps |

--- a/.planning/phases/20-musician-timeline/20-14-γ-SUMMARY.md
+++ b/.planning/phases/20-musician-timeline/20-14-γ-SUMMARY.md
@@ -199,3 +199,148 @@ Two patterns surfaced during γ-2 worth promoting if they recur:
   include glob, the snapshot directory layout — all matched precedent
   (IRInspectorPanel.test.tsx's HapStream/BreakpointStore convention)
   rather than introducing a new style.
+
+---
+
+## Parser-gap fix (post-execution, 2026-05-15)
+
+### Discovery
+
+γ-2's parity snapshot run revealed all 16 corpus tunes fell through to
+plain Code-fallback at the top level. The corpus was committed in that
+shape so the snapshot test passed (frozen-but-wrong), but the underlying
+parser was discarding structural detail for every real-world Strudel
+tune.
+
+A follow-up STOP rule fired after the first cluster of fixes landed
+without a green corpus: rather than patch a third workaround, the
+remaining surface was diagnosed cleanly and routed to a separate phase.
+
+### Three clusters fixed
+
+**Cluster 1 — top-level prelude strip** (commit 1: `1d6a314`)
+- New `stripParserPrelude(code)` helper. Skips leading blank lines,
+  whole-line `// …` comments, and recognised top-level boot calls
+  (`samples`, `useRNG`, `setcps`, `setVoicingRange`, `initAudio`,
+  `aliasBank`) with paren/brace/bracket depth tracking so multi-line
+  calls (e.g., `samples({ … })`) are consumed as one unit. Threaded into
+  parseStrudel's no-`$:` branch.
+- Skip set is explicit (D-08 exact tokens). Inline `// …` after
+  expression code is untouched.
+- Brought 6 tunes from bare-Code to structured.
+
+**Cluster 2 — bare-string-as-pattern** (commit 2: `322d912`, half 1)
+- Strudel's transpiler auto-promotes top-level string literals to
+  mini-patterns (`"0,2,[7 6]".add(…)`). Pre-fix: splitRootAndChain
+  saw `expr[0]==='"'`, returned empty root, parseRoot fell through to
+  IR.code(), chain was discarded.
+- Fix: splitRootAndChain now consumes a leading quoted string (escape-
+  aware, single-line) as the root. parseRoot has a new bare-string arm
+  after all named-function arms that delegates to parseMini with the
+  inner offset.
+
+**Cluster 3 — multi-line chain walker + Code-with-via discriminator**
+(commit 2: `322d912`, half 2)
+- Pre-fix `while (remaining.startsWith('.'))` was anchored after a
+  single initial `.trim()`. The first newline between methods exited
+  the loop and every subsequent method was silently dropped.
+- Fix: replaced with `while (true)` that strips an inter-method
+  separator (whitespace + inline `// …` comments up to and including
+  the trailing newline) before each iteration. Offset accumulator
+  advances with every consumed char.
+- Subordinate fix: parseExpression's `rootIR.tag === 'Code'` check now
+  also requires `rootIR.via === undefined`. Without this, wrapAsOpaque
+  wrappers (PV37 wrap-never-drop, tag `Code` but structural via the
+  `.via` field) were thrown away when they reached parseExpression as
+  the root IR — surfaces for `stack(single-arg-with-unmapped-pattern-
+  chain).method(…)` shapes such as `delay.strudel`.
+
+### Final state — 15 of 16 tunes structured
+
+| tune | shape after fix |
+|---|---|
+| amensister | structured (Code-with-via tower) |
+| **arpoon** | **STILL bare-Code — see "residual gap" below** |
+| barryHarris | structured (Code-with-via tower) |
+| bassFuge | structured (Code-with-via tower) |
+| belldub | structured (nested Stack) |
+| chop | structured (Code-with-via tower) |
+| delay | structured (Choice from `.sometimes` over via tower) |
+| dinofunk | structured (Stack) |
+| echoPiano | structured (Code-with-via tower) |
+| flatrave | structured (Stack) |
+| holyflute | structured (Code-with-via tower) |
+| juxUndTollerei | structured (Code-with-via tower) |
+| meltingsubmarine | structured (Code-with-via tower) |
+| orbit | structured (Stack) |
+| randomBells | structured (Code-with-via tower) |
+| sampleDrums | structured (Code-with-via tower) |
+
+### Residual gap — arpoon
+
+```
+n("[0,3] 2 [1,3] 2".fast(3).lastOf(4, fast(2))).clip(2)
+  .offset("<<1 2> 2 1 1>")
+  .chord("<<Am7 C^7> C7 F^7 [Fm7 E7b9]>")
+  …
+```
+
+The OUTER chain (`.clip / .offset / .chord / …`) walks correctly with
+the cluster-3 fix. The OUTER root is `n(EXPR)` where EXPR is itself a
+mini-string-with-chain (`"…".fast(3).lastOf(4, fast(2))`). parseRoot's
+note/n arm currently requires a plain quoted string:
+`^(?:note|n)\s*\(\s*"([^"]*)"\s*\)`. The inner expression doesn't
+match — so the root falls to opaque Code, which (since the chain is
+non-empty) causes parseExpression to discard the whole expression as
+bare Code.
+
+This is a separate parser shape that needs its own design pass: the
+note/n arm needs to delegate inner parsing recursively to
+parseExpression when the inner isn't a flat quoted string. Punted
+deliberately — STOP rule: don't add a third workaround.
+
+### Skip set + new parseRoot/applyChain semantics — at a glance
+
+- `stripParserPrelude` skip set: `samples | useRNG | setcps |
+  setVoicingRange | initAudio | aliasBank` (whole-line top-level calls,
+  multi-line tolerant via depth tracking) + blank lines + whole-line
+  `// …` comments.
+- `splitRootAndChain` now recognises a leading bare-string as the root
+  (escape-aware, single-line).
+- `parseRoot` has a new bare-string arm `^"([^"]*)"$` after all
+  named-function arms; delegates to parseMini.
+- `applyChain` walks across `\s+` and inline `// … \n` separators
+  between methods (regex `^(?:\s+|//[^\n]*\n?)+`).
+- `parseExpression` discriminates bare Code (`tag === 'Code' && !via`)
+  from structural Code-with-via wrappers (PV37); only the bare case is
+  discarded.
+
+### Catalogue candidates
+
+- **hetvabhasa (new entry candidate):** "tag-only `=== 'Code'` check
+  conflates structural wrapAsOpaque wrappers with bare-Code fallbacks."
+  Already cost one round-trip in this session. If it recurs, promote to
+  a full entry — discriminator must inspect `via` field, not the tag
+  alone.
+
+- **vyapti (new entry candidate):** "Strudel parser walkers must
+  tolerate inter-element whitespace (incl. newlines) AND inline `// …`
+  line comments — the upstream transpiler does, and tunes are
+  formatted on the assumption that it does." Spans applyChain (now
+  fixed) + stripParserPrelude (already fixed) + any future
+  splitArgs-style walker.
+
+- **krama (relevant existing):** PK15 (μ-α parse cycle) extends — the
+  prelude-strip step lives BEFORE splitRootAndChain in the no-`$:`
+  branch. Same shape as μ's pre-parse normalisations.
+
+### Test counts (per commit)
+
+| commit | shape | editor | app |
+|---|---|---|---|
+| `1d6a314` prelude strip | added 11 tests | 1547 → 1547 | 314 → 314 |
+| `322d912` clusters A+B | added 4 tests | 1547 → 1551 | 314 → 314 |
+| `1238ed3` snapshot regen | snapshot only | 1551 | 314 (17 parity) |
+
+All green after every commit.
+

--- a/.planning/phases/20-musician-timeline/20-14-γ-SUMMARY.md
+++ b/.planning/phases/20-musician-timeline/20-14-γ-SUMMARY.md
@@ -1,0 +1,201 @@
+---
+phase: 20-14
+wave: γ
+title: Parity corpus + CI gate
+created: 2026-05-15
+closes: "#110"
+gate: γ-verification-passed
+upstream_pin_sha: f73b395648645aabe699f91ba0989f35a6fd8a3c
+---
+
+# Phase 20-14 — γ-wave SUMMARY
+
+**Closes #110.** This wave closes the user-visible `s("piano")` parity gap
+opened by 20-12's manual gate. α loaded the upstream manifests, β lit up
+the bare-name path, and γ now gates regression with a 16-tune structural
+parity corpus that runs as part of `pnpm --filter @stave/app test`.
+
+The γ PR body carries the actual `closes #110` keyword to GitHub.
+
+## γ-1 — Vendored 16-tune corpus + CORPUS-SOURCE.md
+
+Lokayata observation: `pnpm parity:refresh --sha
+f73b395648645aabe699f91ba0989f35a6fd8a3c` reports `unchanged: 16,
+changed: 0, missing: 0` against the same pin used to fetch — confirming
+byte-faithful extraction across all 16 curated exports (no
+hand-edits, no quote conversion, P62 trap explicitly avoided per PLAN
+§2). The 16 tunes fan out across the parity surface table in
+RESEARCH §5 (sample chop, FX, orbit, alias-required bare-names,
+soundfonts, `.bank()`, `.piano()`, polyphony + voicing, polyrhythm,
+metadata, arp/chord — see CORPUS-SOURCE.md for the per-tune line range +
+surface column). `csoundDemo` deliberately omitted (heavy tier — PLAN §7
+follow-up). No tune was missing from upstream at the pinned SHA; no
+fabrication required.
+
+## γ-2 — Vitest spec + IR-shape normalizer + seeded snapshots
+
+Lokayata observation: `pnpm --filter @stave/app test` reports `Test
+Files 15 passed (15), Tests 314 passed (314)` — a clean delta of
+**+17 tests, +1 file** from the pre-γ baseline of 297/14 (1 sanity
+gate + 16 per-tune tests). The spec lives at
+`packages/app/tests/parity-corpus/parity.test.ts` next to its
+fixtures; `vitest.config.ts` widens the `include` glob to pick up
+`tests/parity-corpus/**/*.test.{ts,tsx}` so it runs under the existing
+test invocation with no separate CI step (D-04 — live network forbidden
+on PR CI).
+
+**Parser-IR vs runtime-IR choice — and reasoning.** The spec asserts the
+**parser-level `PatternIR`** from `parseStrudel(code)`, NOT the runtime
+event stream. Reasoning, copied into CORPUS-SOURCE.md for posterity:
+1. **Determinism.** `parseStrudel` is a pure structural matcher with no
+   audio context dependency, no RNG, no scheduler. Same code → same IR.
+   Runtime collection threads the scheduler whose seeding
+   (`useRNG('legacy')`, `seededRandsAtTime`) is per-cycle and would
+   require pinning a synthetic clock.
+2. **Environment.** Vitest runs under jsdom. The runtime audio path
+   needs `AudioContext` + `AudioWorklet` + `@strudel/webaudio`
+   superdough — none of which boot in jsdom without heavy stubbing
+   beyond the existing editor-side kabelsalat stub.
+3. **What parity surfaces.** D-01 locks the rung at IR-shape level. The
+   parser IR is the artifact every downstream consumer (collect,
+   toStrudel, IR Inspector, irProjection) reads first. Parser-IR
+   parity ⇒ all downstream surfaces inherit structural parity for
+   free. Runtime drift on modeled-Tier-4 surfaces remains the
+   responsibility of the editor's existing
+   `packages/editor/src/ir/__tests__/parity.test.ts` (which runs the
+   Strudel evaluator under jsdom via vite-node).
+
+**Tunes that did NOT cleanly snapshot to a structured IR.** All 16
+tunes currently snapshot to `Track(d1, Code(<verbatim source>))`. This
+is NOT a γ failure — it is the truth about Stave's structural parser
+surface vs the upstream corpus today. The parser's pattern matchers
+require a recognized root (bare `note(...)`, `s(...)`, `mini(...)`, or
+`stack(...)`) at the top of the source after trimming. All 16 corpus
+tunes lead with `// "Title"` / `// @license` / `// @by` comment blocks,
+which the structural matcher does not strip before pattern-matching,
+so the entire body falls through to the `Code` fallback. Additional
+top-level forms not in the matcher today (`samples({...})`,
+`useRNG('legacy')`) compound this. This was verified by probing
+`parseStrudel('// hello\ns("bd cp")')` → `Track(Code(...))` vs
+`parseStrudel('s("bd cp")')` → `Track(Seq(Play, Play))`.
+
+The snapshot still gates structural drift:
+- Parser GAINS capability (e.g. learns to skip leading comments, or
+  parses `samples()` as a Param-like setup node) → snapshots shift from
+  `Code` body to a typed body → diff exposes the regression in
+  coverage as growth.
+- Parser REGRESSES and throws on a tune that previously matched →
+  test errors (not a silent diff).
+- A tune's source changes upstream → `Code.code` body differs in the
+  snapshot → caught alongside γ-3's refresh diff.
+
+This is documented in CORPUS-SOURCE.md so future maintainers don't read
+the `Code` fallback as a γ bug.
+
+**Manual mutation gate — Lokayata.** Per PLAN γ-2 verify: inserted
+`.fast(2)` into `chop.strudel` after `.sustain(.6)`, re-ran `pnpm exec
+vitest run tests/parity-corpus`, observed `Tests 1 failed | 16 passed
+(17)` with a snapshot diff naming exactly the added line. Reverted
+the file via `git checkout`; re-run cleanly green. Drift detection
+works at single-tune granularity, not just whole-suite.
+
+**Normalizer.** `tests/parity-corpus/normalize.ts` strips three field
+shapes with inline-comment rationales: `loc` (byte offsets — drift
+with file framing, not IR shape), `chainOffset` (stage-transition
+annotation — same byte-offset hazard), and `Code.via.callSiteRange`
+(opaque-fragment wrapper byte range). The
+"add a new stripped field" rule is documented in the file header:
+state the class of drift it would otherwise mask, or do not strip it.
+
+## γ-3 — `pnpm parity:refresh` script + CI wiring
+
+Lokayata observation: three end-to-end runs verified the maintainer
+workflow:
+- `pnpm parity:refresh --sha f73b3956...` → `no drift — corpus is in
+  sync with the targeted upstream SHA` (pinned SHA = vendored SHA, by
+  construction).
+- `pnpm parity:refresh` (default — fetches upstream `main` tip) →
+  same `no drift` output. Upstream main hasn't moved since the pin
+  (2026-05-07 → 2026-05-15).
+- Local mutation: replaced `// "Chop"` with `// "Chop-LOCAL-MUTATION"`,
+  re-ran `pnpm parity:refresh --sha <pinned>`, observed
+  `changed: 1 (chop)` with a 2-line diff naming the exact change,
+  followed by the next-step copy. Reverted.
+
+**Maintainer workflow for refresh:**
+1. Run `pnpm parity:refresh` (or `pnpm parity:refresh --sha <new>` to
+   target a specific upstream SHA).
+2. Review the per-tune diffs in stdout. Decide whether to accept
+   upstream's drift.
+3. Open a PR titled `corpus: refresh from upstream SHA <new-sha>`.
+4. In that PR: apply the diffs by hand to each affected `.strudel` file,
+   update the SHA pin + "What changed since snapshot" log in
+   CORPUS-SOURCE.md, and regenerate the parity snapshot with
+   `pnpm --filter @stave/app exec vitest run tests/parity-corpus -u`.
+5. Reviewer reads the snapshot diff alongside the source diff — that's
+   the structural-parity gate moment for the new SHA.
+
+**Non-corpus snapshot drift policy (PLAN §2, restated for γ-PR
+reviewers):** any PR that touches `packages/editor/src/engine/` or
+`packages/editor/src/ir/` AND incidentally causes a γ-2 snapshot diff
+**MUST call out the diff in the PR body**. The diff itself is the news
+— explicit acknowledgement gates merge. The γ-3 refresh script handles
+corpus-side drift; this policy handles engine-side drift. The two paths
+are orthogonal: snapshot regen via `vitest -u` is appropriate in the
+corpus-refresh PR; it is **never** appropriate to silently regen
+snapshots inside an engine PR to "make CI green" — that would mask
+the very regression class γ-2 exists to catch.
+
+**CI wiring posture:** the parity spec is picked up by the existing
+`pnpm --filter @stave/app test` invocation (via the vitest.config.ts
+include-glob widening landed in γ-2). No new CI job is added. The
+refresh script is **maintainer-only** and never invoked on PRs — D-04
+prohibits live network at CI time, and the script's whole purpose is
+to fetch from upstream.
+
+## γ verification gate — status
+
+| Gate | Status | Evidence |
+| --- | --- | --- |
+| All 16 corpus tunes pass parity spec locally | PASS | `Tests 17 passed (17)` per run above |
+| Snapshot file committed, regen-stable | PASS | `vitest -u` ran once; subsequent runs without `-u` are byte-identical |
+| `pnpm parity:refresh` runs without error and surfaces diff or no-drift | PASS | 3 verified runs (pinned, main, mutated-local) |
+| Parity spec runs under existing app `pnpm test` (no separate CI step) | PASS | `Test Files 15 passed (15), Tests 314 passed (314)` includes parity-corpus |
+| Parity job runtime under 60s | PASS | Parity-only run: `Duration 275ms`. Full app suite: `Duration 1.45s`. |
+
+All gates green. γ wave is ready for PR.
+
+## Catalogue candidates (deferred per task rules)
+
+Two patterns surfaced during γ-2 worth promoting if they recur:
+
+- **Editor barrel transitive imports break vite-node:** importing runtime
+  values (not just types) from `@stave/editor` pulls in the full dist
+  bundle including gifenc, which crashes the ESM loader. Existing app
+  tests work around this with deep-path imports (`from
+  "../../../../editor/src/engine/HapStream"`). γ-2's parity test follows
+  the same pattern. Single occurrence here — record in session memory
+  per dharana promotion rule, watch for recurrence.
+
+- **`vitest.config.ts include` glob silently excludes corpora that live
+  outside `src/`:** an empty test file ran for `tests/parity-corpus/`
+  with the original include glob, producing no error and no test
+  coverage. Generic vitest gotcha but worth a note. Single occurrence;
+  not promoted.
+
+## Cognitive notes (internal)
+
+- **Krama:** γ-1 → γ-2 → γ-3 → γ-4 ordering was load-bearing as PLAN
+  §3 stated: the spec needed corpus files to read; the refresh script
+  needed the spec wired so the maintainer copy could reference
+  `vitest -u`; this SUMMARY needed all three landed for the verification
+  table to cite concrete numbers.
+- **Lokayata:** every claim in the per-task paragraphs above traces to a
+  command output or observed snapshot diff. The "all 16 fall through to
+  Code" finding was the most useful Lokayata moment — easy to mistake
+  for a γ failure without the probe.
+- **Chesterton:** read existing app test conventions before writing
+  parity.test.ts. The deep-path import pattern, the vitest config
+  include glob, the snapshot directory layout — all matched precedent
+  (IRInspectorPanel.test.tsx's HapStream/BreakpointStore convention)
+  rather than introducing a new style.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "turbo run dev",
     "test": "turbo run test",
     "lint": "turbo run lint",
-    "clean": "turbo run clean"
+    "clean": "turbo run clean",
+    "parity:refresh": "node packages/app/scripts/parity-refresh.mjs"
   },
   "devDependencies": {
     "turbo": "^2.0.0",

--- a/packages/app/scripts/parity-refresh.mjs
+++ b/packages/app/scripts/parity-refresh.mjs
@@ -1,0 +1,191 @@
+#!/usr/bin/env node
+/**
+ * parity-refresh.mjs — maintainer-only upstream drift surfacer (γ-3).
+ *
+ * Reads the SHA pin from `packages/app/tests/parity-corpus/CORPUS-SOURCE.md`
+ * (or accepts `--sha <new>`), fetches `website/src/repl/tunes.mjs` from
+ * upstream `uzu/strudel` on Codeberg, re-extracts the 16 curated tunes
+ * by named export, and prints a unified diff for every tune whose body
+ * differs from the currently-vendored `.strudel` copy.
+ *
+ * IMPORTANT — this script:
+ *   - Never overwrites a corpus file. Output is a human diff.
+ *   - Never runs on CI. Live network is forbidden on PR CI per PLAN §2
+ *     D-04. The vitest spec at parity.test.ts is the CI gate; this is
+ *     the maintainer-side tool for moving the SHA pin forward.
+ *   - Never auto-commits. The maintainer applies any accepted diff by
+ *     hand in a PR titled `corpus: refresh from upstream SHA <x>` and
+ *     regenerates snapshots there with `vitest -u`.
+ *
+ * Exit code is always 0 when the network succeeds — the purpose is
+ * surfacing drift, not gating. A non-zero exit means the fetch itself
+ * failed (network flake, upstream rate limit, removed file).
+ *
+ * Usage:
+ *   node packages/app/scripts/parity-refresh.mjs                  # diff against upstream main
+ *   node packages/app/scripts/parity-refresh.mjs --sha <hexsha>   # diff against a specific SHA
+ *
+ * Wired as `pnpm parity:refresh` (root package.json).
+ */
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const corpusDir = path.resolve(here, '..', 'tests', 'parity-corpus')
+const sourceFile = path.join(corpusDir, 'CORPUS-SOURCE.md')
+
+// Tunes to re-extract. Keep in lockstep with the CORPUS-SOURCE.md curated
+// list — if a tune is added/removed there, mirror the change here.
+const TARGETS = [
+  'chop',
+  'delay',
+  'orbit',
+  'belldub',
+  'sampleDrums',
+  'randomBells',
+  'barryHarris',
+  'echoPiano',
+  'holyflute',
+  'flatrave',
+  'amensister',
+  'juxUndTollerei',
+  'bassFuge',
+  'dinofunk',
+  'meltingsubmarine',
+  'arpoon',
+]
+
+const args = process.argv.slice(2)
+let overrideSha
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--sha' && args[i + 1]) {
+    overrideSha = args[i + 1]
+    i++
+  }
+}
+
+async function readCurrentSha() {
+  const md = await fs.readFile(sourceFile, 'utf8')
+  const m = md.match(/Commit SHA \| `([0-9a-f]{40})`/i)
+  if (!m) {
+    throw new Error(
+      'Could not find current SHA pin in CORPUS-SOURCE.md — expected a `Commit SHA | <hash>` row.',
+    )
+  }
+  return m[1]
+}
+
+function buildUrl(sha) {
+  if (sha) {
+    return `https://codeberg.org/uzu/strudel/raw/commit/${sha}/website/src/repl/tunes.mjs`
+  }
+  // Latest tip of main.
+  return 'https://codeberg.org/uzu/strudel/raw/branch/main/website/src/repl/tunes.mjs'
+}
+
+async function fetchUpstream(sha) {
+  const url = buildUrl(sha)
+  const res = await fetch(url)
+  if (!res.ok) {
+    throw new Error(`Fetch failed (${res.status}): ${url}`)
+  }
+  return await res.text()
+}
+
+function extractTune(source, name) {
+  // Mirrors the γ-1 extractor — match `export const <name> = \`...\`;`
+  // tolerating any chars (including newlines) inside backticks. Escaped
+  // backticks inside template literals would break this; none of the 16
+  // tunes currently use them.
+  const re = new RegExp(`export const ${name} = \`([\\s\\S]*?)\`;`, 'm')
+  const m = source.match(re)
+  if (!m) return null
+  const body = m[1]
+  return body.endsWith('\n') ? body : body + '\n'
+}
+
+function unifiedDiff(a, b, label) {
+  // Tiny line-by-line diff. Not a full implementation of the
+  // Myers algorithm — sufficient for "did this body change at all?"
+  // and prints any differing lines with -/+ markers. For deep diffing,
+  // pipe the two files through your editor's diff tool.
+  const aLines = a.split('\n')
+  const bLines = b.split('\n')
+  const max = Math.max(aLines.length, bLines.length)
+  const out = [`--- vendored: ${label}`, `+++ upstream: ${label}`]
+  let changed = false
+  for (let i = 0; i < max; i++) {
+    const av = aLines[i]
+    const bv = bLines[i]
+    if (av === bv) continue
+    changed = true
+    if (av !== undefined) out.push(`- ${av}`)
+    if (bv !== undefined) out.push(`+ ${bv}`)
+  }
+  return changed ? out.join('\n') : null
+}
+
+async function main() {
+  const currentSha = await readCurrentSha()
+  const targetSha = overrideSha
+  const label = targetSha ? `SHA ${targetSha.slice(0, 8)}` : 'main (latest)'
+  console.log(`# parity:refresh`)
+  console.log(`# vendored pin: ${currentSha}`)
+  console.log(`# fetching:     ${label}`)
+  console.log('')
+
+  const upstream = await fetchUpstream(targetSha)
+  let unchanged = 0
+  let changed = 0
+  let missing = 0
+  const changedTunes = []
+
+  for (const name of TARGETS) {
+    const upstreamBody = extractTune(upstream, name)
+    const vendoredPath = path.join(corpusDir, `${name}.strudel`)
+    let vendoredBody
+    try {
+      vendoredBody = await fs.readFile(vendoredPath, 'utf8')
+    } catch {
+      console.log(`! missing vendored file: ${vendoredPath}`)
+      missing++
+      continue
+    }
+    if (upstreamBody === null) {
+      console.log(`! tune disappeared upstream: ${name}`)
+      missing++
+      continue
+    }
+    if (upstreamBody === vendoredBody) {
+      unchanged++
+      continue
+    }
+    changed++
+    changedTunes.push(name)
+    const diff = unifiedDiff(vendoredBody, upstreamBody, `${name}.strudel`)
+    if (diff) {
+      console.log(diff)
+      console.log('')
+    }
+  }
+
+  console.log('# summary')
+  console.log(`# unchanged: ${unchanged}`)
+  console.log(`# changed:   ${changed}${changed ? ` (${changedTunes.join(', ')})` : ''}`)
+  console.log(`# missing:   ${missing}`)
+  console.log('')
+  if (changed > 0) {
+    console.log('# next step: open a PR titled `corpus: refresh from upstream SHA <x>`,')
+    console.log('# apply the diffs above by hand, update CORPUS-SOURCE.md SHA pin')
+    console.log('# + "what changed since snapshot" log, then run')
+    console.log('# `pnpm --filter @stave/app exec vitest run tests/parity-corpus -u` to regen snapshots.')
+  } else {
+    console.log('# no drift — corpus is in sync with the targeted upstream SHA.')
+  }
+}
+
+main().catch((err) => {
+  console.error('parity:refresh failed:', err.message)
+  process.exit(1)
+})

--- a/packages/app/tests/parity-corpus/CORPUS-SOURCE.md
+++ b/packages/app/tests/parity-corpus/CORPUS-SOURCE.md
@@ -1,0 +1,145 @@
+# Strudel.cc Parity Corpus — Source Pin
+
+This corpus is the structural-parity gate for Phase 20-14 (D-04).
+Each `*.strudel` file in this directory is a **byte-faithful extraction** of
+a named `export const` from upstream strudel's `tunes.mjs`. The vitest spec at
+`parity.test.ts` evals each file through Stave's parser and asserts the
+resulting `PatternIR` shape (post-normalization) against a committed snapshot.
+
+## Upstream pin
+
+| Field | Value |
+| --- | --- |
+| Repository | [`uzu/strudel`](https://codeberg.org/uzu/strudel) (Codeberg) |
+| Branch | `main` |
+| Commit SHA | `f73b395648645aabe699f91ba0989f35a6fd8a3c` |
+| Source file | `website/src/repl/tunes.mjs` |
+| Snapshot date | 2026-05-15 |
+| Raw URL | https://codeberg.org/uzu/strudel/raw/commit/f73b395648645aabe699f91ba0989f35a6fd8a3c/website/src/repl/tunes.mjs |
+
+## License
+
+Both upstream Strudel and Stave editor are licensed under
+**AGPL-3.0-or-later**. Vendoring is license-compatible — no porting or
+rewrite required. See the per-file `@license` headers (CC BY-NC-SA 4.0 in
+most cases; that license applies to the tune CONTENT — the AGPL-3.0 frame
+applies to inclusion as test fixtures in this repo).
+
+## Parity rung
+
+Per PLAN §3 D-01: **structural parity only**. The spec asserts:
+
+- IR tag tree shape after `parseStrudel(code)`
+- Source-loc offsets, dollar positions, and any timestamp / uuid-like
+  identifiers are stripped by `normalize.ts:normalizeIRShape` before
+  comparison — see that file's inline comments for the rationale per
+  field.
+
+The spec does NOT assert audible output, scheduler timing, or rendered
+visual output. Those rungs are queued (PLAN §7).
+
+### Parser-IR vs runtime-IR choice
+
+The spec asserts the **parser-level `PatternIR`** produced by
+`parseStrudel(code)` from `@stave/editor`, NOT the runtime event stream
+collected from the audio scheduler.
+
+Reasoning:
+
+1. **Determinism.** `parseStrudel` is a pure structural matcher with no
+   audio context dependency and no random-number sources. The same code
+   produces the same IR every run. Runtime collection threads through the
+   Strudel scheduler whose RNG seeding (`useRNG('legacy')`, `seededRandsAtTime`)
+   is per-cycle and would require pinning a synthetic clock.
+2. **Environment.** Vitest runs in jsdom. The runtime audio path requires
+   `AudioContext` + `AudioWorklet` + `@strudel/webaudio` superdough — none
+   of which boot in jsdom without heavy stubbing. The kabelsalat stub the
+   editor's existing parity harness uses is sufficient for parser-level
+   work but not for full eval.
+3. **What parity surfaces.** D-01 explicitly locks the parity rung at
+   IR-shape level. The parser IR is the artifact downstream consumers
+   (collect, toStrudel, IR Inspector, irProjection) read first. If the
+   parser IR matches structurally, downstream surfaces inherit
+   structural parity for free; if it diverges, the spec catches it before
+   any other layer is consulted.
+
+The cost of this choice: tunes whose meaning depends on runtime
+expansion that the parser cannot see at parse time (random-seed-bound
+permutations, late-binding scale lookups inside `.struct()`, etc.) snapshot
+their **literal parsed structure**, not their expanded denotation. Drift
+in the runtime expansion logic would NOT be caught by this gate alone —
+it remains the responsibility of the editor-side `parity.test.ts` (which
+runs the Strudel evaluator under jsdom-via-vite-node) to catch
+runtime drift on the modeled-Tier-4 surface.
+
+## Curated 16 tunes
+
+| # | File | Upstream lines | Parity surface |
+| --- | --- | --- | --- |
+| 1 | `chop.strudel` | 562-575 | `.chop()`, `.jux(rev)`, sample chop |
+| 2 | `delay.strudel` | 577-586 | simple FX chain, param keys |
+| 3 | `orbit.strudel` | 588-602 | `.orbit()` routing across tracks |
+| 4 | `belldub.strudel` | 604-642 | `.s("bell")` bare name — alias layer |
+| 5 | `sampleDrums.strudel` | 169-181 | inline `samples()` + bare `bd/sd/hh` |
+| 6 | `randomBells.strudel` | 387-410 | `.note().scale()` tonal IR |
+| 7 | `barryHarris.strudel` | 183-191 | jazz harmony + xen edge |
+| 8 | `echoPiano.strudel` | 339-350 | `.piano()` chain method (α-4) |
+| 9 | `holyflute.strudel` | 694-709 | soundfont (`gm_*`) IR |
+| 10 | `flatrave.strudel` | 711-737 | `.bank("RolandTR909")` (α-2 + α-3) |
+| 11 | `amensister.strudel` | 739-777 | sample chop + stutter sequencing |
+| 12 | `juxUndTollerei.strudel` | 779-792 | `.jux()` higher-order combinator |
+| 13 | `bassFuge.strudel` | 532-560 | polyphony + `.voicing()` |
+| 14 | `dinofunk.strudel` | 644-672 | drum-machines + polyrhythm mini |
+| 15 | `meltingsubmarine.strudel` | 455-496 | `.color()` + viz hints metadata |
+| 16 | `arpoon.strudel` | 850-878 | arp + chord ops |
+
+## Deliberately omitted (queued)
+
+Per RESEARCH §5:
+
+- `csoundDemo` — requires `@strudel/csound` tier (PLAN §7 follow-up).
+- Surface duplicates: `swimming`, `giantSteps`, `caverave`, `zeldasRescue`,
+  `goodTimes`, `festivalOfFingers`, `festivalOfFingers3`, `sml1`, `waa2`,
+  `outroMusic`, `undergroundPlumber`, `wavyKalimba`, `blippyRhodes`,
+  `loungeSponge`, `sampleDemo` — exercise surfaces already covered. Add if
+  a parity gap surfaces.
+
+## P62 — quote-style policy
+
+**Do NOT mass-convert quotes in this directory.** Per PLAN §2 + hetvabhasa
+P62: the upstream tunes use double-quoted strings inside `.s("bd")`,
+`.bank("tr909")`, etc., because Strudel's transpiler reifies them as
+Patterns intentionally — that IS upstream behavior. Both Stave and
+upstream pipe through the same transpiler, so structural parity holds.
+P62 only bites string-id chain methods (`.p('name')`, `.viz('name')`)
+that are NOT in this corpus.
+
+The corpus must remain a byte-faithful extraction. Any quote change has to
+land via the refresh script (with the diff visible in the refresh PR), not
+as a hand-edit here.
+
+## Refresh procedure
+
+Run `pnpm parity:refresh` from the repo root (or `pnpm --filter @stave/app
+parity:refresh`). The script:
+
+1. Reads this file to discover the current SHA pin.
+2. Fetches `tunes.mjs` from upstream at `main`'s current tip (or `--sha
+   <NEW_SHA>` if supplied).
+3. Re-extracts the 16 curated tunes by name.
+4. Prints a unified `diff` for each tune whose body differs from the
+   currently-vendored copy.
+5. **Never writes files automatically.** The maintainer applies any
+   accepted diff by hand and commits it in a PR titled
+   `corpus: refresh from upstream SHA <x>`.
+
+The script does NOT run on CI. PR CI only runs the parity spec
+(`pnpm --filter @stave/app test`) — see PLAN §2 D-04.
+
+## What changed since snapshot
+
+_None yet — corpus was vendored at the pinned SHA on 2026-05-15._
+
+When refreshing, append a dated entry summarizing which tune bodies moved
+and why (upstream renamed a method, added a chain, etc.). This section is
+the audit trail for the structural parity surface over time.

--- a/packages/app/tests/parity-corpus/CORPUS-SOURCE.md
+++ b/packages/app/tests/parity-corpus/CORPUS-SOURCE.md
@@ -93,6 +93,24 @@ runtime drift on the modeled-Tier-4 surface.
 | 15 | `meltingsubmarine.strudel` | 455-496 | `.color()` + viz hints metadata |
 | 16 | `arpoon.strudel` | 850-878 | arp + chord ops |
 
+## Known parser-coverage gaps
+
+After the γ-wave parser-gap fix (commits `1d6a314`, `322d912`), 15 of 16
+tunes produce **structured PatternIR** in their snapshots. One tune still
+falls back to opaque `Track(d1, Code(<verbatim>))`:
+
+- **`arpoon.strudel`** — body shape `n("…".fast(3).lastOf(4, fast(2))).clip(2).offset(…)`.
+  The OUTER chain walks correctly (cluster B fix), but the ROOT `n(…)` arm
+  requires its argument to be a bare `"…"` quoted string. When the inner arg
+  is itself a mini-string with its own method chain, the regex fails and the
+  whole expression becomes opaque. Tracked at **#132** — recursive
+  expression parsing inside `note`/`n`/`s` args.
+
+The Code-fallback still gates structural drift (any upstream text change to
+arpoon trips a snapshot diff), but the assertion is weaker than full IR
+parity for that one tune. Audible behavior is unaffected — the transpiler
+reifies and chains through the runtime correctly.
+
 ## Deliberately omitted (queued)
 
 Per RESEARCH §5:

--- a/packages/app/tests/parity-corpus/__snapshots__/parity.test.ts.snap
+++ b/packages/app/tests/parity-corpus/__snapshots__/parity.test.ts.snap
@@ -3,25 +3,28 @@
 exports[`strudel.cc parity corpus — structural IR shape > amensister parses to a stable IR shape 1`] = `
 {
   "body": {
-    "code": "// "Amensister"
-// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
-// @by Felix Roos
-
-samples('github:tidalcycles/dirt-samples')
-
-useRNG('legacy')
-
-stack(
-  // amen
+    "code": "",
+    "lang": "strudel",
+    "tag": "Code",
+    "via": {
+      "args": ""<x@7 x(5,8,-1)>"",
+      "inner": {
+        "tag": "Stack",
+        "tracks": [
+          {
+            "code": "// amen
   n("0 1 2 3 4 5 6 7")
   .sometimes(x=>x.ply(2))
   .rarely(x=>x.speed("2 | -2"))
   .sometimesBy(.4, x=>x.delay(".5"))
   .s("amencutup")
   .slow(2)
-  .room(.5)
-  ,
-  // bass
+  .room(.5)",
+            "lang": "strudel",
+            "tag": "Code",
+          },
+          {
+            "code": "// bass
   sine.add(saw.slow(4)).range(0,7).segment(8)
   .superimpose(x=>x.add(.1))
   .scale('G0 minor').note()
@@ -30,20 +33,81 @@ stack(
   .lpa(.1).lpenv(-4).lpq(10)
   .cutoff(perlin.range(300,3000).slow(8))
   .degradeBy("0 0.1 .5 .1")
-  .rarely(add(note("12")))
-  ,
-  // chord
+  .rarely(add(note("12")))",
+            "lang": "strudel",
+            "tag": "Code",
+          },
+          {
+            "code": "// chord
   note("Bb3,D4".superimpose(x=>x.add(.2)))
   .s('sawtooth').lpf(1000).struct("<~@3 [~ x]>")
-  .decay(.05).sustain(.0).delay(.8).delaytime(.125).room(.8)
-  ,
-  // alien
-  s("breath").room(1).shape(.6).chop(16).rev().mask("<x ~@7>")
-  ,
-  n("0 1").s("east").delay(.5).degradeBy(.8).speed(rand.range(.5,1.5))
-).reset("<x@7 x(5,8,-1)>")",
-    "lang": "strudel",
-    "tag": "Code",
+  .decay(.05).sustain(.0).delay(.8).delaytime(.125).room(.8)",
+            "lang": "strudel",
+            "tag": "Code",
+          },
+          {
+            "code": "// alien
+  s("breath").room(1).shape(.6).chop(16).rev().mask("<x ~@7>")",
+            "lang": "strudel",
+            "tag": "Code",
+          },
+          {
+            "code": "",
+            "lang": "strudel",
+            "tag": "Code",
+            "via": {
+              "args": "rand.range(.5,1.5)",
+              "inner": {
+                "body": {
+                  "body": {
+                    "body": {
+                      "children": [
+                        {
+                          "duration": 0.25,
+                          "note": "0",
+                          "params": {
+                            "gain": 1,
+                            "velocity": 1,
+                          },
+                          "tag": "Play",
+                        },
+                        {
+                          "duration": 0.25,
+                          "note": "1",
+                          "params": {
+                            "gain": 1,
+                            "velocity": 1,
+                          },
+                          "tag": "Play",
+                        },
+                      ],
+                      "tag": "Seq",
+                    },
+                    "key": "s",
+                    "rawArgs": ""east"",
+                    "tag": "Param",
+                    "userMethod": "s",
+                    "value": "east",
+                  },
+                  "name": "delay",
+                  "params": {
+                    "delay": 0.5,
+                  },
+                  "tag": "FX",
+                  "userMethod": "delay",
+                },
+                "p": 0.19999999999999996,
+                "tag": "Degrade",
+                "userMethod": "degradeBy",
+              },
+              "method": "speed",
+            },
+          },
+        ],
+        "userMethod": "stack",
+      },
+      "method": "reset",
+    },
   },
   "tag": "Track",
   "trackId": "d1",
@@ -53,15 +117,7 @@ stack(
 exports[`strudel.cc parity corpus — structural IR shape > arpoon parses to a stable IR shape 1`] = `
 {
   "body": {
-    "code": "// "Arpoon"
-// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
-// @by Felix Roos
-
-useRNG('legacy')
-
-samples('github:tidalcycles/dirt-samples')
-
-n("[0,3] 2 [1,3] 2".fast(3).lastOf(4, fast(2))).clip(2)
+    "code": "n("[0,3] 2 [1,3] 2".fast(3).lastOf(4, fast(2))).clip(2)
   .offset("<<1 2> 2 1 1>")
   .chord("<<Am7 C^7> C7 F^7 [Fm7 E7b9]>")
   .dict('lefthand').voicing()
@@ -92,16 +148,109 @@ n("[0,3] 2 [1,3] 2".fast(3).lastOf(4, fast(2))).clip(2)
 exports[`strudel.cc parity corpus — structural IR shape > barryHarris parses to a stable IR shape 1`] = `
 {
   "body": {
-    "code": "// adapted from a Barry Harris excercise
-"0,2,[7 6]"
-  .add("<0 1 2 3 4 5 7 8>")
-  .scale('C bebop major')
-  .transpose("<0 1 2 1>/8")
-  .slow(2)
-  .note().piano()
-  .color('#00B8D4')",
+    "code": "",
     "lang": "strudel",
     "tag": "Code",
+    "via": {
+      "args": "'#00B8D4'",
+      "inner": {
+        "code": "",
+        "lang": "strudel",
+        "tag": "Code",
+        "via": {
+          "args": "",
+          "inner": {
+            "code": "",
+            "lang": "strudel",
+            "tag": "Code",
+            "via": {
+              "args": "",
+              "inner": {
+                "body": {
+                  "code": "",
+                  "lang": "strudel",
+                  "tag": "Code",
+                  "via": {
+                    "args": ""<0 1 2 1>/8"",
+                    "inner": {
+                      "code": "",
+                      "lang": "strudel",
+                      "tag": "Code",
+                      "via": {
+                        "args": "'C bebop major'",
+                        "inner": {
+                          "code": "",
+                          "lang": "strudel",
+                          "tag": "Code",
+                          "via": {
+                            "args": ""<0 1 2 3 4 5 7 8>"",
+                            "inner": {
+                              "children": [
+                                {
+                                  "duration": 0.25,
+                                  "note": "0",
+                                  "params": {
+                                    "gain": 1,
+                                    "velocity": 1,
+                                  },
+                                  "tag": "Play",
+                                },
+                                {
+                                  "duration": 0.25,
+                                  "note": "2",
+                                  "params": {
+                                    "gain": 1,
+                                    "velocity": 1,
+                                  },
+                                  "tag": "Play",
+                                },
+                                {
+                                  "children": [
+                                    {
+                                      "duration": 0.25,
+                                      "note": "7",
+                                      "params": {
+                                        "gain": 1,
+                                        "velocity": 1,
+                                      },
+                                      "tag": "Play",
+                                    },
+                                    {
+                                      "duration": 0.25,
+                                      "note": "6",
+                                      "params": {
+                                        "gain": 1,
+                                        "velocity": 1,
+                                      },
+                                      "tag": "Play",
+                                    },
+                                  ],
+                                  "tag": "Seq",
+                                },
+                              ],
+                              "tag": "Seq",
+                            },
+                            "method": "add",
+                          },
+                        },
+                        "method": "scale",
+                      },
+                    },
+                    "method": "transpose",
+                  },
+                },
+                "factor": 2,
+                "tag": "Slow",
+                "userMethod": "slow",
+              },
+              "method": "note",
+            },
+          },
+          "method": "piano",
+        },
+      },
+      "method": "color",
+    },
   },
   "tag": "Track",
   "trackId": "d1",
@@ -111,37 +260,353 @@ exports[`strudel.cc parity corpus — structural IR shape > barryHarris parses t
 exports[`strudel.cc parity corpus — structural IR shape > bassFuge parses to a stable IR shape 1`] = `
 {
   "body": {
-    "code": "// "Bass fuge"
-// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
-// @by Felix Roos
-
-samples({ flbass: ['00_c2_finger_long_neck.wav','01_c2_finger_short_neck.wav','02_c2_finger_long_bridge.wav','03_c2_finger_short_bridge.wav','04_c2_pick_long.wav','05_c2_pick_short.wav','06_c2_palm_mute.wav'] }, 
-  'github:cleary/samples-flbass/main/')
-samples({
-bd: ['bd/BT0AADA.wav','bd/BT0AAD0.wav','bd/BT0A0DA.wav','bd/BT0A0D3.wav','bd/BT0A0D0.wav','bd/BT0A0A7.wav'],
-sd: ['sd/rytm-01-classic.wav','sd/rytm-00-hard.wav'],
-hh: ['hh27/000_hh27closedhh.wav','hh/000_hh3closedhh.wav'],
-}, 'github:tidalcycles/dirt-samples');
-
-setcps(1)
-
-"<8(3,8) <7 7*2> [4 5@3] 8>".sub(1) // sub 1 -> 1-indexed
-.layer(
-x=>x,
-x=>x.add(7)
-.off(1/8,x=>x.add("2,4").off(1/8,x=>x.add(5).echo(4,.125,.5)))
-.slow(2),
-).n().scale('A1 minor')
-.s("flbass").n(0)
-.mul(gain(.3))
-.cutoff(sine.slow(7).range(200,4000))
-.resonance(10)
-//.hcutoff(400)
-.clip(1)
-.stack(s("bd:1*2,~ sd:0,[~ hh:0]*2"))
-.pianoroll({vertical:1})",
+    "code": "",
     "lang": "strudel",
     "tag": "Code",
+    "via": {
+      "args": "{vertical:1}",
+      "inner": {
+        "code": "",
+        "lang": "strudel",
+        "tag": "Code",
+        "via": {
+          "args": "s("bd:1*2,~ sd:0,[~ hh:0]*2")",
+          "inner": {
+            "code": "",
+            "lang": "strudel",
+            "tag": "Code",
+            "via": {
+              "args": "1",
+              "inner": {
+                "body": {
+                  "code": "",
+                  "lang": "strudel",
+                  "tag": "Code",
+                  "via": {
+                    "args": "sine.slow(7).range(200,4000)",
+                    "inner": {
+                      "code": "",
+                      "lang": "strudel",
+                      "tag": "Code",
+                      "via": {
+                        "args": "gain(.3)",
+                        "inner": {
+                          "body": {
+                            "body": {
+                              "code": "",
+                              "lang": "strudel",
+                              "tag": "Code",
+                              "via": {
+                                "args": "'A1 minor'",
+                                "inner": {
+                                  "code": "",
+                                  "lang": "strudel",
+                                  "tag": "Code",
+                                  "via": {
+                                    "args": "",
+                                    "inner": {
+                                      "tag": "Stack",
+                                      "tracks": [
+                                        {
+                                          "code": "",
+                                          "lang": "strudel",
+                                          "tag": "Code",
+                                          "via": {
+                                            "args": "1",
+                                            "inner": {
+                                              "items": [
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "8",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                    {
+                                                      "duration": 1,
+                                                      "tag": "Sleep",
+                                                    },
+                                                    {
+                                                      "duration": 1,
+                                                      "tag": "Sleep",
+                                                    },
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "8",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                    {
+                                                      "duration": 1,
+                                                      "tag": "Sleep",
+                                                    },
+                                                    {
+                                                      "duration": 1,
+                                                      "tag": "Sleep",
+                                                    },
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "8",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                    {
+                                                      "duration": 1,
+                                                      "tag": "Sleep",
+                                                    },
+                                                  ],
+                                                  "tag": "Seq",
+                                                },
+                                                {
+                                                  "items": [
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "7",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                    {
+                                                      "body": {
+                                                        "duration": 0.25,
+                                                        "note": "7",
+                                                        "params": {
+                                                          "gain": 1,
+                                                          "velocity": 1,
+                                                        },
+                                                        "tag": "Play",
+                                                      },
+                                                      "factor": 2,
+                                                      "tag": "Fast",
+                                                    },
+                                                  ],
+                                                  "tag": "Cycle",
+                                                },
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "4",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                    {
+                                                      "body": {
+                                                        "duration": 0.25,
+                                                        "note": "5",
+                                                        "params": {
+                                                          "gain": 1,
+                                                          "velocity": 1,
+                                                        },
+                                                        "tag": "Play",
+                                                      },
+                                                      "factor": 3,
+                                                      "tag": "Elongate",
+                                                    },
+                                                  ],
+                                                  "tag": "Seq",
+                                                },
+                                                {
+                                                  "duration": 0.25,
+                                                  "note": "8",
+                                                  "params": {
+                                                    "gain": 1,
+                                                    "velocity": 1,
+                                                  },
+                                                  "tag": "Play",
+                                                },
+                                              ],
+                                              "tag": "Cycle",
+                                            },
+                                            "method": "sub",
+                                          },
+                                        },
+                                        {
+                                          "code": "",
+                                          "lang": "strudel",
+                                          "tag": "Code",
+                                          "via": {
+                                            "args": "1",
+                                            "inner": {
+                                              "items": [
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "8",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                    {
+                                                      "duration": 1,
+                                                      "tag": "Sleep",
+                                                    },
+                                                    {
+                                                      "duration": 1,
+                                                      "tag": "Sleep",
+                                                    },
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "8",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                    {
+                                                      "duration": 1,
+                                                      "tag": "Sleep",
+                                                    },
+                                                    {
+                                                      "duration": 1,
+                                                      "tag": "Sleep",
+                                                    },
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "8",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                    {
+                                                      "duration": 1,
+                                                      "tag": "Sleep",
+                                                    },
+                                                  ],
+                                                  "tag": "Seq",
+                                                },
+                                                {
+                                                  "items": [
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "7",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                    {
+                                                      "body": {
+                                                        "duration": 0.25,
+                                                        "note": "7",
+                                                        "params": {
+                                                          "gain": 1,
+                                                          "velocity": 1,
+                                                        },
+                                                        "tag": "Play",
+                                                      },
+                                                      "factor": 2,
+                                                      "tag": "Fast",
+                                                    },
+                                                  ],
+                                                  "tag": "Cycle",
+                                                },
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "4",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                    {
+                                                      "body": {
+                                                        "duration": 0.25,
+                                                        "note": "5",
+                                                        "params": {
+                                                          "gain": 1,
+                                                          "velocity": 1,
+                                                        },
+                                                        "tag": "Play",
+                                                      },
+                                                      "factor": 3,
+                                                      "tag": "Elongate",
+                                                    },
+                                                  ],
+                                                  "tag": "Seq",
+                                                },
+                                                {
+                                                  "duration": 0.25,
+                                                  "note": "8",
+                                                  "params": {
+                                                    "gain": 1,
+                                                    "velocity": 1,
+                                                  },
+                                                  "tag": "Play",
+                                                },
+                                              ],
+                                              "tag": "Cycle",
+                                            },
+                                            "method": "sub",
+                                          },
+                                        },
+                                      ],
+                                      "userMethod": "layer",
+                                    },
+                                    "method": "n",
+                                  },
+                                },
+                                "method": "scale",
+                              },
+                            },
+                            "key": "s",
+                            "rawArgs": ""flbass"",
+                            "tag": "Param",
+                            "userMethod": "s",
+                            "value": "flbass",
+                          },
+                          "key": "n",
+                          "rawArgs": "0",
+                          "tag": "Param",
+                          "userMethod": "n",
+                          "value": 0,
+                        },
+                        "method": "mul",
+                      },
+                    },
+                    "method": "cutoff",
+                  },
+                },
+                "name": "resonance",
+                "params": {
+                  "resonance": 10,
+                },
+                "tag": "FX",
+                "userMethod": "resonance",
+              },
+              "method": "clip",
+            },
+          },
+          "method": "stack",
+        },
+      },
+      "method": "pianoroll",
+    },
   },
   "tag": "Track",
   "trackId": "d1",
@@ -151,32 +616,224 @@ x=>x.add(7)
 exports[`strudel.cc parity corpus — structural IR shape > belldub parses to a stable IR shape 1`] = `
 {
   "body": {
-    "code": "// "Belldub"
-// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
-// @by Felix Roos
-
-samples({ bell: {b4:'https://cdn.freesound.org/previews/339/339809_5121236-lq.mp3'}})
-// "Hand Bells, B, Single.wav" by InspectorJ (www.jshaw.co.uk) of Freesound.org
-
-useRNG('legacy')
-
-stack(
-  // bass
+    "body": {
+      "tag": "Stack",
+      "tracks": [
+        {
+          "code": "// bass
   note("[0 ~] [2 [0 2]] [4 4*2] [[4 ~] [2 ~] 0@2]".scale('g1 dorian').superimpose(x=>x.add(.02)))
-  .s('sawtooth').cutoff(200).resonance(20).gain(.15).shape(.6).release(.05),
-  // perc
-  s("[~ hh]*4").room("0 0.5".fast(2)).end(perlin.range(0.02,1)),
-  s("mt lt ht").struct("x(3,8)").fast(2).gain(.5).room(.5).sometimes(x=>x.speed(".5")),
-  s("misc:2").speed(1).delay(.5).delaytime(1/3).gain(.4),
-  // chords
+  .s('sawtooth').cutoff(200).resonance(20).gain(.15).shape(.6).release(.05)",
+          "lang": "strudel",
+          "tag": "Code",
+        },
+        {
+          "code": "// perc
+  s("[~ hh]*4").room("0 0.5".fast(2)).end(perlin.range(0.02,1))",
+          "lang": "strudel",
+          "tag": "Code",
+        },
+        {
+          "else_": {
+            "body": {
+              "code": "",
+              "lang": "strudel",
+              "tag": "Code",
+              "via": {
+                "args": ".5",
+                "inner": {
+                  "body": {
+                    "body": {
+                      "children": [
+                        {
+                          "duration": 1,
+                          "note": "mt",
+                          "params": {
+                            "gain": 1,
+                            "s": "mt",
+                            "velocity": 1,
+                          },
+                          "tag": "Play",
+                        },
+                        {
+                          "duration": 1,
+                          "note": "lt",
+                          "params": {
+                            "gain": 1,
+                            "s": "lt",
+                            "velocity": 1,
+                          },
+                          "tag": "Play",
+                        },
+                        {
+                          "duration": 1,
+                          "note": "ht",
+                          "params": {
+                            "gain": 1,
+                            "s": "ht",
+                            "velocity": 1,
+                          },
+                          "tag": "Play",
+                        },
+                      ],
+                      "tag": "Seq",
+                    },
+                    "mask": "x(3,8)",
+                    "tag": "Struct",
+                    "userMethod": "struct",
+                  },
+                  "factor": 2,
+                  "tag": "Fast",
+                  "userMethod": "fast",
+                },
+                "method": "gain",
+              },
+            },
+            "name": "room",
+            "params": {
+              "room": 0.5,
+            },
+            "tag": "FX",
+            "userMethod": "room",
+          },
+          "p": 0.5,
+          "tag": "Choice",
+          "then": {
+            "body": {
+              "body": {
+                "code": "",
+                "lang": "strudel",
+                "tag": "Code",
+                "via": {
+                  "args": ".5",
+                  "inner": {
+                    "body": {
+                      "body": {
+                        "children": [
+                          {
+                            "duration": 1,
+                            "note": "mt",
+                            "params": {
+                              "gain": 1,
+                              "s": "mt",
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                          {
+                            "duration": 1,
+                            "note": "lt",
+                            "params": {
+                              "gain": 1,
+                              "s": "lt",
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                          {
+                            "duration": 1,
+                            "note": "ht",
+                            "params": {
+                              "gain": 1,
+                              "s": "ht",
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                        ],
+                        "tag": "Seq",
+                      },
+                      "mask": "x(3,8)",
+                      "tag": "Struct",
+                      "userMethod": "struct",
+                    },
+                    "factor": 2,
+                    "tag": "Fast",
+                    "userMethod": "fast",
+                  },
+                  "method": "gain",
+                },
+              },
+              "name": "room",
+              "params": {
+                "room": 0.5,
+              },
+              "tag": "FX",
+              "userMethod": "room",
+            },
+            "key": "speed",
+            "rawArgs": "".5"",
+            "tag": "Param",
+            "userMethod": "speed",
+            "value": {
+              "duration": 0.25,
+              "note": "5",
+              "params": {
+                "gain": 1,
+                "velocity": 1,
+              },
+              "tag": "Play",
+            },
+          },
+          "userMethod": "sometimes",
+        },
+        {
+          "code": "",
+          "lang": "strudel",
+          "tag": "Code",
+          "via": {
+            "args": ".4",
+            "inner": {
+              "code": "",
+              "lang": "strudel",
+              "tag": "Code",
+              "via": {
+                "args": "1/3",
+                "inner": {
+                  "body": {
+                    "body": {
+                      "duration": 1,
+                      "note": "misc",
+                      "params": {
+                        "gain": 1,
+                        "s": "misc",
+                        "slice": 2,
+                        "velocity": 1,
+                      },
+                      "tag": "Play",
+                    },
+                    "key": "speed",
+                    "rawArgs": "1",
+                    "tag": "Param",
+                    "userMethod": "speed",
+                    "value": 1,
+                  },
+                  "name": "delay",
+                  "params": {
+                    "delay": 0.5,
+                  },
+                  "tag": "FX",
+                  "userMethod": "delay",
+                },
+                "method": "delaytime",
+              },
+            },
+            "method": "gain",
+          },
+        },
+        {
+          "code": "// chords
   chord("[~ Gm7] ~ [~ Dm7] ~")
   .dict('lefthand').voicing()
   .add(note("0,.1"))
   .s('sawtooth').gain(.8)
   .cutoff(perlin.range(400,3000).slow(8))
   .decay(perlin.range(0.05,.2)).sustain(0)
-  .delay(.9).room(1),
-  // blips
+  .delay(.9).room(1)",
+          "lang": "strudel",
+          "tag": "Code",
+        },
+        {
+          "code": "// blips
   note(
     "0 5 4 2".iter(4)
     .off(1/3, add(7))
@@ -184,14 +841,24 @@ stack(
   ).s('square').cutoff(2000).decay(.03).sustain(0)
   .degradeBy(.2)
   .orbit(2).delay(.2).delaytime(".33 | .6 | .166 | .25")
-  .room(1).gain(.5).mask("<0 1>/8"),
-  // bell
+  .room(1).gain(.5).mask("<0 1>/8")",
+          "lang": "strudel",
+          "tag": "Code",
+        },
+        {
+          "code": "// bell
   note(rand.range(0,12).struct("x(5,8,-1)").scale('g2 minor pentatonic')).s('bell').begin(.05)
   .delay(.2).degradeBy(.4).gain(.4)
-  .mask("<1 0>/8")
-).slow(5)",
-    "lang": "strudel",
-    "tag": "Code",
+  .mask("<1 0>/8")",
+          "lang": "strudel",
+          "tag": "Code",
+        },
+      ],
+      "userMethod": "stack",
+    },
+    "factor": 5,
+    "tag": "Slow",
+    "userMethod": "slow",
   },
   "tag": "Track",
   "trackId": "d1",
@@ -201,21 +868,99 @@ stack(
 exports[`strudel.cc parity corpus — structural IR shape > chop parses to a stable IR shape 1`] = `
 {
   "body": {
-    "code": "// "Chop"
-// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
-// @by Felix Roos
-
-samples({ p: 'https://cdn.freesound.org/previews/648/648433_11943129-lq.mp3' })
-
-s("p")
-  .loopAt(32)
-  .chop(128)
-  .jux(rev)
-  .shape(.4)
-  .decay(.1)
-  .sustain(.6)",
+    "code": "",
     "lang": "strudel",
     "tag": "Code",
+    "via": {
+      "args": ".6",
+      "inner": {
+        "code": "",
+        "lang": "strudel",
+        "tag": "Code",
+        "via": {
+          "args": ".1",
+          "inner": {
+            "code": "",
+            "lang": "strudel",
+            "tag": "Code",
+            "via": {
+              "args": ".4",
+              "inner": {
+                "tag": "Stack",
+                "tracks": [
+                  {
+                    "body": {
+                      "body": {
+                        "code": "",
+                        "lang": "strudel",
+                        "tag": "Code",
+                        "via": {
+                          "args": "32",
+                          "inner": {
+                            "duration": 1,
+                            "note": "p",
+                            "params": {
+                              "gain": 1,
+                              "s": "p",
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                          "method": "loopAt",
+                        },
+                      },
+                      "n": 128,
+                      "tag": "Chop",
+                      "userMethod": "chop",
+                    },
+                    "name": "pan",
+                    "params": {
+                      "pan": -1,
+                    },
+                    "tag": "FX",
+                  },
+                  {
+                    "body": {
+                      "body": {
+                        "code": "",
+                        "lang": "strudel",
+                        "tag": "Code",
+                        "via": {
+                          "args": "32",
+                          "inner": {
+                            "duration": 1,
+                            "note": "p",
+                            "params": {
+                              "gain": 1,
+                              "s": "p",
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                          "method": "loopAt",
+                        },
+                      },
+                      "n": 128,
+                      "tag": "Chop",
+                      "userMethod": "chop",
+                    },
+                    "name": "pan",
+                    "params": {
+                      "pan": 1,
+                    },
+                    "tag": "FX",
+                  },
+                ],
+                "userMethod": "jux",
+              },
+              "method": "shape",
+            },
+          },
+          "method": "decay",
+        },
+      },
+      "method": "sustain",
+    },
   },
   "tag": "Track",
   "trackId": "d1",
@@ -225,18 +970,150 @@ s("p")
 exports[`strudel.cc parity corpus — structural IR shape > delay parses to a stable IR shape 1`] = `
 {
   "body": {
-    "code": "// "Delay"
-// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
-// @by Felix Roos
-
-stack(
-    s("bd <sd cp>")
-    .delay("<0 .5>")
-    .delaytime(".16 | .33")
-    .delayfeedback(".6 | .8")
-  ).sometimes(x=>x.speed("-1"))",
-    "lang": "strudel",
-    "tag": "Code",
+    "else_": {
+      "code": "",
+      "lang": "strudel",
+      "tag": "Code",
+      "via": {
+        "args": "".6 | .8"",
+        "inner": {
+          "code": "",
+          "lang": "strudel",
+          "tag": "Code",
+          "via": {
+            "args": "".16 | .33"",
+            "inner": {
+              "code": "",
+              "lang": "strudel",
+              "tag": "Code",
+              "via": {
+                "args": ""<0 .5>"",
+                "inner": {
+                  "children": [
+                    {
+                      "duration": 1,
+                      "note": "bd",
+                      "params": {
+                        "gain": 1,
+                        "s": "bd",
+                        "velocity": 1,
+                      },
+                      "tag": "Play",
+                    },
+                    {
+                      "items": [
+                        {
+                          "duration": 1,
+                          "note": "sd",
+                          "params": {
+                            "gain": 1,
+                            "s": "sd",
+                            "velocity": 1,
+                          },
+                          "tag": "Play",
+                        },
+                        {
+                          "duration": 1,
+                          "note": "cp",
+                          "params": {
+                            "gain": 1,
+                            "s": "cp",
+                            "velocity": 1,
+                          },
+                          "tag": "Play",
+                        },
+                      ],
+                      "tag": "Cycle",
+                    },
+                  ],
+                  "tag": "Seq",
+                },
+                "method": "delay",
+              },
+            },
+            "method": "delaytime",
+          },
+        },
+        "method": "delayfeedback",
+      },
+    },
+    "p": 0.5,
+    "tag": "Choice",
+    "then": {
+      "body": {
+        "code": "",
+        "lang": "strudel",
+        "tag": "Code",
+        "via": {
+          "args": "".6 | .8"",
+          "inner": {
+            "code": "",
+            "lang": "strudel",
+            "tag": "Code",
+            "via": {
+              "args": "".16 | .33"",
+              "inner": {
+                "code": "",
+                "lang": "strudel",
+                "tag": "Code",
+                "via": {
+                  "args": ""<0 .5>"",
+                  "inner": {
+                    "children": [
+                      {
+                        "duration": 1,
+                        "note": "bd",
+                        "params": {
+                          "gain": 1,
+                          "s": "bd",
+                          "velocity": 1,
+                        },
+                        "tag": "Play",
+                      },
+                      {
+                        "items": [
+                          {
+                            "duration": 1,
+                            "note": "sd",
+                            "params": {
+                              "gain": 1,
+                              "s": "sd",
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                          {
+                            "duration": 1,
+                            "note": "cp",
+                            "params": {
+                              "gain": 1,
+                              "s": "cp",
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                        ],
+                        "tag": "Cycle",
+                      },
+                    ],
+                    "tag": "Seq",
+                  },
+                  "method": "delay",
+                },
+              },
+              "method": "delaytime",
+            },
+          },
+          "method": "delayfeedback",
+        },
+      },
+      "key": "speed",
+      "rawArgs": ""-1"",
+      "tag": "Param",
+      "userMethod": "speed",
+      "value": "-1",
+    },
+    "userMethod": "sometimes",
   },
   "tag": "Track",
   "trackId": "d1",
@@ -246,37 +1123,332 @@ stack(
 exports[`strudel.cc parity corpus — structural IR shape > dinofunk parses to a stable IR shape 1`] = `
 {
   "body": {
-    "code": "// "Dinofunk"
-// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
-// @by Felix Roos
-
-setcps(1)
-useRNG('legacy')
-
-samples({bass:'https://cdn.freesound.org/previews/614/614637_2434927-hq.mp3',
-dino:{b4:'https://cdn.freesound.org/previews/316/316403_5123851-hq.mp3'}})
-setVoicingRange('lefthand', ['c3','a4'])
-
-stack(
-s('bass').loopAt(8).clip(1),
-s("bd*2, ~ sd,hh*4"),
-chord("Abm7")
+    "tag": "Stack",
+    "tracks": [
+      {
+        "code": "s('bass').loopAt(8).clip(1)",
+        "lang": "strudel",
+        "tag": "Code",
+      },
+      {
+        "children": [
+          {
+            "body": {
+              "duration": 1,
+              "note": "bd",
+              "params": {
+                "gain": 1,
+                "s": "bd",
+                "velocity": 1,
+              },
+              "tag": "Play",
+            },
+            "factor": 2,
+            "tag": "Fast",
+          },
+          {
+            "duration": 1,
+            "tag": "Sleep",
+          },
+          {
+            "duration": 1,
+            "note": "sd",
+            "params": {
+              "gain": 1,
+              "s": "sd",
+              "velocity": 1,
+            },
+            "tag": "Play",
+          },
+          {
+            "body": {
+              "duration": 1,
+              "note": "hh",
+              "params": {
+                "gain": 1,
+                "s": "hh",
+                "velocity": 1,
+              },
+              "tag": "Play",
+            },
+            "factor": 4,
+            "tag": "Fast",
+          },
+        ],
+        "tag": "Seq",
+      },
+      {
+        "code": "chord("Abm7")
   .mode("below:G4")
   .dict('lefthand')
   .voicing()
-  .struct("x(3,8,1)".slow(2)),
-"0 1 2 3".scale('ab4 minor pentatonic')
-.superimpose(x=>x.add(.1))
-.sometimes(x=>x.add(12))
-.note().s('sawtooth')
-.cutoff(sine.range(400,2000).slow(16)).gain(.8)
-.decay(perlin.range(.05,.2)).sustain(0)
-.delay(sine.range(0,.5).slow(32))
-.degradeBy(.4).room(1),
-note("<b4 eb4>").s('dino').delay(.8).slow(8).room(.5)
-)",
-    "lang": "strudel",
-    "tag": "Code",
+  .struct("x(3,8,1)".slow(2))",
+        "lang": "strudel",
+        "tag": "Code",
+      },
+      {
+        "body": {
+          "body": {
+            "code": "",
+            "lang": "strudel",
+            "tag": "Code",
+            "via": {
+              "args": "sine.range(0,.5).slow(32)",
+              "inner": {
+                "code": "",
+                "lang": "strudel",
+                "tag": "Code",
+                "via": {
+                  "args": "0",
+                  "inner": {
+                    "code": "",
+                    "lang": "strudel",
+                    "tag": "Code",
+                    "via": {
+                      "args": "perlin.range(.05,.2)",
+                      "inner": {
+                        "code": "",
+                        "lang": "strudel",
+                        "tag": "Code",
+                        "via": {
+                          "args": ".8",
+                          "inner": {
+                            "code": "",
+                            "lang": "strudel",
+                            "tag": "Code",
+                            "via": {
+                              "args": "sine.range(400,2000).slow(16)",
+                              "inner": {
+                                "code": "",
+                                "lang": "strudel",
+                                "tag": "Code",
+                                "via": {
+                                  "args": "'sawtooth'",
+                                  "inner": {
+                                    "code": "",
+                                    "lang": "strudel",
+                                    "tag": "Code",
+                                    "via": {
+                                      "args": "",
+                                      "inner": {
+                                        "else_": {
+                                          "code": "",
+                                          "lang": "strudel",
+                                          "tag": "Code",
+                                          "via": {
+                                            "args": "x=>x.add(.1)",
+                                            "inner": {
+                                              "code": "",
+                                              "lang": "strudel",
+                                              "tag": "Code",
+                                              "via": {
+                                                "args": "'ab4 minor pentatonic'",
+                                                "inner": {
+                                                  "children": [
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "0",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "1",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "2",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "3",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                  ],
+                                                  "tag": "Seq",
+                                                },
+                                                "method": "scale",
+                                              },
+                                            },
+                                            "method": "superimpose",
+                                          },
+                                        },
+                                        "p": 0.5,
+                                        "tag": "Choice",
+                                        "then": {
+                                          "code": "",
+                                          "lang": "strudel",
+                                          "tag": "Code",
+                                          "via": {
+                                            "args": "12",
+                                            "inner": {
+                                              "code": "",
+                                              "lang": "strudel",
+                                              "tag": "Code",
+                                              "via": {
+                                                "args": "x=>x.add(.1)",
+                                                "inner": {
+                                                  "code": "",
+                                                  "lang": "strudel",
+                                                  "tag": "Code",
+                                                  "via": {
+                                                    "args": "'ab4 minor pentatonic'",
+                                                    "inner": {
+                                                      "children": [
+                                                        {
+                                                          "duration": 0.25,
+                                                          "note": "0",
+                                                          "params": {
+                                                            "gain": 1,
+                                                            "velocity": 1,
+                                                          },
+                                                          "tag": "Play",
+                                                        },
+                                                        {
+                                                          "duration": 0.25,
+                                                          "note": "1",
+                                                          "params": {
+                                                            "gain": 1,
+                                                            "velocity": 1,
+                                                          },
+                                                          "tag": "Play",
+                                                        },
+                                                        {
+                                                          "duration": 0.25,
+                                                          "note": "2",
+                                                          "params": {
+                                                            "gain": 1,
+                                                            "velocity": 1,
+                                                          },
+                                                          "tag": "Play",
+                                                        },
+                                                        {
+                                                          "duration": 0.25,
+                                                          "note": "3",
+                                                          "params": {
+                                                            "gain": 1,
+                                                            "velocity": 1,
+                                                          },
+                                                          "tag": "Play",
+                                                        },
+                                                      ],
+                                                      "tag": "Seq",
+                                                    },
+                                                    "method": "scale",
+                                                  },
+                                                },
+                                                "method": "superimpose",
+                                              },
+                                            },
+                                            "method": "add",
+                                          },
+                                        },
+                                        "userMethod": "sometimes",
+                                      },
+                                      "method": "note",
+                                    },
+                                  },
+                                  "method": "s",
+                                },
+                              },
+                              "method": "cutoff",
+                            },
+                          },
+                          "method": "gain",
+                        },
+                      },
+                      "method": "decay",
+                    },
+                  },
+                  "method": "sustain",
+                },
+              },
+              "method": "delay",
+            },
+          },
+          "p": 0.6,
+          "tag": "Degrade",
+          "userMethod": "degradeBy",
+        },
+        "name": "room",
+        "params": {
+          "room": 1,
+        },
+        "tag": "FX",
+        "userMethod": "room",
+      },
+      {
+        "body": {
+          "body": {
+            "body": {
+              "code": "",
+              "lang": "strudel",
+              "tag": "Code",
+              "via": {
+                "args": "'dino'",
+                "inner": {
+                  "items": [
+                    {
+                      "duration": 0.25,
+                      "note": "b4",
+                      "params": {
+                        "gain": 1,
+                        "velocity": 1,
+                      },
+                      "tag": "Play",
+                    },
+                    {
+                      "duration": 0.25,
+                      "note": "eb4",
+                      "params": {
+                        "gain": 1,
+                        "velocity": 1,
+                      },
+                      "tag": "Play",
+                    },
+                  ],
+                  "tag": "Cycle",
+                },
+                "method": "s",
+              },
+            },
+            "name": "delay",
+            "params": {
+              "delay": 0.8,
+            },
+            "tag": "FX",
+            "userMethod": "delay",
+          },
+          "factor": 8,
+          "tag": "Slow",
+          "userMethod": "slow",
+        },
+        "name": "room",
+        "params": {
+          "room": 0.5,
+        },
+        "tag": "FX",
+        "userMethod": "room",
+      },
+    ],
+    "userMethod": "stack",
   },
   "tag": "Track",
   "trackId": "d1",
@@ -286,20 +1458,513 @@ note("<b4 eb4>").s('dino').delay(.8).slow(8).room(.5)
 exports[`strudel.cc parity corpus — structural IR shape > echoPiano parses to a stable IR shape 1`] = `
 {
   "body": {
-    "code": "// "Echo piano"
-// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
-// @by Felix Roos
-
-n("<0 2 [4 6](3,4,2) 3*2>").color('salmon')
-.off(1/4, x=>x.add(n(2)).color('green'))
-.off(1/2, x=>x.add(n(6)).color('steelblue'))
-.scale('D minor')
-.echo(4, 1/8, .5)
-.clip(.5)
-.piano()
-.pianoroll()",
+    "code": "",
     "lang": "strudel",
     "tag": "Code",
+    "via": {
+      "args": "",
+      "inner": {
+        "code": "",
+        "lang": "strudel",
+        "tag": "Code",
+        "via": {
+          "args": "",
+          "inner": {
+            "code": "",
+            "lang": "strudel",
+            "tag": "Code",
+            "via": {
+              "args": ".5",
+              "inner": {
+                "code": "",
+                "lang": "strudel",
+                "tag": "Code",
+                "via": {
+                  "args": "4, 1/8, .5",
+                  "inner": {
+                    "code": "",
+                    "lang": "strudel",
+                    "tag": "Code",
+                    "via": {
+                      "args": "'D minor'",
+                      "inner": {
+                        "tag": "Stack",
+                        "tracks": [
+                          {
+                            "tag": "Stack",
+                            "tracks": [
+                              {
+                                "code": "",
+                                "lang": "strudel",
+                                "tag": "Code",
+                                "via": {
+                                  "args": "'salmon'",
+                                  "inner": {
+                                    "items": [
+                                      {
+                                        "duration": 0.25,
+                                        "note": "0",
+                                        "params": {
+                                          "gain": 1,
+                                          "velocity": 1,
+                                        },
+                                        "tag": "Play",
+                                      },
+                                      {
+                                        "duration": 0.25,
+                                        "note": "2",
+                                        "params": {
+                                          "gain": 1,
+                                          "velocity": 1,
+                                        },
+                                        "tag": "Play",
+                                      },
+                                      {
+                                        "children": [
+                                          {
+                                            "duration": 0.25,
+                                            "note": "4",
+                                            "params": {
+                                              "gain": 1,
+                                              "velocity": 1,
+                                            },
+                                            "tag": "Play",
+                                          },
+                                          {
+                                            "duration": 0.25,
+                                            "note": "6",
+                                            "params": {
+                                              "gain": 1,
+                                              "velocity": 1,
+                                            },
+                                            "tag": "Play",
+                                          },
+                                        ],
+                                        "tag": "Seq",
+                                      },
+                                      {
+                                        "duration": 0.25,
+                                        "note": "3",
+                                        "params": {
+                                          "gain": 1,
+                                          "velocity": 1,
+                                        },
+                                        "tag": "Play",
+                                      },
+                                      {
+                                        "duration": 0.25,
+                                        "note": "4",
+                                        "params": {
+                                          "gain": 1,
+                                          "velocity": 1,
+                                        },
+                                        "tag": "Play",
+                                      },
+                                      {
+                                        "duration": 0.25,
+                                        "note": "2",
+                                        "params": {
+                                          "gain": 1,
+                                          "velocity": 1,
+                                        },
+                                        "tag": "Play",
+                                      },
+                                      {
+                                        "body": {
+                                          "duration": 0.25,
+                                          "note": "3",
+                                          "params": {
+                                            "gain": 1,
+                                            "velocity": 1,
+                                          },
+                                          "tag": "Play",
+                                        },
+                                        "factor": 2,
+                                        "tag": "Fast",
+                                      },
+                                    ],
+                                    "tag": "Cycle",
+                                  },
+                                  "method": "color",
+                                },
+                              },
+                              {
+                                "code": "",
+                                "lang": "strudel",
+                                "tag": "Code",
+                                "via": {
+                                  "args": "'green'",
+                                  "inner": {
+                                    "code": "",
+                                    "lang": "strudel",
+                                    "tag": "Code",
+                                    "via": {
+                                      "args": "n(2)",
+                                      "inner": {
+                                        "body": {
+                                          "code": "",
+                                          "lang": "strudel",
+                                          "tag": "Code",
+                                          "via": {
+                                            "args": "'salmon'",
+                                            "inner": {
+                                              "items": [
+                                                {
+                                                  "duration": 0.25,
+                                                  "note": "0",
+                                                  "params": {
+                                                    "gain": 1,
+                                                    "velocity": 1,
+                                                  },
+                                                  "tag": "Play",
+                                                },
+                                                {
+                                                  "duration": 0.25,
+                                                  "note": "2",
+                                                  "params": {
+                                                    "gain": 1,
+                                                    "velocity": 1,
+                                                  },
+                                                  "tag": "Play",
+                                                },
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "4",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "6",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                  ],
+                                                  "tag": "Seq",
+                                                },
+                                                {
+                                                  "duration": 0.25,
+                                                  "note": "3",
+                                                  "params": {
+                                                    "gain": 1,
+                                                    "velocity": 1,
+                                                  },
+                                                  "tag": "Play",
+                                                },
+                                                {
+                                                  "duration": 0.25,
+                                                  "note": "4",
+                                                  "params": {
+                                                    "gain": 1,
+                                                    "velocity": 1,
+                                                  },
+                                                  "tag": "Play",
+                                                },
+                                                {
+                                                  "duration": 0.25,
+                                                  "note": "2",
+                                                  "params": {
+                                                    "gain": 1,
+                                                    "velocity": 1,
+                                                  },
+                                                  "tag": "Play",
+                                                },
+                                                {
+                                                  "body": {
+                                                    "duration": 0.25,
+                                                    "note": "3",
+                                                    "params": {
+                                                      "gain": 1,
+                                                      "velocity": 1,
+                                                    },
+                                                    "tag": "Play",
+                                                  },
+                                                  "factor": 2,
+                                                  "tag": "Fast",
+                                                },
+                                              ],
+                                              "tag": "Cycle",
+                                            },
+                                            "method": "color",
+                                          },
+                                        },
+                                        "offset": 1,
+                                        "tag": "Late",
+                                      },
+                                      "method": "add",
+                                    },
+                                  },
+                                  "method": "color",
+                                },
+                              },
+                            ],
+                            "userMethod": "off",
+                          },
+                          {
+                            "code": "",
+                            "lang": "strudel",
+                            "tag": "Code",
+                            "via": {
+                              "args": "'steelblue'",
+                              "inner": {
+                                "code": "",
+                                "lang": "strudel",
+                                "tag": "Code",
+                                "via": {
+                                  "args": "n(6)",
+                                  "inner": {
+                                    "body": {
+                                      "tag": "Stack",
+                                      "tracks": [
+                                        {
+                                          "code": "",
+                                          "lang": "strudel",
+                                          "tag": "Code",
+                                          "via": {
+                                            "args": "'salmon'",
+                                            "inner": {
+                                              "items": [
+                                                {
+                                                  "duration": 0.25,
+                                                  "note": "0",
+                                                  "params": {
+                                                    "gain": 1,
+                                                    "velocity": 1,
+                                                  },
+                                                  "tag": "Play",
+                                                },
+                                                {
+                                                  "duration": 0.25,
+                                                  "note": "2",
+                                                  "params": {
+                                                    "gain": 1,
+                                                    "velocity": 1,
+                                                  },
+                                                  "tag": "Play",
+                                                },
+                                                {
+                                                  "children": [
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "4",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                    {
+                                                      "duration": 0.25,
+                                                      "note": "6",
+                                                      "params": {
+                                                        "gain": 1,
+                                                        "velocity": 1,
+                                                      },
+                                                      "tag": "Play",
+                                                    },
+                                                  ],
+                                                  "tag": "Seq",
+                                                },
+                                                {
+                                                  "duration": 0.25,
+                                                  "note": "3",
+                                                  "params": {
+                                                    "gain": 1,
+                                                    "velocity": 1,
+                                                  },
+                                                  "tag": "Play",
+                                                },
+                                                {
+                                                  "duration": 0.25,
+                                                  "note": "4",
+                                                  "params": {
+                                                    "gain": 1,
+                                                    "velocity": 1,
+                                                  },
+                                                  "tag": "Play",
+                                                },
+                                                {
+                                                  "duration": 0.25,
+                                                  "note": "2",
+                                                  "params": {
+                                                    "gain": 1,
+                                                    "velocity": 1,
+                                                  },
+                                                  "tag": "Play",
+                                                },
+                                                {
+                                                  "body": {
+                                                    "duration": 0.25,
+                                                    "note": "3",
+                                                    "params": {
+                                                      "gain": 1,
+                                                      "velocity": 1,
+                                                    },
+                                                    "tag": "Play",
+                                                  },
+                                                  "factor": 2,
+                                                  "tag": "Fast",
+                                                },
+                                              ],
+                                              "tag": "Cycle",
+                                            },
+                                            "method": "color",
+                                          },
+                                        },
+                                        {
+                                          "code": "",
+                                          "lang": "strudel",
+                                          "tag": "Code",
+                                          "via": {
+                                            "args": "'green'",
+                                            "inner": {
+                                              "code": "",
+                                              "lang": "strudel",
+                                              "tag": "Code",
+                                              "via": {
+                                                "args": "n(2)",
+                                                "inner": {
+                                                  "body": {
+                                                    "code": "",
+                                                    "lang": "strudel",
+                                                    "tag": "Code",
+                                                    "via": {
+                                                      "args": "'salmon'",
+                                                      "inner": {
+                                                        "items": [
+                                                          {
+                                                            "duration": 0.25,
+                                                            "note": "0",
+                                                            "params": {
+                                                              "gain": 1,
+                                                              "velocity": 1,
+                                                            },
+                                                            "tag": "Play",
+                                                          },
+                                                          {
+                                                            "duration": 0.25,
+                                                            "note": "2",
+                                                            "params": {
+                                                              "gain": 1,
+                                                              "velocity": 1,
+                                                            },
+                                                            "tag": "Play",
+                                                          },
+                                                          {
+                                                            "children": [
+                                                              {
+                                                                "duration": 0.25,
+                                                                "note": "4",
+                                                                "params": {
+                                                                  "gain": 1,
+                                                                  "velocity": 1,
+                                                                },
+                                                                "tag": "Play",
+                                                              },
+                                                              {
+                                                                "duration": 0.25,
+                                                                "note": "6",
+                                                                "params": {
+                                                                  "gain": 1,
+                                                                  "velocity": 1,
+                                                                },
+                                                                "tag": "Play",
+                                                              },
+                                                            ],
+                                                            "tag": "Seq",
+                                                          },
+                                                          {
+                                                            "duration": 0.25,
+                                                            "note": "3",
+                                                            "params": {
+                                                              "gain": 1,
+                                                              "velocity": 1,
+                                                            },
+                                                            "tag": "Play",
+                                                          },
+                                                          {
+                                                            "duration": 0.25,
+                                                            "note": "4",
+                                                            "params": {
+                                                              "gain": 1,
+                                                              "velocity": 1,
+                                                            },
+                                                            "tag": "Play",
+                                                          },
+                                                          {
+                                                            "duration": 0.25,
+                                                            "note": "2",
+                                                            "params": {
+                                                              "gain": 1,
+                                                              "velocity": 1,
+                                                            },
+                                                            "tag": "Play",
+                                                          },
+                                                          {
+                                                            "body": {
+                                                              "duration": 0.25,
+                                                              "note": "3",
+                                                              "params": {
+                                                                "gain": 1,
+                                                                "velocity": 1,
+                                                              },
+                                                              "tag": "Play",
+                                                            },
+                                                            "factor": 2,
+                                                            "tag": "Fast",
+                                                          },
+                                                        ],
+                                                        "tag": "Cycle",
+                                                      },
+                                                      "method": "color",
+                                                    },
+                                                  },
+                                                  "offset": 1,
+                                                  "tag": "Late",
+                                                },
+                                                "method": "add",
+                                              },
+                                            },
+                                            "method": "color",
+                                          },
+                                        },
+                                      ],
+                                      "userMethod": "off",
+                                    },
+                                    "offset": 1,
+                                    "tag": "Late",
+                                  },
+                                  "method": "add",
+                                },
+                              },
+                              "method": "color",
+                            },
+                          },
+                        ],
+                        "userMethod": "off",
+                      },
+                      "method": "scale",
+                    },
+                  },
+                  "method": "echo",
+                },
+              },
+              "method": "clip",
+            },
+          },
+          "method": "piano",
+        },
+      },
+      "method": "pianoroll",
+    },
   },
   "tag": "Track",
   "trackId": "d1",
@@ -309,35 +1974,626 @@ n("<0 2 [4 6](3,4,2) 3*2>").color('salmon')
 exports[`strudel.cc parity corpus — structural IR shape > flatrave parses to a stable IR shape 1`] = `
 {
   "body": {
-    "code": "// "Flatrave"
-// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
-// @by Felix Roos
-
-useRNG('legacy')
-
-stack(
-  s("bd*2,~ [cp,sd]").bank('RolandTR909'),
-  
-  s("hh:1*4").sometimes(fast("2"))
-  .rarely(x=>x.speed(".5").delay(.5))
-  .end(perlin.range(0.02,.05).slow(8))
-  .bank('RolandTR909').room(.5)
-  .gain("0.4,0.4(5,8,-1)"),
-  
-  note("<0 2 5 3>".scale('G1 minor')).struct("x(5,8,-1)")
+    "tag": "Stack",
+    "tracks": [
+      {
+        "code": "",
+        "lang": "strudel",
+        "tag": "Code",
+        "via": {
+          "args": "'RolandTR909'",
+          "inner": {
+            "children": [
+              {
+                "body": {
+                  "duration": 1,
+                  "note": "bd",
+                  "params": {
+                    "gain": 1,
+                    "s": "bd",
+                    "velocity": 1,
+                  },
+                  "tag": "Play",
+                },
+                "factor": 2,
+                "tag": "Fast",
+              },
+              {
+                "duration": 1,
+                "tag": "Sleep",
+              },
+              {
+                "children": [
+                  {
+                    "duration": 1,
+                    "note": "cp",
+                    "params": {
+                      "gain": 1,
+                      "s": "cp",
+                      "velocity": 1,
+                    },
+                    "tag": "Play",
+                  },
+                  {
+                    "duration": 1,
+                    "note": "sd",
+                    "params": {
+                      "gain": 1,
+                      "s": "sd",
+                      "velocity": 1,
+                    },
+                    "tag": "Play",
+                  },
+                ],
+                "tag": "Seq",
+              },
+            ],
+            "tag": "Seq",
+          },
+          "method": "bank",
+        },
+      },
+      {
+        "body": {
+          "body": {
+            "code": "",
+            "lang": "strudel",
+            "tag": "Code",
+            "via": {
+              "args": "'RolandTR909'",
+              "inner": {
+                "code": "",
+                "lang": "strudel",
+                "tag": "Code",
+                "via": {
+                  "args": "perlin.range(0.02,.05).slow(8)",
+                  "inner": {
+                    "code": "",
+                    "lang": "strudel",
+                    "tag": "Code",
+                    "via": {
+                      "args": "x=>x.speed(".5").delay(.5)",
+                      "inner": {
+                        "else_": {
+                          "body": {
+                            "duration": 1,
+                            "note": "hh",
+                            "params": {
+                              "gain": 1,
+                              "s": "hh",
+                              "slice": 1,
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                          "factor": 4,
+                          "tag": "Fast",
+                        },
+                        "p": 0.5,
+                        "tag": "Choice",
+                        "then": {
+                          "body": {
+                            "duration": 1,
+                            "note": "hh",
+                            "params": {
+                              "gain": 1,
+                              "s": "hh",
+                              "slice": 1,
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                          "factor": 4,
+                          "tag": "Fast",
+                        },
+                        "userMethod": "sometimes",
+                      },
+                      "method": "rarely",
+                    },
+                  },
+                  "method": "end",
+                },
+              },
+              "method": "bank",
+            },
+          },
+          "name": "room",
+          "params": {
+            "room": 0.5,
+          },
+          "tag": "FX",
+          "userMethod": "room",
+        },
+        "key": "gain",
+        "rawArgs": ""0.4,0.4(5,8,-1)"",
+        "tag": "Param",
+        "userMethod": "gain",
+        "value": {
+          "children": [
+            {
+              "duration": 0.25,
+              "note": "0.4",
+              "params": {
+                "gain": 1,
+                "velocity": 1,
+              },
+              "tag": "Play",
+            },
+            {
+              "children": [
+                {
+                  "duration": 0.25,
+                  "note": "0.4",
+                  "params": {
+                    "gain": 1,
+                    "velocity": 1,
+                  },
+                  "tag": "Play",
+                },
+                {
+                  "duration": 0.25,
+                  "note": "0.4",
+                  "params": {
+                    "gain": 1,
+                    "velocity": 1,
+                  },
+                  "tag": "Play",
+                },
+                {
+                  "duration": 1,
+                  "tag": "Sleep",
+                },
+                {
+                  "duration": 0.25,
+                  "note": "0.4",
+                  "params": {
+                    "gain": 1,
+                    "velocity": 1,
+                  },
+                  "tag": "Play",
+                },
+                {
+                  "duration": 1,
+                  "tag": "Sleep",
+                },
+                {
+                  "duration": 0.25,
+                  "note": "0.4",
+                  "params": {
+                    "gain": 1,
+                    "velocity": 1,
+                  },
+                  "tag": "Play",
+                },
+                {
+                  "duration": 1,
+                  "tag": "Sleep",
+                },
+                {
+                  "duration": 0.25,
+                  "note": "0.4",
+                  "params": {
+                    "gain": 1,
+                    "velocity": 1,
+                  },
+                  "tag": "Play",
+                },
+              ],
+              "tag": "Seq",
+            },
+          ],
+          "tag": "Seq",
+        },
+      },
+      {
+        "code": "note("<0 2 5 3>".scale('G1 minor')).struct("x(5,8,-1)")
   .s('sawtooth').decay(.1).sustain(0)
-  .lpa(.1).lpenv(-4).lpf(800).lpq(8),
-  
-  note("<G4 A4 Bb4 A4>,Bb3,D3").struct("~ x*2").s('square').clip(1)
-  .cutoff(sine.range(500,4000).slow(16)).resonance(10)
-  .decay(sine.slow(15).range(.05,.2)).sustain(0)
-  .room(.5).gain(.3).delay(.2).mask("<0 1@3>/8"),
-  
-  "0 5 3 2".sometimes(slow(2)).off(1/8,add(5)).scale('G4 minor').note()
-  .decay(.05).sustain(0).delay(.2).degradeBy(.5).mask("<0 1>/16")
-)",
-    "lang": "strudel",
-    "tag": "Code",
+  .lpa(.1).lpenv(-4).lpf(800).lpq(8)",
+        "lang": "strudel",
+        "tag": "Code",
+      },
+      {
+        "body": {
+          "body": {
+            "code": "",
+            "lang": "strudel",
+            "tag": "Code",
+            "via": {
+              "args": ".3",
+              "inner": {
+                "body": {
+                  "code": "",
+                  "lang": "strudel",
+                  "tag": "Code",
+                  "via": {
+                    "args": "0",
+                    "inner": {
+                      "code": "",
+                      "lang": "strudel",
+                      "tag": "Code",
+                      "via": {
+                        "args": "sine.slow(15).range(.05,.2)",
+                        "inner": {
+                          "body": {
+                            "code": "",
+                            "lang": "strudel",
+                            "tag": "Code",
+                            "via": {
+                              "args": "sine.range(500,4000).slow(16)",
+                              "inner": {
+                                "code": "",
+                                "lang": "strudel",
+                                "tag": "Code",
+                                "via": {
+                                  "args": "1",
+                                  "inner": {
+                                    "code": "",
+                                    "lang": "strudel",
+                                    "tag": "Code",
+                                    "via": {
+                                      "args": "'square'",
+                                      "inner": {
+                                        "body": {
+                                          "children": [
+                                            {
+                                              "items": [
+                                                {
+                                                  "duration": 0.25,
+                                                  "note": "G4",
+                                                  "params": {
+                                                    "gain": 1,
+                                                    "velocity": 1,
+                                                  },
+                                                  "tag": "Play",
+                                                },
+                                                {
+                                                  "duration": 0.25,
+                                                  "note": "A4",
+                                                  "params": {
+                                                    "gain": 1,
+                                                    "velocity": 1,
+                                                  },
+                                                  "tag": "Play",
+                                                },
+                                                {
+                                                  "duration": 0.25,
+                                                  "note": "Bb4",
+                                                  "params": {
+                                                    "gain": 1,
+                                                    "velocity": 1,
+                                                  },
+                                                  "tag": "Play",
+                                                },
+                                                {
+                                                  "duration": 0.25,
+                                                  "note": "A4",
+                                                  "params": {
+                                                    "gain": 1,
+                                                    "velocity": 1,
+                                                  },
+                                                  "tag": "Play",
+                                                },
+                                              ],
+                                              "tag": "Cycle",
+                                            },
+                                            {
+                                              "duration": 0.25,
+                                              "note": "Bb3",
+                                              "params": {
+                                                "gain": 1,
+                                                "velocity": 1,
+                                              },
+                                              "tag": "Play",
+                                            },
+                                            {
+                                              "duration": 0.25,
+                                              "note": "D3",
+                                              "params": {
+                                                "gain": 1,
+                                                "velocity": 1,
+                                              },
+                                              "tag": "Play",
+                                            },
+                                          ],
+                                          "tag": "Seq",
+                                        },
+                                        "mask": "~ x*2",
+                                        "tag": "Struct",
+                                        "userMethod": "struct",
+                                      },
+                                      "method": "s",
+                                    },
+                                  },
+                                  "method": "clip",
+                                },
+                              },
+                              "method": "cutoff",
+                            },
+                          },
+                          "name": "resonance",
+                          "params": {
+                            "resonance": 10,
+                          },
+                          "tag": "FX",
+                          "userMethod": "resonance",
+                        },
+                        "method": "decay",
+                      },
+                    },
+                    "method": "sustain",
+                  },
+                },
+                "name": "room",
+                "params": {
+                  "room": 0.5,
+                },
+                "tag": "FX",
+                "userMethod": "room",
+              },
+              "method": "gain",
+            },
+          },
+          "name": "delay",
+          "params": {
+            "delay": 0.2,
+          },
+          "tag": "FX",
+          "userMethod": "delay",
+        },
+        "gate": "<0 1@3>/8",
+        "tag": "When",
+        "userMethod": "mask",
+      },
+      {
+        "body": {
+          "body": {
+            "body": {
+              "code": "",
+              "lang": "strudel",
+              "tag": "Code",
+              "via": {
+                "args": "0",
+                "inner": {
+                  "code": "",
+                  "lang": "strudel",
+                  "tag": "Code",
+                  "via": {
+                    "args": ".05",
+                    "inner": {
+                      "code": "",
+                      "lang": "strudel",
+                      "tag": "Code",
+                      "via": {
+                        "args": "",
+                        "inner": {
+                          "code": "",
+                          "lang": "strudel",
+                          "tag": "Code",
+                          "via": {
+                            "args": "'G4 minor'",
+                            "inner": {
+                              "tag": "Stack",
+                              "tracks": [
+                                {
+                                  "else_": {
+                                    "children": [
+                                      {
+                                        "duration": 0.25,
+                                        "note": "0",
+                                        "params": {
+                                          "gain": 1,
+                                          "velocity": 1,
+                                        },
+                                        "tag": "Play",
+                                      },
+                                      {
+                                        "duration": 0.25,
+                                        "note": "5",
+                                        "params": {
+                                          "gain": 1,
+                                          "velocity": 1,
+                                        },
+                                        "tag": "Play",
+                                      },
+                                      {
+                                        "duration": 0.25,
+                                        "note": "3",
+                                        "params": {
+                                          "gain": 1,
+                                          "velocity": 1,
+                                        },
+                                        "tag": "Play",
+                                      },
+                                      {
+                                        "duration": 0.25,
+                                        "note": "2",
+                                        "params": {
+                                          "gain": 1,
+                                          "velocity": 1,
+                                        },
+                                        "tag": "Play",
+                                      },
+                                    ],
+                                    "tag": "Seq",
+                                  },
+                                  "p": 0.5,
+                                  "tag": "Choice",
+                                  "then": {
+                                    "body": {
+                                      "children": [
+                                        {
+                                          "duration": 0.25,
+                                          "note": "0",
+                                          "params": {
+                                            "gain": 1,
+                                            "velocity": 1,
+                                          },
+                                          "tag": "Play",
+                                        },
+                                        {
+                                          "duration": 0.25,
+                                          "note": "5",
+                                          "params": {
+                                            "gain": 1,
+                                            "velocity": 1,
+                                          },
+                                          "tag": "Play",
+                                        },
+                                        {
+                                          "duration": 0.25,
+                                          "note": "3",
+                                          "params": {
+                                            "gain": 1,
+                                            "velocity": 1,
+                                          },
+                                          "tag": "Play",
+                                        },
+                                        {
+                                          "duration": 0.25,
+                                          "note": "2",
+                                          "params": {
+                                            "gain": 1,
+                                            "velocity": 1,
+                                          },
+                                          "tag": "Play",
+                                        },
+                                      ],
+                                      "tag": "Seq",
+                                    },
+                                    "factor": 2,
+                                    "tag": "Slow",
+                                    "userMethod": "slow",
+                                  },
+                                  "userMethod": "sometimes",
+                                },
+                                {
+                                  "body": {
+                                    "else_": {
+                                      "children": [
+                                        {
+                                          "duration": 0.25,
+                                          "note": "0",
+                                          "params": {
+                                            "gain": 1,
+                                            "velocity": 1,
+                                          },
+                                          "tag": "Play",
+                                        },
+                                        {
+                                          "duration": 0.25,
+                                          "note": "5",
+                                          "params": {
+                                            "gain": 1,
+                                            "velocity": 1,
+                                          },
+                                          "tag": "Play",
+                                        },
+                                        {
+                                          "duration": 0.25,
+                                          "note": "3",
+                                          "params": {
+                                            "gain": 1,
+                                            "velocity": 1,
+                                          },
+                                          "tag": "Play",
+                                        },
+                                        {
+                                          "duration": 0.25,
+                                          "note": "2",
+                                          "params": {
+                                            "gain": 1,
+                                            "velocity": 1,
+                                          },
+                                          "tag": "Play",
+                                        },
+                                      ],
+                                      "tag": "Seq",
+                                    },
+                                    "p": 0.5,
+                                    "tag": "Choice",
+                                    "then": {
+                                      "body": {
+                                        "children": [
+                                          {
+                                            "duration": 0.25,
+                                            "note": "0",
+                                            "params": {
+                                              "gain": 1,
+                                              "velocity": 1,
+                                            },
+                                            "tag": "Play",
+                                          },
+                                          {
+                                            "duration": 0.25,
+                                            "note": "5",
+                                            "params": {
+                                              "gain": 1,
+                                              "velocity": 1,
+                                            },
+                                            "tag": "Play",
+                                          },
+                                          {
+                                            "duration": 0.25,
+                                            "note": "3",
+                                            "params": {
+                                              "gain": 1,
+                                              "velocity": 1,
+                                            },
+                                            "tag": "Play",
+                                          },
+                                          {
+                                            "duration": 0.25,
+                                            "note": "2",
+                                            "params": {
+                                              "gain": 1,
+                                              "velocity": 1,
+                                            },
+                                            "tag": "Play",
+                                          },
+                                        ],
+                                        "tag": "Seq",
+                                      },
+                                      "factor": 2,
+                                      "tag": "Slow",
+                                      "userMethod": "slow",
+                                    },
+                                    "userMethod": "sometimes",
+                                  },
+                                  "offset": 1,
+                                  "tag": "Late",
+                                },
+                              ],
+                              "userMethod": "off",
+                            },
+                            "method": "scale",
+                          },
+                        },
+                        "method": "note",
+                      },
+                    },
+                    "method": "decay",
+                  },
+                },
+                "method": "sustain",
+              },
+            },
+            "name": "delay",
+            "params": {
+              "delay": 0.2,
+            },
+            "tag": "FX",
+            "userMethod": "delay",
+          },
+          "p": 0.5,
+          "tag": "Degrade",
+          "userMethod": "degradeBy",
+        },
+        "gate": "<0 1>/16",
+        "tag": "When",
+        "userMethod": "mask",
+      },
+    ],
+    "userMethod": "stack",
   },
   "tag": "Track",
   "trackId": "d1",
@@ -347,23 +2603,222 @@ stack(
 exports[`strudel.cc parity corpus — structural IR shape > holyflute parses to a stable IR shape 1`] = `
 {
   "body": {
-    "code": "// "Holy flute"
-// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
-// @by Felix Roos
-
-useRNG('legacy')
-
-"c3 eb3(3,8) c4/2 g3*2"
-.superimpose(
-  x=>x.slow(2).add(12),
-  x=>x.slow(4).sub(5)
-).add("<0 1>/16")
-.note().s('ocarina_vib').clip(1)
-.release(.1).room(1).gain(.2)
-.color("salmon | orange | darkseagreen")
-.pianoroll({fold:0,autorange:0,vertical:0,cycles:12,smear:0,minMidi:40})",
+    "code": "",
     "lang": "strudel",
     "tag": "Code",
+    "via": {
+      "args": "{fold:0,autorange:0,vertical:0,cycles:12,smear:0,minMidi:40}",
+      "inner": {
+        "body": {
+          "code": "",
+          "lang": "strudel",
+          "tag": "Code",
+          "via": {
+            "args": ".2",
+            "inner": {
+              "body": {
+                "code": "",
+                "lang": "strudel",
+                "tag": "Code",
+                "via": {
+                  "args": ".1",
+                  "inner": {
+                    "code": "",
+                    "lang": "strudel",
+                    "tag": "Code",
+                    "via": {
+                      "args": "1",
+                      "inner": {
+                        "code": "",
+                        "lang": "strudel",
+                        "tag": "Code",
+                        "via": {
+                          "args": "'ocarina_vib'",
+                          "inner": {
+                            "code": "",
+                            "lang": "strudel",
+                            "tag": "Code",
+                            "via": {
+                              "args": "",
+                              "inner": {
+                                "code": "",
+                                "lang": "strudel",
+                                "tag": "Code",
+                                "via": {
+                                  "args": ""<0 1>/16"",
+                                  "inner": {
+                                    "code": "",
+                                    "lang": "strudel",
+                                    "tag": "Code",
+                                    "via": {
+                                      "args": "
+  x=>x.slow(2).add(12),
+  x=>x.slow(4).sub(5)
+",
+                                      "inner": {
+                                        "children": [
+                                          {
+                                            "duration": 0.25,
+                                            "note": "c3",
+                                            "params": {
+                                              "gain": 1,
+                                              "velocity": 1,
+                                            },
+                                            "tag": "Play",
+                                          },
+                                          {
+                                            "children": [
+                                              {
+                                                "duration": 0.25,
+                                                "note": "eb3",
+                                                "params": {
+                                                  "gain": 1,
+                                                  "velocity": 1,
+                                                },
+                                                "tag": "Play",
+                                              },
+                                              {
+                                                "duration": 1,
+                                                "tag": "Sleep",
+                                              },
+                                              {
+                                                "duration": 1,
+                                                "tag": "Sleep",
+                                              },
+                                              {
+                                                "duration": 0.25,
+                                                "note": "eb3",
+                                                "params": {
+                                                  "gain": 1,
+                                                  "velocity": 1,
+                                                },
+                                                "tag": "Play",
+                                              },
+                                              {
+                                                "duration": 1,
+                                                "tag": "Sleep",
+                                              },
+                                              {
+                                                "duration": 1,
+                                                "tag": "Sleep",
+                                              },
+                                              {
+                                                "duration": 0.25,
+                                                "note": "eb3",
+                                                "params": {
+                                                  "gain": 1,
+                                                  "velocity": 1,
+                                                },
+                                                "tag": "Play",
+                                              },
+                                              {
+                                                "duration": 1,
+                                                "tag": "Sleep",
+                                              },
+                                            ],
+                                            "tag": "Seq",
+                                          },
+                                          {
+                                            "duration": 0.25,
+                                            "note": "c4",
+                                            "params": {
+                                              "gain": 1,
+                                              "velocity": 1,
+                                            },
+                                            "tag": "Play",
+                                          },
+                                          {
+                                            "duration": 0.25,
+                                            "note": "2",
+                                            "params": {
+                                              "gain": 1,
+                                              "velocity": 1,
+                                            },
+                                            "tag": "Play",
+                                          },
+                                          {
+                                            "body": {
+                                              "duration": 0.25,
+                                              "note": "g3",
+                                              "params": {
+                                                "gain": 1,
+                                                "velocity": 1,
+                                              },
+                                              "tag": "Play",
+                                            },
+                                            "factor": 2,
+                                            "tag": "Fast",
+                                          },
+                                        ],
+                                        "tag": "Seq",
+                                      },
+                                      "method": "superimpose",
+                                    },
+                                  },
+                                  "method": "add",
+                                },
+                              },
+                              "method": "note",
+                            },
+                          },
+                          "method": "s",
+                        },
+                      },
+                      "method": "clip",
+                    },
+                  },
+                  "method": "release",
+                },
+              },
+              "name": "room",
+              "params": {
+                "room": 1,
+              },
+              "tag": "FX",
+              "userMethod": "room",
+            },
+            "method": "gain",
+          },
+        },
+        "key": "color",
+        "rawArgs": ""salmon | orange | darkseagreen"",
+        "tag": "Param",
+        "userMethod": "color",
+        "value": {
+          "children": [
+            {
+              "duration": 0.25,
+              "note": "salmon",
+              "params": {
+                "gain": 1,
+                "velocity": 1,
+              },
+              "tag": "Play",
+            },
+            {
+              "duration": 0.25,
+              "note": "orange",
+              "params": {
+                "gain": 1,
+                "velocity": 1,
+              },
+              "tag": "Play",
+            },
+            {
+              "duration": 0.25,
+              "note": "darkseagreen",
+              "params": {
+                "gain": 1,
+                "velocity": 1,
+              },
+              "tag": "Play",
+            },
+          ],
+          "tag": "Seq",
+        },
+      },
+      "method": "pianoroll",
+    },
   },
   "tag": "Track",
   "trackId": "d1",
@@ -373,22 +2828,460 @@ useRNG('legacy')
 exports[`strudel.cc parity corpus — structural IR shape > juxUndTollerei parses to a stable IR shape 1`] = `
 {
   "body": {
-    "code": "// "Jux und tollerei"
-// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
-// @by Felix Roos
-
-note("c3 eb3 g3 bb3").palindrome()
-.s('sawtooth')
-.jux(x=>x.rev().color('green').s('sawtooth'))
-.off(1/4, x=>x.add(note("<7 12>/2")).slow(2).late(.005).s('triangle'))
-.lpf(sine.range(200,2000).slow(8))
-.lpa(.2).lpenv(-2)
-.decay(.05).sustain(0)
-.room(.6)
-.delay(.5).delaytime(.1).delayfeedback(.4)
-.pianoroll()",
+    "code": "",
     "lang": "strudel",
     "tag": "Code",
+    "via": {
+      "args": "",
+      "inner": {
+        "code": "",
+        "lang": "strudel",
+        "tag": "Code",
+        "via": {
+          "args": ".4",
+          "inner": {
+            "code": "",
+            "lang": "strudel",
+            "tag": "Code",
+            "via": {
+              "args": ".1",
+              "inner": {
+                "body": {
+                  "body": {
+                    "code": "",
+                    "lang": "strudel",
+                    "tag": "Code",
+                    "via": {
+                      "args": "0",
+                      "inner": {
+                        "code": "",
+                        "lang": "strudel",
+                        "tag": "Code",
+                        "via": {
+                          "args": ".05",
+                          "inner": {
+                            "code": "",
+                            "lang": "strudel",
+                            "tag": "Code",
+                            "via": {
+                              "args": "-2",
+                              "inner": {
+                                "code": "",
+                                "lang": "strudel",
+                                "tag": "Code",
+                                "via": {
+                                  "args": ".2",
+                                  "inner": {
+                                    "code": "",
+                                    "lang": "strudel",
+                                    "tag": "Code",
+                                    "via": {
+                                      "args": "sine.range(200,2000).slow(8)",
+                                      "inner": {
+                                        "tag": "Stack",
+                                        "tracks": [
+                                          {
+                                            "tag": "Stack",
+                                            "tracks": [
+                                              {
+                                                "body": {
+                                                  "code": "",
+                                                  "lang": "strudel",
+                                                  "tag": "Code",
+                                                  "via": {
+                                                    "args": "'sawtooth'",
+                                                    "inner": {
+                                                      "code": "",
+                                                      "lang": "strudel",
+                                                      "tag": "Code",
+                                                      "via": {
+                                                        "args": "",
+                                                        "inner": {
+                                                          "children": [
+                                                            {
+                                                              "duration": 0.25,
+                                                              "note": "c3",
+                                                              "params": {
+                                                                "gain": 1,
+                                                                "velocity": 1,
+                                                              },
+                                                              "tag": "Play",
+                                                            },
+                                                            {
+                                                              "duration": 0.25,
+                                                              "note": "eb3",
+                                                              "params": {
+                                                                "gain": 1,
+                                                                "velocity": 1,
+                                                              },
+                                                              "tag": "Play",
+                                                            },
+                                                            {
+                                                              "duration": 0.25,
+                                                              "note": "g3",
+                                                              "params": {
+                                                                "gain": 1,
+                                                                "velocity": 1,
+                                                              },
+                                                              "tag": "Play",
+                                                            },
+                                                            {
+                                                              "duration": 0.25,
+                                                              "note": "bb3",
+                                                              "params": {
+                                                                "gain": 1,
+                                                                "velocity": 1,
+                                                              },
+                                                              "tag": "Play",
+                                                            },
+                                                          ],
+                                                          "tag": "Seq",
+                                                        },
+                                                        "method": "palindrome",
+                                                      },
+                                                    },
+                                                    "method": "s",
+                                                  },
+                                                },
+                                                "name": "pan",
+                                                "params": {
+                                                  "pan": -1,
+                                                },
+                                                "tag": "FX",
+                                              },
+                                              {
+                                                "body": {
+                                                  "code": "",
+                                                  "lang": "strudel",
+                                                  "tag": "Code",
+                                                  "via": {
+                                                    "args": "'sawtooth'",
+                                                    "inner": {
+                                                      "code": "",
+                                                      "lang": "strudel",
+                                                      "tag": "Code",
+                                                      "via": {
+                                                        "args": "'green'",
+                                                        "inner": {
+                                                          "code": "",
+                                                          "lang": "strudel",
+                                                          "tag": "Code",
+                                                          "via": {
+                                                            "args": "",
+                                                            "inner": {
+                                                              "code": "",
+                                                              "lang": "strudel",
+                                                              "tag": "Code",
+                                                              "via": {
+                                                                "args": "'sawtooth'",
+                                                                "inner": {
+                                                                  "code": "",
+                                                                  "lang": "strudel",
+                                                                  "tag": "Code",
+                                                                  "via": {
+                                                                    "args": "",
+                                                                    "inner": {
+                                                                      "children": [
+                                                                        {
+                                                                          "duration": 0.25,
+                                                                          "note": "c3",
+                                                                          "params": {
+                                                                            "gain": 1,
+                                                                            "velocity": 1,
+                                                                          },
+                                                                          "tag": "Play",
+                                                                        },
+                                                                        {
+                                                                          "duration": 0.25,
+                                                                          "note": "eb3",
+                                                                          "params": {
+                                                                            "gain": 1,
+                                                                            "velocity": 1,
+                                                                          },
+                                                                          "tag": "Play",
+                                                                        },
+                                                                        {
+                                                                          "duration": 0.25,
+                                                                          "note": "g3",
+                                                                          "params": {
+                                                                            "gain": 1,
+                                                                            "velocity": 1,
+                                                                          },
+                                                                          "tag": "Play",
+                                                                        },
+                                                                        {
+                                                                          "duration": 0.25,
+                                                                          "note": "bb3",
+                                                                          "params": {
+                                                                            "gain": 1,
+                                                                            "velocity": 1,
+                                                                          },
+                                                                          "tag": "Play",
+                                                                        },
+                                                                      ],
+                                                                      "tag": "Seq",
+                                                                    },
+                                                                    "method": "palindrome",
+                                                                  },
+                                                                },
+                                                                "method": "s",
+                                                              },
+                                                            },
+                                                            "method": "rev",
+                                                          },
+                                                        },
+                                                        "method": "color",
+                                                      },
+                                                    },
+                                                    "method": "s",
+                                                  },
+                                                },
+                                                "name": "pan",
+                                                "params": {
+                                                  "pan": 1,
+                                                },
+                                                "tag": "FX",
+                                              },
+                                            ],
+                                            "userMethod": "jux",
+                                          },
+                                          {
+                                            "code": "",
+                                            "lang": "strudel",
+                                            "tag": "Code",
+                                            "via": {
+                                              "args": "'triangle'",
+                                              "inner": {
+                                                "body": {
+                                                  "body": {
+                                                    "code": "",
+                                                    "lang": "strudel",
+                                                    "tag": "Code",
+                                                    "via": {
+                                                      "args": "note("<7 12>/2")",
+                                                      "inner": {
+                                                        "body": {
+                                                          "tag": "Stack",
+                                                          "tracks": [
+                                                            {
+                                                              "body": {
+                                                                "code": "",
+                                                                "lang": "strudel",
+                                                                "tag": "Code",
+                                                                "via": {
+                                                                  "args": "'sawtooth'",
+                                                                  "inner": {
+                                                                    "code": "",
+                                                                    "lang": "strudel",
+                                                                    "tag": "Code",
+                                                                    "via": {
+                                                                      "args": "",
+                                                                      "inner": {
+                                                                        "children": [
+                                                                          {
+                                                                            "duration": 0.25,
+                                                                            "note": "c3",
+                                                                            "params": {
+                                                                              "gain": 1,
+                                                                              "velocity": 1,
+                                                                            },
+                                                                            "tag": "Play",
+                                                                          },
+                                                                          {
+                                                                            "duration": 0.25,
+                                                                            "note": "eb3",
+                                                                            "params": {
+                                                                              "gain": 1,
+                                                                              "velocity": 1,
+                                                                            },
+                                                                            "tag": "Play",
+                                                                          },
+                                                                          {
+                                                                            "duration": 0.25,
+                                                                            "note": "g3",
+                                                                            "params": {
+                                                                              "gain": 1,
+                                                                              "velocity": 1,
+                                                                            },
+                                                                            "tag": "Play",
+                                                                          },
+                                                                          {
+                                                                            "duration": 0.25,
+                                                                            "note": "bb3",
+                                                                            "params": {
+                                                                              "gain": 1,
+                                                                              "velocity": 1,
+                                                                            },
+                                                                            "tag": "Play",
+                                                                          },
+                                                                        ],
+                                                                        "tag": "Seq",
+                                                                      },
+                                                                      "method": "palindrome",
+                                                                    },
+                                                                  },
+                                                                  "method": "s",
+                                                                },
+                                                              },
+                                                              "name": "pan",
+                                                              "params": {
+                                                                "pan": -1,
+                                                              },
+                                                              "tag": "FX",
+                                                            },
+                                                            {
+                                                              "body": {
+                                                                "code": "",
+                                                                "lang": "strudel",
+                                                                "tag": "Code",
+                                                                "via": {
+                                                                  "args": "'sawtooth'",
+                                                                  "inner": {
+                                                                    "code": "",
+                                                                    "lang": "strudel",
+                                                                    "tag": "Code",
+                                                                    "via": {
+                                                                      "args": "'green'",
+                                                                      "inner": {
+                                                                        "code": "",
+                                                                        "lang": "strudel",
+                                                                        "tag": "Code",
+                                                                        "via": {
+                                                                          "args": "",
+                                                                          "inner": {
+                                                                            "code": "",
+                                                                            "lang": "strudel",
+                                                                            "tag": "Code",
+                                                                            "via": {
+                                                                              "args": "'sawtooth'",
+                                                                              "inner": {
+                                                                                "code": "",
+                                                                                "lang": "strudel",
+                                                                                "tag": "Code",
+                                                                                "via": {
+                                                                                  "args": "",
+                                                                                  "inner": {
+                                                                                    "children": [
+                                                                                      {
+                                                                                        "duration": 0.25,
+                                                                                        "note": "c3",
+                                                                                        "params": {
+                                                                                          "gain": 1,
+                                                                                          "velocity": 1,
+                                                                                        },
+                                                                                        "tag": "Play",
+                                                                                      },
+                                                                                      {
+                                                                                        "duration": 0.25,
+                                                                                        "note": "eb3",
+                                                                                        "params": {
+                                                                                          "gain": 1,
+                                                                                          "velocity": 1,
+                                                                                        },
+                                                                                        "tag": "Play",
+                                                                                      },
+                                                                                      {
+                                                                                        "duration": 0.25,
+                                                                                        "note": "g3",
+                                                                                        "params": {
+                                                                                          "gain": 1,
+                                                                                          "velocity": 1,
+                                                                                        },
+                                                                                        "tag": "Play",
+                                                                                      },
+                                                                                      {
+                                                                                        "duration": 0.25,
+                                                                                        "note": "bb3",
+                                                                                        "params": {
+                                                                                          "gain": 1,
+                                                                                          "velocity": 1,
+                                                                                        },
+                                                                                        "tag": "Play",
+                                                                                      },
+                                                                                    ],
+                                                                                    "tag": "Seq",
+                                                                                  },
+                                                                                  "method": "palindrome",
+                                                                                },
+                                                                              },
+                                                                              "method": "s",
+                                                                            },
+                                                                          },
+                                                                          "method": "rev",
+                                                                        },
+                                                                      },
+                                                                      "method": "color",
+                                                                    },
+                                                                  },
+                                                                  "method": "s",
+                                                                },
+                                                              },
+                                                              "name": "pan",
+                                                              "params": {
+                                                                "pan": 1,
+                                                              },
+                                                              "tag": "FX",
+                                                            },
+                                                          ],
+                                                          "userMethod": "jux",
+                                                        },
+                                                        "offset": 1,
+                                                        "tag": "Late",
+                                                      },
+                                                      "method": "add",
+                                                    },
+                                                  },
+                                                  "factor": 2,
+                                                  "tag": "Slow",
+                                                  "userMethod": "slow",
+                                                },
+                                                "offset": 0.005,
+                                                "tag": "Late",
+                                                "userMethod": "late",
+                                              },
+                                              "method": "s",
+                                            },
+                                          },
+                                        ],
+                                        "userMethod": "off",
+                                      },
+                                      "method": "lpf",
+                                    },
+                                  },
+                                  "method": "lpa",
+                                },
+                              },
+                              "method": "lpenv",
+                            },
+                          },
+                          "method": "decay",
+                        },
+                      },
+                      "method": "sustain",
+                    },
+                  },
+                  "name": "room",
+                  "params": {
+                    "room": 0.6,
+                  },
+                  "tag": "FX",
+                  "userMethod": "room",
+                },
+                "name": "delay",
+                "params": {
+                  "delay": 0.5,
+                },
+                "tag": "FX",
+                "userMethod": "delay",
+              },
+              "method": "delaytime",
+            },
+          },
+          "method": "delayfeedback",
+        },
+      },
+      "method": "pianoroll",
+    },
   },
   "tag": "Track",
   "trackId": "d1",
@@ -398,50 +3291,478 @@ note("c3 eb3 g3 bb3").palindrome()
 exports[`strudel.cc parity corpus — structural IR shape > meltingsubmarine parses to a stable IR shape 1`] = `
 {
   "body": {
-    "code": "// "Melting submarine"
-// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
-// @by Felix Roos
-
-samples('github:tidalcycles/dirt-samples')
-useRNG('legacy')
-
-stack(
-  s("bd:5,[~ <sd:1!3 sd:1(3,4,3)>],hh27(3,4,1)") // drums
-  .speed(perlin.range(.7,.9)) // random sample speed variation
-  //.hush()
-  ,"<a1 b1*2 a1(3,8) e2>" // bassline
-  .off(1/8,x=>x.add(12).degradeBy(.5)) // random octave jumps
-  .add(perlin.range(0,.5)) // random pitch variation
-  .superimpose(add(.05)) // add second, slightly detuned voice
+    "code": "",
+    "lang": "strudel",
+    "tag": "Code",
+    "via": {
+      "args": "4,.125,(x,n)=>x.gain(.15*1/(n+1))",
+      "inner": {
+        "tag": "Stack",
+        "tracks": [
+          {
+            "code": "",
+            "lang": "strudel",
+            "tag": "Code",
+            "via": {
+              "args": "perlin.range(.7,.9)",
+              "inner": {
+                "children": [
+                  {
+                    "duration": 1,
+                    "note": "bd",
+                    "params": {
+                      "gain": 1,
+                      "s": "bd",
+                      "slice": 5,
+                      "velocity": 1,
+                    },
+                    "tag": "Play",
+                  },
+                  {
+                    "children": [
+                      {
+                        "duration": 1,
+                        "tag": "Sleep",
+                      },
+                      {
+                        "items": [
+                          {
+                            "duration": 1,
+                            "note": "sd",
+                            "params": {
+                              "gain": 1,
+                              "s": "sd",
+                              "slice": 1,
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                          {
+                            "duration": 1,
+                            "note": "3",
+                            "params": {
+                              "gain": 1,
+                              "s": "3",
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                          {
+                            "children": [
+                              {
+                                "duration": 1,
+                                "tag": "Sleep",
+                              },
+                              {
+                                "duration": 1,
+                                "note": "sd",
+                                "params": {
+                                  "gain": 1,
+                                  "s": "sd",
+                                  "slice": 1,
+                                  "velocity": 1,
+                                },
+                                "tag": "Play",
+                              },
+                              {
+                                "duration": 1,
+                                "note": "sd",
+                                "params": {
+                                  "gain": 1,
+                                  "s": "sd",
+                                  "slice": 1,
+                                  "velocity": 1,
+                                },
+                                "tag": "Play",
+                              },
+                              {
+                                "duration": 1,
+                                "note": "sd",
+                                "params": {
+                                  "gain": 1,
+                                  "s": "sd",
+                                  "slice": 1,
+                                  "velocity": 1,
+                                },
+                                "tag": "Play",
+                              },
+                            ],
+                            "tag": "Seq",
+                          },
+                        ],
+                        "tag": "Cycle",
+                      },
+                    ],
+                    "tag": "Seq",
+                  },
+                  {
+                    "children": [
+                      {
+                        "duration": 1,
+                        "note": "hh27",
+                        "params": {
+                          "gain": 1,
+                          "s": "hh27",
+                          "velocity": 1,
+                        },
+                        "tag": "Play",
+                      },
+                      {
+                        "duration": 1,
+                        "note": "hh27",
+                        "params": {
+                          "gain": 1,
+                          "s": "hh27",
+                          "velocity": 1,
+                        },
+                        "tag": "Play",
+                      },
+                      {
+                        "duration": 1,
+                        "tag": "Sleep",
+                      },
+                      {
+                        "duration": 1,
+                        "note": "hh27",
+                        "params": {
+                          "gain": 1,
+                          "s": "hh27",
+                          "velocity": 1,
+                        },
+                        "tag": "Play",
+                      },
+                    ],
+                    "tag": "Seq",
+                  },
+                ],
+                "tag": "Seq",
+              },
+              "method": "speed",
+            },
+          },
+          {
+            "code": "",
+            "lang": "strudel",
+            "tag": "Code",
+            "via": {
+              "args": "add(.05)",
+              "inner": {
+                "code": "",
+                "lang": "strudel",
+                "tag": "Code",
+                "via": {
+                  "args": "perlin.range(0,.5)",
+                  "inner": {
+                    "tag": "Stack",
+                    "tracks": [
+                      {
+                        "items": [
+                          {
+                            "duration": 0.25,
+                            "note": "a1",
+                            "params": {
+                              "gain": 1,
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                          {
+                            "body": {
+                              "duration": 0.25,
+                              "note": "b1",
+                              "params": {
+                                "gain": 1,
+                                "velocity": 1,
+                              },
+                              "tag": "Play",
+                            },
+                            "factor": 2,
+                            "tag": "Fast",
+                          },
+                          {
+                            "children": [
+                              {
+                                "duration": 0.25,
+                                "note": "a1",
+                                "params": {
+                                  "gain": 1,
+                                  "velocity": 1,
+                                },
+                                "tag": "Play",
+                              },
+                              {
+                                "duration": 1,
+                                "tag": "Sleep",
+                              },
+                              {
+                                "duration": 1,
+                                "tag": "Sleep",
+                              },
+                              {
+                                "duration": 0.25,
+                                "note": "a1",
+                                "params": {
+                                  "gain": 1,
+                                  "velocity": 1,
+                                },
+                                "tag": "Play",
+                              },
+                              {
+                                "duration": 1,
+                                "tag": "Sleep",
+                              },
+                              {
+                                "duration": 1,
+                                "tag": "Sleep",
+                              },
+                              {
+                                "duration": 0.25,
+                                "note": "a1",
+                                "params": {
+                                  "gain": 1,
+                                  "velocity": 1,
+                                },
+                                "tag": "Play",
+                              },
+                              {
+                                "duration": 1,
+                                "tag": "Sleep",
+                              },
+                            ],
+                            "tag": "Seq",
+                          },
+                          {
+                            "duration": 0.25,
+                            "note": "e2",
+                            "params": {
+                              "gain": 1,
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                        ],
+                        "tag": "Cycle",
+                      },
+                      {
+                        "body": {
+                          "code": "",
+                          "lang": "strudel",
+                          "tag": "Code",
+                          "via": {
+                            "args": "12",
+                            "inner": {
+                              "body": {
+                                "items": [
+                                  {
+                                    "duration": 0.25,
+                                    "note": "a1",
+                                    "params": {
+                                      "gain": 1,
+                                      "velocity": 1,
+                                    },
+                                    "tag": "Play",
+                                  },
+                                  {
+                                    "body": {
+                                      "duration": 0.25,
+                                      "note": "b1",
+                                      "params": {
+                                        "gain": 1,
+                                        "velocity": 1,
+                                      },
+                                      "tag": "Play",
+                                    },
+                                    "factor": 2,
+                                    "tag": "Fast",
+                                  },
+                                  {
+                                    "children": [
+                                      {
+                                        "duration": 0.25,
+                                        "note": "a1",
+                                        "params": {
+                                          "gain": 1,
+                                          "velocity": 1,
+                                        },
+                                        "tag": "Play",
+                                      },
+                                      {
+                                        "duration": 1,
+                                        "tag": "Sleep",
+                                      },
+                                      {
+                                        "duration": 1,
+                                        "tag": "Sleep",
+                                      },
+                                      {
+                                        "duration": 0.25,
+                                        "note": "a1",
+                                        "params": {
+                                          "gain": 1,
+                                          "velocity": 1,
+                                        },
+                                        "tag": "Play",
+                                      },
+                                      {
+                                        "duration": 1,
+                                        "tag": "Sleep",
+                                      },
+                                      {
+                                        "duration": 1,
+                                        "tag": "Sleep",
+                                      },
+                                      {
+                                        "duration": 0.25,
+                                        "note": "a1",
+                                        "params": {
+                                          "gain": 1,
+                                          "velocity": 1,
+                                        },
+                                        "tag": "Play",
+                                      },
+                                      {
+                                        "duration": 1,
+                                        "tag": "Sleep",
+                                      },
+                                    ],
+                                    "tag": "Seq",
+                                  },
+                                  {
+                                    "duration": 0.25,
+                                    "note": "e2",
+                                    "params": {
+                                      "gain": 1,
+                                      "velocity": 1,
+                                    },
+                                    "tag": "Play",
+                                  },
+                                ],
+                                "tag": "Cycle",
+                              },
+                              "offset": 1,
+                              "tag": "Late",
+                            },
+                            "method": "add",
+                          },
+                        },
+                        "p": 0.5,
+                        "tag": "Degrade",
+                        "userMethod": "degradeBy",
+                      },
+                    ],
+                    "userMethod": "off",
+                  },
+                  "method": "add",
+                },
+              },
+              "method": "superimpose",
+            },
+          },
+          {
+            "code": "slightly detuned voice
   .note() // wrap in "note"
   .decay(.15).sustain(0) // make each note of equal length
   .s('sawtooth') // waveform
   .gain(.4) // turn down
   .cutoff(sine.slow(7).range(300,5000)) // automate cutoff
   .lpa(.1).lpenv(-2)
-  //.hush()
-  ,chord("<Am7!3 <Em7 E7b13 Em7 Ebm7b5>>")
+  //.hush()",
+            "lang": "strudel",
+            "tag": "Code",
+          },
+          {
+            "code": "chord("<Am7!3 <Em7 E7b13 Em7 Ebm7b5>>")
   .dict('lefthand').voicing() // chords
-  .add(note("0,.04")) // add second, slightly detuned voice
+  .add(note("0,.04")) // add second",
+            "lang": "strudel",
+            "tag": "Code",
+          },
+          {
+            "code": "slightly detuned voice
   .add(note(perlin.range(0,.5))) // random pitch variation
   .s('sawtooth') // waveform
   .gain(.16) // turn down
   .cutoff(500) // fixed cutoff
   .attack(1) // slowly fade in
-  //.hush()
-  ,"a4 c5 <e6 a6>".struct("x(5,8,-1)")
-  .superimpose(x=>x.add(.04)) // add second, slightly detuned voice
+  //.hush()",
+            "lang": "strudel",
+            "tag": "Code",
+          },
+          {
+            "code": "",
+            "lang": "strudel",
+            "tag": "Code",
+            "via": {
+              "args": "x=>x.add(.04)",
+              "inner": {
+                "body": {
+                  "children": [
+                    {
+                      "duration": 0.25,
+                      "note": "a4",
+                      "params": {
+                        "gain": 1,
+                        "velocity": 1,
+                      },
+                      "tag": "Play",
+                    },
+                    {
+                      "duration": 0.25,
+                      "note": "c5",
+                      "params": {
+                        "gain": 1,
+                        "velocity": 1,
+                      },
+                      "tag": "Play",
+                    },
+                    {
+                      "items": [
+                        {
+                          "duration": 0.25,
+                          "note": "e6",
+                          "params": {
+                            "gain": 1,
+                            "velocity": 1,
+                          },
+                          "tag": "Play",
+                        },
+                        {
+                          "duration": 0.25,
+                          "note": "a6",
+                          "params": {
+                            "gain": 1,
+                            "velocity": 1,
+                          },
+                          "tag": "Play",
+                        },
+                      ],
+                      "tag": "Cycle",
+                    },
+                  ],
+                  "tag": "Seq",
+                },
+                "mask": "x(5,8,-1)",
+                "tag": "Struct",
+                "userMethod": "struct",
+              },
+              "method": "superimpose",
+            },
+          },
+          {
+            "code": "slightly detuned voice
   .add(perlin.range(0,.5)) // random pitch variation
   .note() // wrap in "note"
   .decay(.1).sustain(0) // make notes short
   .s('triangle') // waveform
-  .degradeBy(perlin.range(0,.5)) // randomly controlled random removal :)
-  .echoWith(4,.125,(x,n)=>x.gain(.15*1/(n+1))) // echo notes
-  //.hush()
-)
-  .slow(3/2)",
-    "lang": "strudel",
-    "tag": "Code",
+  .degradeBy(perlin.range(0,.5)) // randomly controlled random removal :",
+            "lang": "strudel",
+            "tag": "Code",
+          },
+        ],
+        "userMethod": "stack",
+      },
+      "method": "echoWith",
+    },
   },
   "tag": "Track",
   "trackId": "d1",
@@ -451,23 +3772,258 @@ stack(
 exports[`strudel.cc parity corpus — structural IR shape > orbit parses to a stable IR shape 1`] = `
 {
   "body": {
-    "code": "// "Orbit"
-// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
-// @by Felix Roos
-
-stack(
-    s("bd <sd cp>")
-    .delay(.5)
-    .delaytime(.33)
-    .delayfeedback(.6),
-    s("hh*2")
-    .delay(.8)
-    .delaytime(.08)
-    .delayfeedback(.7)
-    .orbit(2)
-  ).sometimes(x=>x.speed("-1"))",
-    "lang": "strudel",
-    "tag": "Code",
+    "else_": {
+      "tag": "Stack",
+      "tracks": [
+        {
+          "code": "",
+          "lang": "strudel",
+          "tag": "Code",
+          "via": {
+            "args": ".6",
+            "inner": {
+              "code": "",
+              "lang": "strudel",
+              "tag": "Code",
+              "via": {
+                "args": ".33",
+                "inner": {
+                  "body": {
+                    "children": [
+                      {
+                        "duration": 1,
+                        "note": "bd",
+                        "params": {
+                          "gain": 1,
+                          "s": "bd",
+                          "velocity": 1,
+                        },
+                        "tag": "Play",
+                      },
+                      {
+                        "items": [
+                          {
+                            "duration": 1,
+                            "note": "sd",
+                            "params": {
+                              "gain": 1,
+                              "s": "sd",
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                          {
+                            "duration": 1,
+                            "note": "cp",
+                            "params": {
+                              "gain": 1,
+                              "s": "cp",
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                        ],
+                        "tag": "Cycle",
+                      },
+                    ],
+                    "tag": "Seq",
+                  },
+                  "name": "delay",
+                  "params": {
+                    "delay": 0.5,
+                  },
+                  "tag": "FX",
+                  "userMethod": "delay",
+                },
+                "method": "delaytime",
+              },
+            },
+            "method": "delayfeedback",
+          },
+        },
+        {
+          "code": "",
+          "lang": "strudel",
+          "tag": "Code",
+          "via": {
+            "args": "2",
+            "inner": {
+              "code": "",
+              "lang": "strudel",
+              "tag": "Code",
+              "via": {
+                "args": ".7",
+                "inner": {
+                  "code": "",
+                  "lang": "strudel",
+                  "tag": "Code",
+                  "via": {
+                    "args": ".08",
+                    "inner": {
+                      "body": {
+                        "body": {
+                          "duration": 1,
+                          "note": "hh",
+                          "params": {
+                            "gain": 1,
+                            "s": "hh",
+                            "velocity": 1,
+                          },
+                          "tag": "Play",
+                        },
+                        "factor": 2,
+                        "tag": "Fast",
+                      },
+                      "name": "delay",
+                      "params": {
+                        "delay": 0.8,
+                      },
+                      "tag": "FX",
+                      "userMethod": "delay",
+                    },
+                    "method": "delaytime",
+                  },
+                },
+                "method": "delayfeedback",
+              },
+            },
+            "method": "orbit",
+          },
+        },
+      ],
+      "userMethod": "stack",
+    },
+    "p": 0.5,
+    "tag": "Choice",
+    "then": {
+      "body": {
+        "tag": "Stack",
+        "tracks": [
+          {
+            "code": "",
+            "lang": "strudel",
+            "tag": "Code",
+            "via": {
+              "args": ".6",
+              "inner": {
+                "code": "",
+                "lang": "strudel",
+                "tag": "Code",
+                "via": {
+                  "args": ".33",
+                  "inner": {
+                    "body": {
+                      "children": [
+                        {
+                          "duration": 1,
+                          "note": "bd",
+                          "params": {
+                            "gain": 1,
+                            "s": "bd",
+                            "velocity": 1,
+                          },
+                          "tag": "Play",
+                        },
+                        {
+                          "items": [
+                            {
+                              "duration": 1,
+                              "note": "sd",
+                              "params": {
+                                "gain": 1,
+                                "s": "sd",
+                                "velocity": 1,
+                              },
+                              "tag": "Play",
+                            },
+                            {
+                              "duration": 1,
+                              "note": "cp",
+                              "params": {
+                                "gain": 1,
+                                "s": "cp",
+                                "velocity": 1,
+                              },
+                              "tag": "Play",
+                            },
+                          ],
+                          "tag": "Cycle",
+                        },
+                      ],
+                      "tag": "Seq",
+                    },
+                    "name": "delay",
+                    "params": {
+                      "delay": 0.5,
+                    },
+                    "tag": "FX",
+                    "userMethod": "delay",
+                  },
+                  "method": "delaytime",
+                },
+              },
+              "method": "delayfeedback",
+            },
+          },
+          {
+            "code": "",
+            "lang": "strudel",
+            "tag": "Code",
+            "via": {
+              "args": "2",
+              "inner": {
+                "code": "",
+                "lang": "strudel",
+                "tag": "Code",
+                "via": {
+                  "args": ".7",
+                  "inner": {
+                    "code": "",
+                    "lang": "strudel",
+                    "tag": "Code",
+                    "via": {
+                      "args": ".08",
+                      "inner": {
+                        "body": {
+                          "body": {
+                            "duration": 1,
+                            "note": "hh",
+                            "params": {
+                              "gain": 1,
+                              "s": "hh",
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                          "factor": 2,
+                          "tag": "Fast",
+                        },
+                        "name": "delay",
+                        "params": {
+                          "delay": 0.8,
+                        },
+                        "tag": "FX",
+                        "userMethod": "delay",
+                      },
+                      "method": "delaytime",
+                    },
+                  },
+                  "method": "delayfeedback",
+                },
+              },
+              "method": "orbit",
+            },
+          },
+        ],
+        "userMethod": "stack",
+      },
+      "key": "speed",
+      "rawArgs": ""-1"",
+      "tag": "Param",
+      "userMethod": "speed",
+      "value": "-1",
+    },
+    "userMethod": "sometimes",
   },
   "tag": "Track",
   "trackId": "d1",
@@ -477,32 +4033,41 @@ stack(
 exports[`strudel.cc parity corpus — structural IR shape > randomBells parses to a stable IR shape 1`] = `
 {
   "body": {
-    "code": "// "Random bells"
-// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
-// @by Felix Roos
-
-samples({
-  bell: { c6: 'https://cdn.freesound.org/previews/411/411089_5121236-lq.mp3' },
-  bass: { d2: 'https://cdn.freesound.org/previews/608/608286_13074022-lq.mp3' }
-})
-
-useRNG('legacy')
-
-stack(
-  // bells
+    "code": "",
+    "lang": "strudel",
+    "tag": "Code",
+    "via": {
+      "args": "{vertical:1}",
+      "inner": {
+        "body": {
+          "tag": "Stack",
+          "tracks": [
+            {
+              "code": "// bells
   n("0").euclidLegato(3,8)
   .echo(3, 1/16, .5)
   .add(n(rand.range(0,12)))
   .scale("D:minor:pentatonic")
   .velocity(rand.range(.5,1))
-  .s('bell').gain(.6).delay(.2).delaytime(1/3).delayfeedback(.8),
-  // bass
-  note("<D2 A2 G2 F2>").euclidLegatoRot(6,8,4).s('bass').clip(1).gain(.8)
-)
-  .slow(6)
-  .pianoroll({vertical:1})",
-    "lang": "strudel",
-    "tag": "Code",
+  .s('bell').gain(.6).delay(.2).delaytime(1/3).delayfeedback(.8)",
+              "lang": "strudel",
+              "tag": "Code",
+            },
+            {
+              "code": "// bass
+  note("<D2 A2 G2 F2>").euclidLegatoRot(6,8,4).s('bass').clip(1).gain(.8)",
+              "lang": "strudel",
+              "tag": "Code",
+            },
+          ],
+          "userMethod": "stack",
+        },
+        "factor": 6,
+        "tag": "Slow",
+        "userMethod": "slow",
+      },
+      "method": "pianoroll",
+    },
   },
   "tag": "Track",
   "trackId": "d1",
@@ -512,20 +4077,195 @@ stack(
 exports[`strudel.cc parity corpus — structural IR shape > sampleDrums parses to a stable IR shape 1`] = `
 {
   "body": {
-    "code": "samples({
-  bd: 'bd/BT0A0D0.wav',
-  sn: 'sn/ST0T0S3.wav',
-  hh: 'hh/000_hh3closedhh.wav'
-}, 'https://loophole-letters.vercel.app/samples/tidal/')
-
-stack(
-  "<bd!3 bd(3,4,3)>".color('#F5A623'),
-  "hh*4".color('#673AB7'),
-  "~ <sn!3 sn(3,4,2)>".color('#4CAF50')
-).s()
-.pianoroll({fold:1})",
+    "code": "",
     "lang": "strudel",
     "tag": "Code",
+    "via": {
+      "args": "{fold:1}",
+      "inner": {
+        "code": "",
+        "lang": "strudel",
+        "tag": "Code",
+        "via": {
+          "args": "",
+          "inner": {
+            "tag": "Stack",
+            "tracks": [
+              {
+                "code": "",
+                "lang": "strudel",
+                "tag": "Code",
+                "via": {
+                  "args": "'#F5A623'",
+                  "inner": {
+                    "items": [
+                      {
+                        "duration": 0.25,
+                        "note": "bd",
+                        "params": {
+                          "gain": 1,
+                          "velocity": 1,
+                        },
+                        "tag": "Play",
+                      },
+                      {
+                        "duration": 0.25,
+                        "note": "3",
+                        "params": {
+                          "gain": 1,
+                          "velocity": 1,
+                        },
+                        "tag": "Play",
+                      },
+                      {
+                        "children": [
+                          {
+                            "duration": 1,
+                            "tag": "Sleep",
+                          },
+                          {
+                            "duration": 0.25,
+                            "note": "bd",
+                            "params": {
+                              "gain": 1,
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                          {
+                            "duration": 0.25,
+                            "note": "bd",
+                            "params": {
+                              "gain": 1,
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                          {
+                            "duration": 0.25,
+                            "note": "bd",
+                            "params": {
+                              "gain": 1,
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                        ],
+                        "tag": "Seq",
+                      },
+                    ],
+                    "tag": "Cycle",
+                  },
+                  "method": "color",
+                },
+              },
+              {
+                "code": "",
+                "lang": "strudel",
+                "tag": "Code",
+                "via": {
+                  "args": "'#673AB7'",
+                  "inner": {
+                    "body": {
+                      "duration": 0.25,
+                      "note": "hh",
+                      "params": {
+                        "gain": 1,
+                        "velocity": 1,
+                      },
+                      "tag": "Play",
+                    },
+                    "factor": 4,
+                    "tag": "Fast",
+                  },
+                  "method": "color",
+                },
+              },
+              {
+                "code": "",
+                "lang": "strudel",
+                "tag": "Code",
+                "via": {
+                  "args": "'#4CAF50'",
+                  "inner": {
+                    "children": [
+                      {
+                        "duration": 1,
+                        "tag": "Sleep",
+                      },
+                      {
+                        "items": [
+                          {
+                            "duration": 0.25,
+                            "note": "sn",
+                            "params": {
+                              "gain": 1,
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                          {
+                            "duration": 0.25,
+                            "note": "3",
+                            "params": {
+                              "gain": 1,
+                              "velocity": 1,
+                            },
+                            "tag": "Play",
+                          },
+                          {
+                            "children": [
+                              {
+                                "duration": 0.25,
+                                "note": "sn",
+                                "params": {
+                                  "gain": 1,
+                                  "velocity": 1,
+                                },
+                                "tag": "Play",
+                              },
+                              {
+                                "duration": 1,
+                                "tag": "Sleep",
+                              },
+                              {
+                                "duration": 0.25,
+                                "note": "sn",
+                                "params": {
+                                  "gain": 1,
+                                  "velocity": 1,
+                                },
+                                "tag": "Play",
+                              },
+                              {
+                                "duration": 0.25,
+                                "note": "sn",
+                                "params": {
+                                  "gain": 1,
+                                  "velocity": 1,
+                                },
+                                "tag": "Play",
+                              },
+                            ],
+                            "tag": "Seq",
+                          },
+                        ],
+                        "tag": "Cycle",
+                      },
+                    ],
+                    "tag": "Seq",
+                  },
+                  "method": "color",
+                },
+              },
+            ],
+            "userMethod": "stack",
+          },
+          "method": "s",
+        },
+      },
+      "method": "pianoroll",
+    },
   },
   "tag": "Track",
   "trackId": "d1",

--- a/packages/app/tests/parity-corpus/__snapshots__/parity.test.ts.snap
+++ b/packages/app/tests/parity-corpus/__snapshots__/parity.test.ts.snap
@@ -1,0 +1,533 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`strudel.cc parity corpus — structural IR shape > amensister parses to a stable IR shape 1`] = `
+{
+  "body": {
+    "code": "// "Amensister"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+samples('github:tidalcycles/dirt-samples')
+
+useRNG('legacy')
+
+stack(
+  // amen
+  n("0 1 2 3 4 5 6 7")
+  .sometimes(x=>x.ply(2))
+  .rarely(x=>x.speed("2 | -2"))
+  .sometimesBy(.4, x=>x.delay(".5"))
+  .s("amencutup")
+  .slow(2)
+  .room(.5)
+  ,
+  // bass
+  sine.add(saw.slow(4)).range(0,7).segment(8)
+  .superimpose(x=>x.add(.1))
+  .scale('G0 minor').note()
+  .s("sawtooth")
+  .gain(.4).decay(.1).sustain(0)
+  .lpa(.1).lpenv(-4).lpq(10)
+  .cutoff(perlin.range(300,3000).slow(8))
+  .degradeBy("0 0.1 .5 .1")
+  .rarely(add(note("12")))
+  ,
+  // chord
+  note("Bb3,D4".superimpose(x=>x.add(.2)))
+  .s('sawtooth').lpf(1000).struct("<~@3 [~ x]>")
+  .decay(.05).sustain(.0).delay(.8).delaytime(.125).room(.8)
+  ,
+  // alien
+  s("breath").room(1).shape(.6).chop(16).rev().mask("<x ~@7>")
+  ,
+  n("0 1").s("east").delay(.5).degradeBy(.8).speed(rand.range(.5,1.5))
+).reset("<x@7 x(5,8,-1)>")",
+    "lang": "strudel",
+    "tag": "Code",
+  },
+  "tag": "Track",
+  "trackId": "d1",
+}
+`;
+
+exports[`strudel.cc parity corpus — structural IR shape > arpoon parses to a stable IR shape 1`] = `
+{
+  "body": {
+    "code": "// "Arpoon"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+useRNG('legacy')
+
+samples('github:tidalcycles/dirt-samples')
+
+n("[0,3] 2 [1,3] 2".fast(3).lastOf(4, fast(2))).clip(2)
+  .offset("<<1 2> 2 1 1>")
+  .chord("<<Am7 C^7> C7 F^7 [Fm7 E7b9]>")
+  .dict('lefthand').voicing()
+  .add(perlin.range(0,0.2).add("<-12 0>/8").note())
+  .cutoff(perlin.range(500,4000)).resonance(12)
+  .gain("<.5 .8>*16")
+  .decay(.16).sustain(0.5)
+  .delay(.2)
+  .room(.5).pan(sine.range(.3,.6))
+  .s('piano')
+  .stack(
+    "<<A1 C2>!2 F2 F2>"
+    .add.out("0 -5".fast(2))
+    .add("0,.12").note()
+    .s('sawtooth').cutoff(180)
+    .lpa(.1).lpenv(2)
+  )
+  .slow(4)
+  .stack(s("bd*4, [~ [hh hh? hh?]]*2,~ [sd ~ [sd:2? bd?]]").bank('RolandTR909').gain(.5).slow(2))",
+    "lang": "strudel",
+    "tag": "Code",
+  },
+  "tag": "Track",
+  "trackId": "d1",
+}
+`;
+
+exports[`strudel.cc parity corpus — structural IR shape > barryHarris parses to a stable IR shape 1`] = `
+{
+  "body": {
+    "code": "// adapted from a Barry Harris excercise
+"0,2,[7 6]"
+  .add("<0 1 2 3 4 5 7 8>")
+  .scale('C bebop major')
+  .transpose("<0 1 2 1>/8")
+  .slow(2)
+  .note().piano()
+  .color('#00B8D4')",
+    "lang": "strudel",
+    "tag": "Code",
+  },
+  "tag": "Track",
+  "trackId": "d1",
+}
+`;
+
+exports[`strudel.cc parity corpus — structural IR shape > bassFuge parses to a stable IR shape 1`] = `
+{
+  "body": {
+    "code": "// "Bass fuge"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+samples({ flbass: ['00_c2_finger_long_neck.wav','01_c2_finger_short_neck.wav','02_c2_finger_long_bridge.wav','03_c2_finger_short_bridge.wav','04_c2_pick_long.wav','05_c2_pick_short.wav','06_c2_palm_mute.wav'] }, 
+  'github:cleary/samples-flbass/main/')
+samples({
+bd: ['bd/BT0AADA.wav','bd/BT0AAD0.wav','bd/BT0A0DA.wav','bd/BT0A0D3.wav','bd/BT0A0D0.wav','bd/BT0A0A7.wav'],
+sd: ['sd/rytm-01-classic.wav','sd/rytm-00-hard.wav'],
+hh: ['hh27/000_hh27closedhh.wav','hh/000_hh3closedhh.wav'],
+}, 'github:tidalcycles/dirt-samples');
+
+setcps(1)
+
+"<8(3,8) <7 7*2> [4 5@3] 8>".sub(1) // sub 1 -> 1-indexed
+.layer(
+x=>x,
+x=>x.add(7)
+.off(1/8,x=>x.add("2,4").off(1/8,x=>x.add(5).echo(4,.125,.5)))
+.slow(2),
+).n().scale('A1 minor')
+.s("flbass").n(0)
+.mul(gain(.3))
+.cutoff(sine.slow(7).range(200,4000))
+.resonance(10)
+//.hcutoff(400)
+.clip(1)
+.stack(s("bd:1*2,~ sd:0,[~ hh:0]*2"))
+.pianoroll({vertical:1})",
+    "lang": "strudel",
+    "tag": "Code",
+  },
+  "tag": "Track",
+  "trackId": "d1",
+}
+`;
+
+exports[`strudel.cc parity corpus — structural IR shape > belldub parses to a stable IR shape 1`] = `
+{
+  "body": {
+    "code": "// "Belldub"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+samples({ bell: {b4:'https://cdn.freesound.org/previews/339/339809_5121236-lq.mp3'}})
+// "Hand Bells, B, Single.wav" by InspectorJ (www.jshaw.co.uk) of Freesound.org
+
+useRNG('legacy')
+
+stack(
+  // bass
+  note("[0 ~] [2 [0 2]] [4 4*2] [[4 ~] [2 ~] 0@2]".scale('g1 dorian').superimpose(x=>x.add(.02)))
+  .s('sawtooth').cutoff(200).resonance(20).gain(.15).shape(.6).release(.05),
+  // perc
+  s("[~ hh]*4").room("0 0.5".fast(2)).end(perlin.range(0.02,1)),
+  s("mt lt ht").struct("x(3,8)").fast(2).gain(.5).room(.5).sometimes(x=>x.speed(".5")),
+  s("misc:2").speed(1).delay(.5).delaytime(1/3).gain(.4),
+  // chords
+  chord("[~ Gm7] ~ [~ Dm7] ~")
+  .dict('lefthand').voicing()
+  .add(note("0,.1"))
+  .s('sawtooth').gain(.8)
+  .cutoff(perlin.range(400,3000).slow(8))
+  .decay(perlin.range(0.05,.2)).sustain(0)
+  .delay(.9).room(1),
+  // blips
+  note(
+    "0 5 4 2".iter(4)
+    .off(1/3, add(7))
+    .scale('g4 dorian')
+  ).s('square').cutoff(2000).decay(.03).sustain(0)
+  .degradeBy(.2)
+  .orbit(2).delay(.2).delaytime(".33 | .6 | .166 | .25")
+  .room(1).gain(.5).mask("<0 1>/8"),
+  // bell
+  note(rand.range(0,12).struct("x(5,8,-1)").scale('g2 minor pentatonic')).s('bell').begin(.05)
+  .delay(.2).degradeBy(.4).gain(.4)
+  .mask("<1 0>/8")
+).slow(5)",
+    "lang": "strudel",
+    "tag": "Code",
+  },
+  "tag": "Track",
+  "trackId": "d1",
+}
+`;
+
+exports[`strudel.cc parity corpus — structural IR shape > chop parses to a stable IR shape 1`] = `
+{
+  "body": {
+    "code": "// "Chop"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+samples({ p: 'https://cdn.freesound.org/previews/648/648433_11943129-lq.mp3' })
+
+s("p")
+  .loopAt(32)
+  .chop(128)
+  .jux(rev)
+  .shape(.4)
+  .decay(.1)
+  .sustain(.6)",
+    "lang": "strudel",
+    "tag": "Code",
+  },
+  "tag": "Track",
+  "trackId": "d1",
+}
+`;
+
+exports[`strudel.cc parity corpus — structural IR shape > delay parses to a stable IR shape 1`] = `
+{
+  "body": {
+    "code": "// "Delay"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+stack(
+    s("bd <sd cp>")
+    .delay("<0 .5>")
+    .delaytime(".16 | .33")
+    .delayfeedback(".6 | .8")
+  ).sometimes(x=>x.speed("-1"))",
+    "lang": "strudel",
+    "tag": "Code",
+  },
+  "tag": "Track",
+  "trackId": "d1",
+}
+`;
+
+exports[`strudel.cc parity corpus — structural IR shape > dinofunk parses to a stable IR shape 1`] = `
+{
+  "body": {
+    "code": "// "Dinofunk"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+setcps(1)
+useRNG('legacy')
+
+samples({bass:'https://cdn.freesound.org/previews/614/614637_2434927-hq.mp3',
+dino:{b4:'https://cdn.freesound.org/previews/316/316403_5123851-hq.mp3'}})
+setVoicingRange('lefthand', ['c3','a4'])
+
+stack(
+s('bass').loopAt(8).clip(1),
+s("bd*2, ~ sd,hh*4"),
+chord("Abm7")
+  .mode("below:G4")
+  .dict('lefthand')
+  .voicing()
+  .struct("x(3,8,1)".slow(2)),
+"0 1 2 3".scale('ab4 minor pentatonic')
+.superimpose(x=>x.add(.1))
+.sometimes(x=>x.add(12))
+.note().s('sawtooth')
+.cutoff(sine.range(400,2000).slow(16)).gain(.8)
+.decay(perlin.range(.05,.2)).sustain(0)
+.delay(sine.range(0,.5).slow(32))
+.degradeBy(.4).room(1),
+note("<b4 eb4>").s('dino').delay(.8).slow(8).room(.5)
+)",
+    "lang": "strudel",
+    "tag": "Code",
+  },
+  "tag": "Track",
+  "trackId": "d1",
+}
+`;
+
+exports[`strudel.cc parity corpus — structural IR shape > echoPiano parses to a stable IR shape 1`] = `
+{
+  "body": {
+    "code": "// "Echo piano"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+n("<0 2 [4 6](3,4,2) 3*2>").color('salmon')
+.off(1/4, x=>x.add(n(2)).color('green'))
+.off(1/2, x=>x.add(n(6)).color('steelblue'))
+.scale('D minor')
+.echo(4, 1/8, .5)
+.clip(.5)
+.piano()
+.pianoroll()",
+    "lang": "strudel",
+    "tag": "Code",
+  },
+  "tag": "Track",
+  "trackId": "d1",
+}
+`;
+
+exports[`strudel.cc parity corpus — structural IR shape > flatrave parses to a stable IR shape 1`] = `
+{
+  "body": {
+    "code": "// "Flatrave"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+useRNG('legacy')
+
+stack(
+  s("bd*2,~ [cp,sd]").bank('RolandTR909'),
+  
+  s("hh:1*4").sometimes(fast("2"))
+  .rarely(x=>x.speed(".5").delay(.5))
+  .end(perlin.range(0.02,.05).slow(8))
+  .bank('RolandTR909').room(.5)
+  .gain("0.4,0.4(5,8,-1)"),
+  
+  note("<0 2 5 3>".scale('G1 minor')).struct("x(5,8,-1)")
+  .s('sawtooth').decay(.1).sustain(0)
+  .lpa(.1).lpenv(-4).lpf(800).lpq(8),
+  
+  note("<G4 A4 Bb4 A4>,Bb3,D3").struct("~ x*2").s('square').clip(1)
+  .cutoff(sine.range(500,4000).slow(16)).resonance(10)
+  .decay(sine.slow(15).range(.05,.2)).sustain(0)
+  .room(.5).gain(.3).delay(.2).mask("<0 1@3>/8"),
+  
+  "0 5 3 2".sometimes(slow(2)).off(1/8,add(5)).scale('G4 minor').note()
+  .decay(.05).sustain(0).delay(.2).degradeBy(.5).mask("<0 1>/16")
+)",
+    "lang": "strudel",
+    "tag": "Code",
+  },
+  "tag": "Track",
+  "trackId": "d1",
+}
+`;
+
+exports[`strudel.cc parity corpus — structural IR shape > holyflute parses to a stable IR shape 1`] = `
+{
+  "body": {
+    "code": "// "Holy flute"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+useRNG('legacy')
+
+"c3 eb3(3,8) c4/2 g3*2"
+.superimpose(
+  x=>x.slow(2).add(12),
+  x=>x.slow(4).sub(5)
+).add("<0 1>/16")
+.note().s('ocarina_vib').clip(1)
+.release(.1).room(1).gain(.2)
+.color("salmon | orange | darkseagreen")
+.pianoroll({fold:0,autorange:0,vertical:0,cycles:12,smear:0,minMidi:40})",
+    "lang": "strudel",
+    "tag": "Code",
+  },
+  "tag": "Track",
+  "trackId": "d1",
+}
+`;
+
+exports[`strudel.cc parity corpus — structural IR shape > juxUndTollerei parses to a stable IR shape 1`] = `
+{
+  "body": {
+    "code": "// "Jux und tollerei"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+note("c3 eb3 g3 bb3").palindrome()
+.s('sawtooth')
+.jux(x=>x.rev().color('green').s('sawtooth'))
+.off(1/4, x=>x.add(note("<7 12>/2")).slow(2).late(.005).s('triangle'))
+.lpf(sine.range(200,2000).slow(8))
+.lpa(.2).lpenv(-2)
+.decay(.05).sustain(0)
+.room(.6)
+.delay(.5).delaytime(.1).delayfeedback(.4)
+.pianoroll()",
+    "lang": "strudel",
+    "tag": "Code",
+  },
+  "tag": "Track",
+  "trackId": "d1",
+}
+`;
+
+exports[`strudel.cc parity corpus — structural IR shape > meltingsubmarine parses to a stable IR shape 1`] = `
+{
+  "body": {
+    "code": "// "Melting submarine"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+samples('github:tidalcycles/dirt-samples')
+useRNG('legacy')
+
+stack(
+  s("bd:5,[~ <sd:1!3 sd:1(3,4,3)>],hh27(3,4,1)") // drums
+  .speed(perlin.range(.7,.9)) // random sample speed variation
+  //.hush()
+  ,"<a1 b1*2 a1(3,8) e2>" // bassline
+  .off(1/8,x=>x.add(12).degradeBy(.5)) // random octave jumps
+  .add(perlin.range(0,.5)) // random pitch variation
+  .superimpose(add(.05)) // add second, slightly detuned voice
+  .note() // wrap in "note"
+  .decay(.15).sustain(0) // make each note of equal length
+  .s('sawtooth') // waveform
+  .gain(.4) // turn down
+  .cutoff(sine.slow(7).range(300,5000)) // automate cutoff
+  .lpa(.1).lpenv(-2)
+  //.hush()
+  ,chord("<Am7!3 <Em7 E7b13 Em7 Ebm7b5>>")
+  .dict('lefthand').voicing() // chords
+  .add(note("0,.04")) // add second, slightly detuned voice
+  .add(note(perlin.range(0,.5))) // random pitch variation
+  .s('sawtooth') // waveform
+  .gain(.16) // turn down
+  .cutoff(500) // fixed cutoff
+  .attack(1) // slowly fade in
+  //.hush()
+  ,"a4 c5 <e6 a6>".struct("x(5,8,-1)")
+  .superimpose(x=>x.add(.04)) // add second, slightly detuned voice
+  .add(perlin.range(0,.5)) // random pitch variation
+  .note() // wrap in "note"
+  .decay(.1).sustain(0) // make notes short
+  .s('triangle') // waveform
+  .degradeBy(perlin.range(0,.5)) // randomly controlled random removal :)
+  .echoWith(4,.125,(x,n)=>x.gain(.15*1/(n+1))) // echo notes
+  //.hush()
+)
+  .slow(3/2)",
+    "lang": "strudel",
+    "tag": "Code",
+  },
+  "tag": "Track",
+  "trackId": "d1",
+}
+`;
+
+exports[`strudel.cc parity corpus — structural IR shape > orbit parses to a stable IR shape 1`] = `
+{
+  "body": {
+    "code": "// "Orbit"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+stack(
+    s("bd <sd cp>")
+    .delay(.5)
+    .delaytime(.33)
+    .delayfeedback(.6),
+    s("hh*2")
+    .delay(.8)
+    .delaytime(.08)
+    .delayfeedback(.7)
+    .orbit(2)
+  ).sometimes(x=>x.speed("-1"))",
+    "lang": "strudel",
+    "tag": "Code",
+  },
+  "tag": "Track",
+  "trackId": "d1",
+}
+`;
+
+exports[`strudel.cc parity corpus — structural IR shape > randomBells parses to a stable IR shape 1`] = `
+{
+  "body": {
+    "code": "// "Random bells"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+samples({
+  bell: { c6: 'https://cdn.freesound.org/previews/411/411089_5121236-lq.mp3' },
+  bass: { d2: 'https://cdn.freesound.org/previews/608/608286_13074022-lq.mp3' }
+})
+
+useRNG('legacy')
+
+stack(
+  // bells
+  n("0").euclidLegato(3,8)
+  .echo(3, 1/16, .5)
+  .add(n(rand.range(0,12)))
+  .scale("D:minor:pentatonic")
+  .velocity(rand.range(.5,1))
+  .s('bell').gain(.6).delay(.2).delaytime(1/3).delayfeedback(.8),
+  // bass
+  note("<D2 A2 G2 F2>").euclidLegatoRot(6,8,4).s('bass').clip(1).gain(.8)
+)
+  .slow(6)
+  .pianoroll({vertical:1})",
+    "lang": "strudel",
+    "tag": "Code",
+  },
+  "tag": "Track",
+  "trackId": "d1",
+}
+`;
+
+exports[`strudel.cc parity corpus — structural IR shape > sampleDrums parses to a stable IR shape 1`] = `
+{
+  "body": {
+    "code": "samples({
+  bd: 'bd/BT0A0D0.wav',
+  sn: 'sn/ST0T0S3.wav',
+  hh: 'hh/000_hh3closedhh.wav'
+}, 'https://loophole-letters.vercel.app/samples/tidal/')
+
+stack(
+  "<bd!3 bd(3,4,3)>".color('#F5A623'),
+  "hh*4".color('#673AB7'),
+  "~ <sn!3 sn(3,4,2)>".color('#4CAF50')
+).s()
+.pianoroll({fold:1})",
+    "lang": "strudel",
+    "tag": "Code",
+  },
+  "tag": "Track",
+  "trackId": "d1",
+}
+`;

--- a/packages/app/tests/parity-corpus/amensister.strudel
+++ b/packages/app/tests/parity-corpus/amensister.strudel
@@ -1,0 +1,39 @@
+// "Amensister"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+samples('github:tidalcycles/dirt-samples')
+
+useRNG('legacy')
+
+stack(
+  // amen
+  n("0 1 2 3 4 5 6 7")
+  .sometimes(x=>x.ply(2))
+  .rarely(x=>x.speed("2 | -2"))
+  .sometimesBy(.4, x=>x.delay(".5"))
+  .s("amencutup")
+  .slow(2)
+  .room(.5)
+  ,
+  // bass
+  sine.add(saw.slow(4)).range(0,7).segment(8)
+  .superimpose(x=>x.add(.1))
+  .scale('G0 minor').note()
+  .s("sawtooth")
+  .gain(.4).decay(.1).sustain(0)
+  .lpa(.1).lpenv(-4).lpq(10)
+  .cutoff(perlin.range(300,3000).slow(8))
+  .degradeBy("0 0.1 .5 .1")
+  .rarely(add(note("12")))
+  ,
+  // chord
+  note("Bb3,D4".superimpose(x=>x.add(.2)))
+  .s('sawtooth').lpf(1000).struct("<~@3 [~ x]>")
+  .decay(.05).sustain(.0).delay(.8).delaytime(.125).room(.8)
+  ,
+  // alien
+  s("breath").room(1).shape(.6).chop(16).rev().mask("<x ~@7>")
+  ,
+  n("0 1").s("east").delay(.5).degradeBy(.8).speed(rand.range(.5,1.5))
+).reset("<x@7 x(5,8,-1)>")

--- a/packages/app/tests/parity-corpus/arpoon.strudel
+++ b/packages/app/tests/parity-corpus/arpoon.strudel
@@ -1,0 +1,28 @@
+// "Arpoon"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+useRNG('legacy')
+
+samples('github:tidalcycles/dirt-samples')
+
+n("[0,3] 2 [1,3] 2".fast(3).lastOf(4, fast(2))).clip(2)
+  .offset("<<1 2> 2 1 1>")
+  .chord("<<Am7 C^7> C7 F^7 [Fm7 E7b9]>")
+  .dict('lefthand').voicing()
+  .add(perlin.range(0,0.2).add("<-12 0>/8").note())
+  .cutoff(perlin.range(500,4000)).resonance(12)
+  .gain("<.5 .8>*16")
+  .decay(.16).sustain(0.5)
+  .delay(.2)
+  .room(.5).pan(sine.range(.3,.6))
+  .s('piano')
+  .stack(
+    "<<A1 C2>!2 F2 F2>"
+    .add.out("0 -5".fast(2))
+    .add("0,.12").note()
+    .s('sawtooth').cutoff(180)
+    .lpa(.1).lpenv(2)
+  )
+  .slow(4)
+  .stack(s("bd*4, [~ [hh hh? hh?]]*2,~ [sd ~ [sd:2? bd?]]").bank('RolandTR909').gain(.5).slow(2))

--- a/packages/app/tests/parity-corpus/barryHarris.strudel
+++ b/packages/app/tests/parity-corpus/barryHarris.strudel
@@ -1,0 +1,8 @@
+// adapted from a Barry Harris excercise
+"0,2,[7 6]"
+  .add("<0 1 2 3 4 5 7 8>")
+  .scale('C bebop major')
+  .transpose("<0 1 2 1>/8")
+  .slow(2)
+  .note().piano()
+  .color('#00B8D4')

--- a/packages/app/tests/parity-corpus/bassFuge.strudel
+++ b/packages/app/tests/parity-corpus/bassFuge.strudel
@@ -1,0 +1,29 @@
+// "Bass fuge"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+samples({ flbass: ['00_c2_finger_long_neck.wav','01_c2_finger_short_neck.wav','02_c2_finger_long_bridge.wav','03_c2_finger_short_bridge.wav','04_c2_pick_long.wav','05_c2_pick_short.wav','06_c2_palm_mute.wav'] }, 
+  'github:cleary/samples-flbass/main/')
+samples({
+bd: ['bd/BT0AADA.wav','bd/BT0AAD0.wav','bd/BT0A0DA.wav','bd/BT0A0D3.wav','bd/BT0A0D0.wav','bd/BT0A0A7.wav'],
+sd: ['sd/rytm-01-classic.wav','sd/rytm-00-hard.wav'],
+hh: ['hh27/000_hh27closedhh.wav','hh/000_hh3closedhh.wav'],
+}, 'github:tidalcycles/dirt-samples');
+
+setcps(1)
+
+"<8(3,8) <7 7*2> [4 5@3] 8>".sub(1) // sub 1 -> 1-indexed
+.layer(
+x=>x,
+x=>x.add(7)
+.off(1/8,x=>x.add("2,4").off(1/8,x=>x.add(5).echo(4,.125,.5)))
+.slow(2),
+).n().scale('A1 minor')
+.s("flbass").n(0)
+.mul(gain(.3))
+.cutoff(sine.slow(7).range(200,4000))
+.resonance(10)
+//.hcutoff(400)
+.clip(1)
+.stack(s("bd:1*2,~ sd:0,[~ hh:0]*2"))
+.pianoroll({vertical:1})

--- a/packages/app/tests/parity-corpus/belldub.strudel
+++ b/packages/app/tests/parity-corpus/belldub.strudel
@@ -1,0 +1,39 @@
+// "Belldub"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+samples({ bell: {b4:'https://cdn.freesound.org/previews/339/339809_5121236-lq.mp3'}})
+// "Hand Bells, B, Single.wav" by InspectorJ (www.jshaw.co.uk) of Freesound.org
+
+useRNG('legacy')
+
+stack(
+  // bass
+  note("[0 ~] [2 [0 2]] [4 4*2] [[4 ~] [2 ~] 0@2]".scale('g1 dorian').superimpose(x=>x.add(.02)))
+  .s('sawtooth').cutoff(200).resonance(20).gain(.15).shape(.6).release(.05),
+  // perc
+  s("[~ hh]*4").room("0 0.5".fast(2)).end(perlin.range(0.02,1)),
+  s("mt lt ht").struct("x(3,8)").fast(2).gain(.5).room(.5).sometimes(x=>x.speed(".5")),
+  s("misc:2").speed(1).delay(.5).delaytime(1/3).gain(.4),
+  // chords
+  chord("[~ Gm7] ~ [~ Dm7] ~")
+  .dict('lefthand').voicing()
+  .add(note("0,.1"))
+  .s('sawtooth').gain(.8)
+  .cutoff(perlin.range(400,3000).slow(8))
+  .decay(perlin.range(0.05,.2)).sustain(0)
+  .delay(.9).room(1),
+  // blips
+  note(
+    "0 5 4 2".iter(4)
+    .off(1/3, add(7))
+    .scale('g4 dorian')
+  ).s('square').cutoff(2000).decay(.03).sustain(0)
+  .degradeBy(.2)
+  .orbit(2).delay(.2).delaytime(".33 | .6 | .166 | .25")
+  .room(1).gain(.5).mask("<0 1>/8"),
+  // bell
+  note(rand.range(0,12).struct("x(5,8,-1)").scale('g2 minor pentatonic')).s('bell').begin(.05)
+  .delay(.2).degradeBy(.4).gain(.4)
+  .mask("<1 0>/8")
+).slow(5)

--- a/packages/app/tests/parity-corpus/chop.strudel
+++ b/packages/app/tests/parity-corpus/chop.strudel
@@ -1,0 +1,14 @@
+// "Chop"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+samples({ p: 'https://cdn.freesound.org/previews/648/648433_11943129-lq.mp3' })
+
+s("p")
+  .loopAt(32)
+  .chop(128)
+  .jux(rev)
+  .shape(.4)
+  .decay(.1)
+  .sustain(.6)
+  

--- a/packages/app/tests/parity-corpus/delay.strudel
+++ b/packages/app/tests/parity-corpus/delay.strudel
@@ -1,0 +1,10 @@
+// "Delay"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+stack(
+    s("bd <sd cp>")
+    .delay("<0 .5>")
+    .delaytime(".16 | .33")
+    .delayfeedback(".6 | .8")
+  ).sometimes(x=>x.speed("-1"))

--- a/packages/app/tests/parity-corpus/dinofunk.strudel
+++ b/packages/app/tests/parity-corpus/dinofunk.strudel
@@ -1,0 +1,29 @@
+// "Dinofunk"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+setcps(1)
+useRNG('legacy')
+
+samples({bass:'https://cdn.freesound.org/previews/614/614637_2434927-hq.mp3',
+dino:{b4:'https://cdn.freesound.org/previews/316/316403_5123851-hq.mp3'}})
+setVoicingRange('lefthand', ['c3','a4'])
+
+stack(
+s('bass').loopAt(8).clip(1),
+s("bd*2, ~ sd,hh*4"),
+chord("Abm7")
+  .mode("below:G4")
+  .dict('lefthand')
+  .voicing()
+  .struct("x(3,8,1)".slow(2)),
+"0 1 2 3".scale('ab4 minor pentatonic')
+.superimpose(x=>x.add(.1))
+.sometimes(x=>x.add(12))
+.note().s('sawtooth')
+.cutoff(sine.range(400,2000).slow(16)).gain(.8)
+.decay(perlin.range(.05,.2)).sustain(0)
+.delay(sine.range(0,.5).slow(32))
+.degradeBy(.4).room(1),
+note("<b4 eb4>").s('dino').delay(.8).slow(8).room(.5)
+)

--- a/packages/app/tests/parity-corpus/echoPiano.strudel
+++ b/packages/app/tests/parity-corpus/echoPiano.strudel
@@ -1,0 +1,12 @@
+// "Echo piano"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+n("<0 2 [4 6](3,4,2) 3*2>").color('salmon')
+.off(1/4, x=>x.add(n(2)).color('green'))
+.off(1/2, x=>x.add(n(6)).color('steelblue'))
+.scale('D minor')
+.echo(4, 1/8, .5)
+.clip(.5)
+.piano()
+.pianoroll()

--- a/packages/app/tests/parity-corpus/flatrave.strudel
+++ b/packages/app/tests/parity-corpus/flatrave.strudel
@@ -1,0 +1,27 @@
+// "Flatrave"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+useRNG('legacy')
+
+stack(
+  s("bd*2,~ [cp,sd]").bank('RolandTR909'),
+  
+  s("hh:1*4").sometimes(fast("2"))
+  .rarely(x=>x.speed(".5").delay(.5))
+  .end(perlin.range(0.02,.05).slow(8))
+  .bank('RolandTR909').room(.5)
+  .gain("0.4,0.4(5,8,-1)"),
+  
+  note("<0 2 5 3>".scale('G1 minor')).struct("x(5,8,-1)")
+  .s('sawtooth').decay(.1).sustain(0)
+  .lpa(.1).lpenv(-4).lpf(800).lpq(8),
+  
+  note("<G4 A4 Bb4 A4>,Bb3,D3").struct("~ x*2").s('square').clip(1)
+  .cutoff(sine.range(500,4000).slow(16)).resonance(10)
+  .decay(sine.slow(15).range(.05,.2)).sustain(0)
+  .room(.5).gain(.3).delay(.2).mask("<0 1@3>/8"),
+  
+  "0 5 3 2".sometimes(slow(2)).off(1/8,add(5)).scale('G4 minor').note()
+  .decay(.05).sustain(0).delay(.2).degradeBy(.5).mask("<0 1>/16")
+)

--- a/packages/app/tests/parity-corpus/holyflute.strudel
+++ b/packages/app/tests/parity-corpus/holyflute.strudel
@@ -1,0 +1,15 @@
+// "Holy flute"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+useRNG('legacy')
+
+"c3 eb3(3,8) c4/2 g3*2"
+.superimpose(
+  x=>x.slow(2).add(12),
+  x=>x.slow(4).sub(5)
+).add("<0 1>/16")
+.note().s('ocarina_vib').clip(1)
+.release(.1).room(1).gain(.2)
+.color("salmon | orange | darkseagreen")
+.pianoroll({fold:0,autorange:0,vertical:0,cycles:12,smear:0,minMidi:40})

--- a/packages/app/tests/parity-corpus/juxUndTollerei.strudel
+++ b/packages/app/tests/parity-corpus/juxUndTollerei.strudel
@@ -1,0 +1,14 @@
+// "Jux und tollerei"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+note("c3 eb3 g3 bb3").palindrome()
+.s('sawtooth')
+.jux(x=>x.rev().color('green').s('sawtooth'))
+.off(1/4, x=>x.add(note("<7 12>/2")).slow(2).late(.005).s('triangle'))
+.lpf(sine.range(200,2000).slow(8))
+.lpa(.2).lpenv(-2)
+.decay(.05).sustain(0)
+.room(.6)
+.delay(.5).delaytime(.1).delayfeedback(.4)
+.pianoroll()

--- a/packages/app/tests/parity-corpus/meltingsubmarine.strudel
+++ b/packages/app/tests/parity-corpus/meltingsubmarine.strudel
@@ -1,0 +1,42 @@
+// "Melting submarine"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+samples('github:tidalcycles/dirt-samples')
+useRNG('legacy')
+
+stack(
+  s("bd:5,[~ <sd:1!3 sd:1(3,4,3)>],hh27(3,4,1)") // drums
+  .speed(perlin.range(.7,.9)) // random sample speed variation
+  //.hush()
+  ,"<a1 b1*2 a1(3,8) e2>" // bassline
+  .off(1/8,x=>x.add(12).degradeBy(.5)) // random octave jumps
+  .add(perlin.range(0,.5)) // random pitch variation
+  .superimpose(add(.05)) // add second, slightly detuned voice
+  .note() // wrap in "note"
+  .decay(.15).sustain(0) // make each note of equal length
+  .s('sawtooth') // waveform
+  .gain(.4) // turn down
+  .cutoff(sine.slow(7).range(300,5000)) // automate cutoff
+  .lpa(.1).lpenv(-2)
+  //.hush()
+  ,chord("<Am7!3 <Em7 E7b13 Em7 Ebm7b5>>")
+  .dict('lefthand').voicing() // chords
+  .add(note("0,.04")) // add second, slightly detuned voice
+  .add(note(perlin.range(0,.5))) // random pitch variation
+  .s('sawtooth') // waveform
+  .gain(.16) // turn down
+  .cutoff(500) // fixed cutoff
+  .attack(1) // slowly fade in
+  //.hush()
+  ,"a4 c5 <e6 a6>".struct("x(5,8,-1)")
+  .superimpose(x=>x.add(.04)) // add second, slightly detuned voice
+  .add(perlin.range(0,.5)) // random pitch variation
+  .note() // wrap in "note"
+  .decay(.1).sustain(0) // make notes short
+  .s('triangle') // waveform
+  .degradeBy(perlin.range(0,.5)) // randomly controlled random removal :)
+  .echoWith(4,.125,(x,n)=>x.gain(.15*1/(n+1))) // echo notes
+  //.hush()
+)
+  .slow(3/2)

--- a/packages/app/tests/parity-corpus/normalize.ts
+++ b/packages/app/tests/parity-corpus/normalize.ts
@@ -1,0 +1,83 @@
+/**
+ * normalize.ts — IR-shape normalizer for the Strudel.cc parity corpus.
+ *
+ * Phase 20-14 γ-2 (D-01 — structural parity only).
+ *
+ * `normalizeIRShape(ir)` strips fields known to vary across runs OR known
+ * NOT to be load-bearing for the structural-parity claim. Every stripped
+ * field carries a one-line rationale inline in the stripper table below.
+ *
+ * RULE for adding new stripped fields:
+ *   - Add the field name + a one-line WHY comment to STRIP_FIELDS below.
+ *   - The WHY must answer: "what class of drift would this snapshot
+ *     otherwise mask?" If you can't answer it, do NOT add the field —
+ *     instead extend the snapshot to capture the new shape signal.
+ *
+ * The normalizer is intentionally narrow today. Future drift in deterministic
+ * fields (e.g. parser refactor surfaces a new IR tag) MUST show up as a
+ * snapshot diff and be reviewed — that's the gate, not a maintenance burden.
+ */
+
+// Fields stripped from every IR node before snapshotting, with WHY.
+const STRIP_FIELDS: Record<string, string> = {
+  // Source-loc offsets are byte-position metadata. They are
+  // deterministic for a given source string, but they change with ANY
+  // file-framing tweak (an extra newline at the top, trailing whitespace
+  // normalization, even editor IDE line-ending policy on Windows). Pinning
+  // them in the snapshot would conflate "the IR shape drifted" with
+  // "the corpus file's framing drifted" — D-01 cares only about the
+  // former. The IREvent-level loc layer is asserted by the editor's own
+  // parity.test.ts at runtime; this corpus is the parser-IR rung.
+  loc: 'source-byte offsets — drift with file framing, not IR shape',
+
+  // chainOffset is a stage-transition annotation set by runMiniExpandedStage
+  // and dropped by runChainAppliedStage; it never reaches engine
+  // consumers (PatternIR.ts:38-44). For the parser-IR shape gate we
+  // strip it because it depends on the same source-byte offsets as loc.
+  chainOffset: 'stage-transition annotation — same byte-offset hazard as loc',
+
+  // callSiteRange lives inside Code.via for opaque-fragment wrappers
+  // (parseStrudel.ts:73 wrapAsOpaque); same source-byte rationale as loc.
+  // Stripped at the .via level via a dedicated rewrite below — see
+  // normalizeViaCallSite.
+}
+
+/**
+ * Recursively walk the IR tree, returning a plain JSON-shaped clone with
+ * the STRIP_FIELDS removed at every node. Other fields pass through
+ * unchanged, including nested PatternIR children (recursion is structural
+ * — we don't enumerate tag-specific child slot names, just walk any nested
+ * object/array we encounter).
+ *
+ * Returns `unknown` to discourage callers from inspecting specific tag
+ * fields directly — the only consumer is the snapshot serializer.
+ */
+export function normalizeIRShape(ir: unknown): unknown {
+  if (ir === null || ir === undefined) return ir
+  if (typeof ir !== 'object') return ir
+  if (Array.isArray(ir)) return ir.map(normalizeIRShape)
+
+  const src = ir as Record<string, unknown>
+  const out: Record<string, unknown> = {}
+
+  for (const key of Object.keys(src)) {
+    if (key in STRIP_FIELDS) continue
+    const value = src[key]
+    if (key === 'via' && value && typeof value === 'object') {
+      // Code.via wrapper — strip callSiteRange explicitly (it lives inside
+      // via, not at the node root). Other via fields (method, args, inner)
+      // are load-bearing for the wrapper-vs-fallback distinction (PV37 /
+      // PK13 step 2) and stay in the snapshot.
+      const viaSrc = value as Record<string, unknown>
+      const viaOut: Record<string, unknown> = {}
+      for (const vKey of Object.keys(viaSrc)) {
+        if (vKey === 'callSiteRange') continue
+        viaOut[vKey] = normalizeIRShape(viaSrc[vKey])
+      }
+      out[key] = viaOut
+      continue
+    }
+    out[key] = normalizeIRShape(value)
+  }
+  return out
+}

--- a/packages/app/tests/parity-corpus/orbit.strudel
+++ b/packages/app/tests/parity-corpus/orbit.strudel
@@ -1,0 +1,15 @@
+// "Orbit"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+stack(
+    s("bd <sd cp>")
+    .delay(.5)
+    .delaytime(.33)
+    .delayfeedback(.6),
+    s("hh*2")
+    .delay(.8)
+    .delaytime(.08)
+    .delayfeedback(.7)
+    .orbit(2)
+  ).sometimes(x=>x.speed("-1"))

--- a/packages/app/tests/parity-corpus/parity.test.ts
+++ b/packages/app/tests/parity-corpus/parity.test.ts
@@ -1,0 +1,71 @@
+/**
+ * parity.test.ts — Strudel.cc parity corpus structural gate (γ-2).
+ *
+ * Phase 20-14 D-01 — structural parity rung only:
+ *   - Parser-IR shape (tag tree)
+ *   - Param keys per node
+ *   - Tree topology (children/body slot population)
+ *
+ * Each `.strudel` file in this directory is a byte-faithful extraction
+ * of a named export from upstream `tunes.mjs` at the SHA pinned in
+ * `CORPUS-SOURCE.md`. The spec evals each file through Stave's pure
+ * `parseStrudel(code)` (no audio context, no scheduler) and snapshots
+ * the normalized IR shape. See `normalize.ts` for the strip-field
+ * rationale and CORPUS-SOURCE.md for the parser-IR vs runtime-IR
+ * choice with reasoning.
+ *
+ * Drift policy:
+ *   - Non-corpus PRs that touch `packages/editor/src/engine/` or
+ *     `packages/editor/src/ir/` and incidentally produce a snapshot
+ *     diff MUST call out the diff in the PR body (PLAN §2).
+ *   - Snapshot regeneration (`vitest -u`) belongs in a PR titled
+ *     `corpus: refresh from upstream SHA <x>` after running γ-3's
+ *     `pnpm parity:refresh`. NEVER run `-u` casually in development
+ *     to "make the test green" — the diff IS the news.
+ */
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Import parseStrudel directly from the editor source path rather than via
+// `@stave/editor` (the package barrel). The barrel re-exports the full
+// editor surface, which pulls in @strudel/draw → gifenc (CJS) → ESM
+// import-resolver crash under vite-node. Existing app tests that need
+// runtime values from the editor follow this same deep-path convention
+// (see e.g. components/__tests__/IRInspectorPanel.test.tsx:32 for the
+// HapStream/BreakpointStore precedent).
+import { parseStrudel } from '../../../editor/src/ir/parseStrudel'
+import { normalizeIRShape } from './normalize'
+
+const corpusDir = path.dirname(fileURLToPath(import.meta.url))
+
+// Read the corpus directory at test-collection time so each tune becomes
+// its own `it()` block with its own snapshot. A new tune appearing in the
+// directory shows up as a failing test on first run, prompting the
+// maintainer to regenerate snapshots (or remove the tune if accidental).
+const corpusFiles = fs
+  .readdirSync(corpusDir)
+  .filter((f) => f.endsWith('.strudel'))
+  .sort()
+
+describe('strudel.cc parity corpus — structural IR shape', () => {
+  it('vendored corpus is non-empty (sanity gate)', () => {
+    // If this fails, the directory got wiped or the test is running with
+    // an unexpected cwd — every other test below would have nothing to
+    // assert and the suite would pass vacuously.
+    expect(corpusFiles.length).toBeGreaterThan(0)
+  })
+
+  for (const fileName of corpusFiles) {
+    const tuneName = fileName.replace(/\.strudel$/, '')
+    it(`${tuneName} parses to a stable IR shape`, () => {
+      const code = fs.readFileSync(path.join(corpusDir, fileName), 'utf8')
+      const ir = parseStrudel(code)
+      const normalized = normalizeIRShape(ir)
+      // Inline snapshot file shape: one entry per tune, keyed by the
+      // test title above. Stored under `__snapshots__/parity.test.ts.snap`.
+      expect(normalized).toMatchSnapshot()
+    })
+  }
+})

--- a/packages/app/tests/parity-corpus/randomBells.strudel
+++ b/packages/app/tests/parity-corpus/randomBells.strudel
@@ -1,0 +1,24 @@
+// "Random bells"
+// @license CC BY-NC-SA 4.0 https://creativecommons.org/licenses/by-nc-sa/4.0/
+// @by Felix Roos
+
+samples({
+  bell: { c6: 'https://cdn.freesound.org/previews/411/411089_5121236-lq.mp3' },
+  bass: { d2: 'https://cdn.freesound.org/previews/608/608286_13074022-lq.mp3' }
+})
+
+useRNG('legacy')
+
+stack(
+  // bells
+  n("0").euclidLegato(3,8)
+  .echo(3, 1/16, .5)
+  .add(n(rand.range(0,12)))
+  .scale("D:minor:pentatonic")
+  .velocity(rand.range(.5,1))
+  .s('bell').gain(.6).delay(.2).delaytime(1/3).delayfeedback(.8),
+  // bass
+  note("<D2 A2 G2 F2>").euclidLegatoRot(6,8,4).s('bass').clip(1).gain(.8)
+)
+  .slow(6)
+  .pianoroll({vertical:1})

--- a/packages/app/tests/parity-corpus/sampleDrums.strudel
+++ b/packages/app/tests/parity-corpus/sampleDrums.strudel
@@ -1,0 +1,12 @@
+samples({
+  bd: 'bd/BT0A0D0.wav',
+  sn: 'sn/ST0T0S3.wav',
+  hh: 'hh/000_hh3closedhh.wav'
+}, 'https://loophole-letters.vercel.app/samples/tidal/')
+
+stack(
+  "<bd!3 bd(3,4,3)>".color('#F5A623'),
+  "hh*4".color('#673AB7'),
+  "~ <sn!3 sn(3,4,2)>".color('#4CAF50')
+).s()
+.pianoroll({fold:1})

--- a/packages/app/vitest.config.ts
+++ b/packages/app/vitest.config.ts
@@ -6,8 +6,17 @@ export default defineConfig({
     globals: true,
     // Exclude Playwright specs (they live under packages/app/tests/) — they
     // import from `@playwright/test` and are not vitest-runnable.
-    include: ['src/**/__tests__/**/*.test.{ts,tsx}'],
-    exclude: ['node_modules', 'tests', '.next'],
+    //
+    // Phase 20-14 γ-2: the parity corpus spec lives under
+    // `tests/parity-corpus/` alongside the vendored `.strudel` fixtures —
+    // include that subdirectory explicitly. The corresponding `exclude`
+    // entry below targets `tests/*.spec.ts` (Playwright glob) rather than
+    // the whole `tests/` tree.
+    include: [
+      'src/**/__tests__/**/*.test.{ts,tsx}',
+      'tests/parity-corpus/**/*.test.{ts,tsx}',
+    ],
+    exclude: ['node_modules', 'tests/*.spec.ts', '.next'],
     // App-package projection helpers are pure functions that import
     // PatternIR types from @stave/editor. Real Strudel parsing in tests
     // means we still need the @strudel transitive imports to resolve via

--- a/packages/editor/src/ir/__tests__/parseStrudel.test.ts
+++ b/packages/editor/src/ir/__tests__/parseStrudel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { parseStrudel, extractTracks } from '../parseStrudel'
+import { parseStrudel, extractTracks, stripParserPrelude } from '../parseStrudel'
 import { toStrudel } from '../toStrudel'
 import type { PatternIR } from '../PatternIR'
 
@@ -238,5 +238,106 @@ describe('20-12 α-1 — freq Param promotion', () => {
       (n) => n.tag === 'Param' && (n as { key: string }).key === 'note',
     )
     expect(noteParam).toBeDefined()
+  })
+})
+
+describe('20-14 parser-gap fix — stripParserPrelude', () => {
+  it('skips a single line comment before the body', () => {
+    const code = '// comment\ns("bd")'
+    const { body, offset } = stripParserPrelude(code)
+    expect(body).toBe('s("bd")')
+    expect(offset).toBe(code.indexOf('s('))
+  })
+
+  it('skips multiple blank lines + comments', () => {
+    const code = '\n\n  // hi\n\nfoo'
+    const { body, offset } = stripParserPrelude(code)
+    expect(body).toBe('foo')
+    expect(offset).toBe(code.indexOf('foo'))
+  })
+
+  it('skips a single-line samples({...}) call', () => {
+    const code = "samples({a:1})\ns(\"bd\")"
+    const { body, offset } = stripParserPrelude(code)
+    expect(body).toBe('s("bd")')
+    expect(offset).toBe(code.indexOf('s("bd")'))
+  })
+
+  it('skips a multi-line samples({…}) call as one unit', () => {
+    const code = 'samples({a:1,\n  b:2})\ns("bd")'
+    const { body, offset } = stripParserPrelude(code)
+    expect(body).toBe('s("bd")')
+    expect(offset).toBe(code.indexOf('s("bd")'))
+  })
+
+  it('skips useRNG()', () => {
+    const code = "useRNG('legacy')\nstack(s(\"bd\"),s(\"hh\"))"
+    const { body, offset } = stripParserPrelude(code)
+    expect(body).toBe('stack(s("bd"),s("hh"))')
+    expect(offset).toBe(code.indexOf('stack('))
+  })
+
+  it('skips a mixed prelude (comment + samples + comment + useRNG)', () => {
+    const code = '// hi\nsamples({a:1})\n// bye\nuseRNG(\'legacy\')\ns("bd")'
+    const { body, offset } = stripParserPrelude(code)
+    expect(body).toBe('s("bd")')
+    expect(offset).toBe(code.indexOf('s("bd")'))
+  })
+
+  it('skips setcps + setVoicingRange (dinofunk-shape prelude)', () => {
+    const code =
+      "setcps(1)\nuseRNG('legacy')\nsetVoicingRange('lefthand', ['c3','a4'])\ns(\"bd\")"
+    const { body, offset } = stripParserPrelude(code)
+    expect(body).toBe('s("bd")')
+    expect(offset).toBe(code.indexOf('s("bd")'))
+  })
+
+  it('returns unchanged code when there is no prelude', () => {
+    const code = 'note("c4")'
+    const { body, offset } = stripParserPrelude(code)
+    expect(body).toBe('note("c4")')
+    expect(offset).toBe(0)
+  })
+
+  it('returns empty body + offset == code.length when source is ALL prelude', () => {
+    const code = "// only a header\nsamples({a:1})\nuseRNG('legacy')\n"
+    const { body, offset } = stripParserPrelude(code)
+    expect(body.trim()).toBe('')
+    // Offset must point past the last consumed prelude line.
+    expect(offset).toBe(code.length)
+  })
+
+  it('does NOT strip inline `// ...` comments after expression code on a body line', () => {
+    // Inline trailing comment on the body line is part of the body —
+    // strip is whole-line only.
+    const code = 's("bd") // explanation'
+    const { body, offset } = stripParserPrelude(code)
+    expect(body).toBe('s("bd") // explanation')
+    expect(offset).toBe(0)
+  })
+})
+
+describe('20-14 parser-gap fix — parseStrudel structural IR for prelude\'d tunes', () => {
+  it('chop-shape body parses to a structured IR (NOT Code fallback)', () => {
+    // Mirrors `packages/app/tests/parity-corpus/chop.strudel` shape:
+    // header comments + samples() prelude + a sample-pattern expression
+    // with a .chop chain. Before the fix this produced Track(d1, Code(<all>)).
+    const code = [
+      '// "Chop"',
+      "// @by Felix Roos",
+      '',
+      "samples({ p: 'https://example.invalid/sample.mp3' })",
+      '',
+      's("p").chop(128)',
+    ].join('\n')
+    const ir = parseStrudel(code)
+    expect(ir.tag).toBe('Track')
+    if (ir.tag !== 'Track') throw new Error('unreachable')
+    expect(ir.trackId).toBe('d1')
+    // Body must be the structured `.chop(...)` IR — not the Code() fallback.
+    expect(ir.body.tag).not.toBe('Code')
+    // .chop(n) produces a Chop tag.
+    const chop = findNode(ir, (n) => n.tag === 'Chop')
+    expect(chop).toBeDefined()
   })
 })

--- a/packages/editor/src/ir/__tests__/parseStrudel.test.ts
+++ b/packages/editor/src/ir/__tests__/parseStrudel.test.ts
@@ -341,3 +341,93 @@ describe('20-14 parser-gap fix — parseStrudel structural IR for prelude\'d tun
     expect(chop).toBeDefined()
   })
 })
+
+describe('20-14 parser-gap fix — bare-string-as-pattern (cluster A)', () => {
+  it('bare string at top level parses to structured IR (NOT Code)', () => {
+    // Strudel transpiler auto-promotes top-level string literals to mini-
+    // patterns. Pre-fix: splitRootAndChain saw expr[0]==='"' (not an
+    // identifier char and not '('), returned root="", chain=<whole expr>;
+    // parseRoot('') fell through to IR.code(). Now parseRoot's bare-string
+    // arm fires and delegates to parseMini.
+    const ir = parseStrudel('"c3 e3"')
+    expect(ir.tag).toBe('Track')
+    if (ir.tag !== 'Track') throw new Error('unreachable')
+    expect(ir.body.tag).not.toBe('Code')
+    // parseMini on `c3 e3` produces a top-level Seq of two Play nodes.
+    const play = findNode(ir, (n) => n.tag === 'Play')
+    expect(play).toBeDefined()
+  })
+
+  it('bare string with method chain parses both the pattern + chain', () => {
+    // barryHarris-shape: `"0,2,[7 6]".add("<0 1>").scale(...)`. The chain
+    // is applied via applyChain on top of the bare-string IR.
+    const ir = parseStrudel('"c3 e3".fast(2)')
+    expect(ir.tag).toBe('Track')
+    if (ir.tag !== 'Track') throw new Error('unreachable')
+    // .fast(n) constructs a Fast tag wrapping the bare-string IR.
+    const fast = findNode(ir, (n) => n.tag === 'Fast')
+    expect(fast).toBeDefined()
+    // And the Play nodes from the inner mini are still present.
+    const play = findNode(ir, (n) => n.tag === 'Play')
+    expect(play).toBeDefined()
+  })
+})
+
+describe('20-14 parser-gap fix — multi-line chain walker (cluster B)', () => {
+  it('walks across newlines + indent between method calls', () => {
+    // Pre-fix: after consuming `.delay("1")`, the walker's `rest` was
+    // `\n  .delaytime(...)\n  .delayfeedback(...)` which doesn't start
+    // with '.', so the loop exited and the later methods were silently
+    // dropped to Code-fallback at parseExpression's catch-all.
+    const ir = parseStrudel(
+      's("bd").fast(2)\n  .slow(3)\n  .fast(4)',
+    )
+    expect(ir.tag).toBe('Track')
+    if (ir.tag !== 'Track') throw new Error('unreachable')
+    // All three methods must land in the chain — without the cluster B
+    // fix, only the first `.fast(2)` was applied and the rest were
+    // dropped to Code-fallback. Verify by counting Fast + Slow tags.
+    const tags: string[] = []
+    function walk(n: PatternIR): void {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const x = n as any
+      tags.push(n.tag)
+      if (x.body && typeof x.body === 'object' && 'tag' in x.body) walk(x.body)
+      if (x.value && typeof x.value === 'object' && 'tag' in x.value) walk(x.value)
+      if (Array.isArray(x.children))
+        for (const c of x.children) if (c && typeof c === 'object' && 'tag' in c) walk(c)
+      if (x.via?.inner) walk(x.via.inner)
+    }
+    walk(ir)
+    // Two `Fast` (outermost from `.fast(4)` + innermost from `.fast(2)`)
+    // and one `Slow` (`.slow(3)`) — all three methods stacked.
+    expect(tags.filter((t) => t === 'Fast').length).toBe(2)
+    expect(tags.filter((t) => t === 'Slow').length).toBe(1)
+  })
+
+  it('tolerates an inline `// comment` between methods', () => {
+    // bassFuge-shape: `.sub(1) // sub 1 -> 1-indexed\n.layer(...)`. The
+    // separator regex must skip both the inline comment AND the trailing
+    // newline before the next `.`.
+    const ir = parseStrudel(
+      's("bd").fast(2)  // explanation\n  .slow(3)',
+    )
+    expect(ir.tag).toBe('Track')
+    if (ir.tag !== 'Track') throw new Error('unreachable')
+    // Both .fast + .slow present despite the inline comment between them.
+    const tags: string[] = []
+    function walk(n: PatternIR): void {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const x = n as any
+      tags.push(n.tag)
+      if (x.body && typeof x.body === 'object' && 'tag' in x.body) walk(x.body)
+      if (x.value && typeof x.value === 'object' && 'tag' in x.value) walk(x.value)
+      if (Array.isArray(x.children))
+        for (const c of x.children) if (c && typeof c === 'object' && 'tag' in c) walk(c)
+      if (x.via?.inner) walk(x.via.inner)
+    }
+    walk(ir)
+    expect(tags).toContain('Fast')
+    expect(tags).toContain('Slow')
+  })
+})

--- a/packages/editor/src/ir/parseStrudel.ts
+++ b/packages/editor/src/ir/parseStrudel.ts
@@ -401,13 +401,23 @@ export function parseExpression(expr: string, baseOffset = 0): PatternIR {
     // Extract root function call and remaining method chain
     const { root, chain } = splitRootAndChain(expr.trim())
 
-    // Parse the root — if it can't be parsed, fall back to full expression as Code
+    // Parse the root — if it can't be parsed, fall back to full expression as Code.
+    //
+    // Phase 20-14 parser-gap fix — discriminate "pure Code fallback" from
+    // "structural Code-with-via wrapper". wrapAsOpaque returns tag: 'Code'
+    // for any unrecognised method arg (PV37 wrap-never-drop), but the
+    // `.via` field carries the structured chain. Checking tag alone treated
+    // those wrappers as opaque and discarded the entire structure — surfaces
+    // for `stack(single-arg-with-unmapped-pattern-chain)` shapes such as
+    // `stack(s("bd").delay("<0 .5>")...).sometimes(...)` in delay.strudel.
     const rootIR = parseRoot(root, trimmedOffset)
-    if (rootIR.tag === 'Code' && !chain.trim()) {
+    const rootIsBareCode =
+      rootIR.tag === 'Code' && (rootIR as { via?: unknown }).via === undefined
+    if (rootIsBareCode && !chain.trim()) {
       // Entire expression is opaque — preserve full original expression
       return IR.code(expr)
     }
-    if (rootIR.tag === 'Code') {
+    if (rootIsBareCode) {
       return IR.code(expr)
     }
 
@@ -511,6 +521,20 @@ export function parseRoot(root: string, baseOffset = 0): PatternIR {
     }
   }
 
+  // Phase 20-14 parser-gap fix (cluster A) — bare-string-as-pattern.
+  // Strudel's transpiler auto-promotes top-level string literals to
+  // mini-patterns. Mirrors mini("...") semantically — produces values,
+  // not notes/samples. Fired AFTER all named-function arms so this is a
+  // fallback for "expression starts with a bare string" (e.g.,
+  // `"0,2,[7 6]".add(...)` from barryHarris / holyflute).
+  // Single-line string only (mini-notation never spans newlines).
+  const bareStringMatch = trimmed.match(/^"([^"]*)"$/)
+  if (bareStringMatch) {
+    // innerOffset points at the FIRST char inside the quotes.
+    const innerOffset = baseOffset + leadingWs + 1
+    return parseMini(bareStringMatch[1], false, innerOffset)
+  }
+
   // Fallback: treat as opaque
   return IR.code(trimmed)
 }
@@ -535,7 +559,25 @@ export function applyChain(ir: PatternIR, chain: string, baseOffset = 0): Patter
   let remainingOffset = baseOffset + leadingWs
   let current = ir
 
-  while (remaining.startsWith('.')) {
+  // Phase 20-14 parser-gap fix (cluster B) — multi-line chain tolerance.
+  // Strudel programs commonly format long chains across newlines + indent
+  // (e.g., `s("bd").delay(.5)\n    .delaytime(.16)\n    .delayfeedback(.6)`)
+  // and tolerate inline `// comment` between methods. The pre-fix walker
+  // only progressed while `remaining.startsWith('.')` after a single
+  // initial `.trim()` — so the first newline between methods exited the
+  // loop and every subsequent method was silently dropped to Code-fallback.
+  // SEP regex: any mix of inter-method whitespace (incl. newlines) and
+  // line comments (`// …` up to and including the trailing newline). The
+  // `+` is anchored to `^` so it ONLY trims at the head of `remaining`.
+  const INTER_METHOD_SEP = /^(?:\s+|\/\/[^\n]*\n?)+/
+  while (true) {
+    // Skip inter-method separator (whitespace + line comments).
+    const sep = remaining.match(INTER_METHOD_SEP)
+    if (sep) {
+      remainingOffset += sep[0].length
+      remaining = remaining.slice(sep[0].length)
+    }
+    if (!remaining.startsWith('.')) break
     const { method, args, rest, argsOffset } = extractNextMethod(remaining)
     if (!method) break
 
@@ -1272,19 +1314,38 @@ function offsetOfSubArg(args: string, subArg: string, argsBaseOffset: number): n
 /**
  * Split expression into root function call and method chain.
  * e.g. 'note("c4").fast(2).slow(3)' → { root: 'note("c4")', chain: '.fast(2).slow(3)' }
+ *
+ * Phase 20-14 parser-gap fix (cluster A) — bare-string-as-pattern.
+ * Strudel's transpiler auto-promotes top-level string literals to
+ * mini-patterns (e.g., `"0,2,[7 6]".add(...)`). When `expr[0]` is `"`,
+ * the root is the quoted string (escapes respected) and the chain
+ * starts at the char immediately after the closing quote.
  */
 export function splitRootAndChain(expr: string): { root: string; chain: string } {
-  // Find the end of the first balanced function call
   let i = 0
 
-  // Skip identifier
-  while (i < expr.length && /[a-zA-Z0-9_$]/.test(expr[i])) i++
+  if (expr[0] === '"') {
+    // Bare-string root — scan to matching closing quote (escape-aware,
+    // single-line: mini-strings never span newlines in the corpus).
+    i = 1
+    while (i < expr.length && expr[i] !== '"') {
+      if (expr[i] === '\\' && i + 1 < expr.length) {
+        i += 2
+        continue
+      }
+      i++
+    }
+    if (i < expr.length) i++ // consume closing quote
+  } else {
+    // Skip identifier
+    while (i < expr.length && /[a-zA-Z0-9_$]/.test(expr[i])) i++
 
-  // If there's an opening paren, find the matching close
-  if (i < expr.length && expr[i] === '(') {
-    const closeIdx = findMatchingParen(expr, i)
-    if (closeIdx !== -1) {
-      i = closeIdx + 1
+    // If there's an opening paren, find the matching close
+    if (i < expr.length && expr[i] === '(') {
+      const closeIdx = findMatchingParen(expr, i)
+      if (closeIdx !== -1) {
+        i = closeIdx + 1
+      }
     }
   }
 

--- a/packages/editor/src/ir/parseStrudel.ts
+++ b/packages/editor/src/ir/parseStrudel.ts
@@ -90,6 +90,141 @@ function wrapAsOpaque(
  *  public API. Consumed by PatternIR.test.ts wave-α probes. */
 export const __test_wrapAsOpaque = wrapAsOpaque
 
+/**
+ * Phase 20-14 parser-gap fix — strip a "prelude" from non-`$:` Strudel
+ * programs so the musical expression that follows parses to a structured
+ * IR instead of the Code() fallback.
+ *
+ * A prelude is the sequence of leading lines that are either:
+ *   - blank
+ *   - a `// …` line comment (whole-line; inline `// …` after expression
+ *     code is untouched)
+ *   - a TOP-LEVEL call to a recognised boot-side-effect function:
+ *     `samples(…)`, `useRNG(…)`, `setcps(…)`, `setVoicingRange(…)`,
+ *     `initAudio(…)`, `aliasBank(…)`. The call may span multiple lines
+ *     (multi-line `samples({ … })` is the common case); we track paren /
+ *     brace / bracket depth across newlines and consume the whole call
+ *     as one unit. The call ends at the line whose end-of-line depth is
+ *     zero AND whose final non-whitespace char is `)` (allowing a
+ *     trailing `;` per `bassFuge.strudel`).
+ *
+ * Returns the substring from the first non-prelude line plus the absolute
+ * char offset where that substring starts in the ORIGINAL `code`. Callers
+ * thread `offset` into `parseExpression` so every `loc.start` derived from
+ * the parser is still a valid index into the user-typed source.
+ *
+ * Forms NOT skipped (fall through to existing Code() fallback at the
+ * call site, same shape as today):
+ *   - `let` / `const` / `var` bindings
+ *   - `await` / arbitrary statements
+ *   - any function we haven't enumerated here
+ * If a corpus tune surfaces another prelude form, add it to the regex
+ * below — explicit list is intentional, not an open-ended skip.
+ */
+export function stripParserPrelude(code: string): { body: string; offset: number } {
+  // Top-level boot-side-effect calls we recognise. Exact tokens — D-08
+  // (no aliasing). Anchored to the start of the trimmed line.
+  const PRELUDE_CALL_RE =
+    /^[ \t]*(?:samples|useRNG|setcps|setVoicingRange|initAudio|aliasBank)\s*\(/
+
+  let i = 0
+  while (i < code.length) {
+    // Walk to end of current line (exclusive of '\n').
+    let lineEnd = code.indexOf('\n', i)
+    if (lineEnd === -1) lineEnd = code.length
+    const line = code.slice(i, lineEnd)
+    const trimmed = line.trim()
+
+    // 1. Blank line — skip and advance past the newline.
+    if (trimmed === '') {
+      i = lineEnd + 1
+      continue
+    }
+
+    // 2. Whole-line comment — skip.
+    if (trimmed.startsWith('//')) {
+      i = lineEnd + 1
+      continue
+    }
+
+    // 3. Top-level recognised prelude call — possibly multi-line.
+    if (PRELUDE_CALL_RE.test(line)) {
+      // Track paren/brace/bracket depth + string state from the line start,
+      // advancing across newlines until depth returns to zero AT THE END
+      // OF A LINE whose final non-ws char is `)` (allow trailing `;`).
+      let j = i
+      let depth = 0
+      let inString = false
+      let stringChar = ''
+      let escaped = false
+      let sawOpenParen = false
+      while (j < code.length) {
+        const ch = code[j]
+        if (escaped) {
+          escaped = false
+          j++
+          continue
+        }
+        if (inString) {
+          if (ch === '\\') {
+            escaped = true
+          } else if (ch === stringChar) {
+            inString = false
+          }
+          j++
+          continue
+        }
+        if (ch === '"' || ch === "'" || ch === '`') {
+          inString = true
+          stringChar = ch
+          j++
+          continue
+        }
+        if (ch === '(' || ch === '[' || ch === '{') {
+          depth++
+          if (ch === '(') sawOpenParen = true
+          j++
+          continue
+        }
+        if (ch === ')' || ch === ']' || ch === '}') {
+          depth--
+          j++
+          // When depth returns to zero AFTER seeing at least one '(', the
+          // call body is closed. Consume any trailing `;`, then advance to
+          // the next line and resume prelude scan.
+          if (depth === 0 && sawOpenParen) {
+            // Allow optional `;` + horizontal whitespace before EOL.
+            while (j < code.length && (code[j] === ' ' || code[j] === '\t' || code[j] === ';')) {
+              j++
+            }
+            // Advance past the newline (if any) so the outer loop
+            // starts at the next line.
+            if (j < code.length && code[j] === '\n') j++
+            break
+          }
+          continue
+        }
+        if (ch === '\n') {
+          j++
+          continue
+        }
+        j++
+      }
+      // Defensive: if depth never closed (malformed source), stop the
+      // prelude scan here and let the body parser handle whatever remains.
+      // We do NOT consume the malformed call.
+      if (depth !== 0) break
+      i = j
+      continue
+    }
+
+    // 4. Anything else — first body line. Stop here.
+    break
+  }
+
+  return { body: code.slice(i), offset: i }
+}
+
 /** Parse a Strudel code string. Always returns a tree (Code node for unsupported). */
 export function parseStrudel(code: string): PatternIR {
   if (!code.trim()) return IR.pure()
@@ -108,8 +243,27 @@ export function parseStrudel(code: string): PatternIR {
       // distinguishes from `.p("d1")`). toStrudel's β-2 Track arm strips
       // synthetic-d1 (userMethod === undefined) on round-trip so the
       // input → IR → string identity is preserved for non-$: sources.
-      const trimStart = code.search(/\S/)
-      const inner = parseExpression(code.trim(), trimStart >= 0 ? trimStart : 0)
+      //
+      // Phase 20-14 parser-gap fix — strip any leading prelude (whole-line
+      // comments, blank lines, recognised boot-side-effect calls) before
+      // parsing. Real upstream tunes start with a license comment block +
+      // `samples(...)` / `useRNG(...)` invocations; without this strip,
+      // `splitRootAndChain` reads the comment text as the root and the
+      // whole tune falls through to the Code() fallback at line 270.
+      //
+      // The strip applies ONLY to the no-`$:` branch. The multi-track
+      // path keeps reading the original `code` so a `$:` line appearing
+      // before the prelude (uncommon but legal) still produces tracks.
+      const stripped = stripParserPrelude(code)
+      if (!stripped.body.trim()) {
+        // Source is ENTIRELY prelude (no musical body). Return an
+        // empty-body Track wrapper so downstream consumers still get
+        // the synthetic-d1 shape. PV37 wrap-never-drop preserved.
+        return IR.track('d1', IR.pure())
+      }
+      const bodyTrimStart = stripped.body.search(/\S/)
+      const innerOffset = stripped.offset + (bodyTrimStart >= 0 ? bodyTrimStart : 0)
+      const inner = parseExpression(stripped.body.trim(), innerOffset)
       return IR.track('d1', inner)
     }
     if (tracks.length === 1) {


### PR DESCRIPTION
## Wave γ of Phase 20-14 — Strudel.cc Parity (stacked on #131)

**Base:** \`feat/20-14-strudel-parity-beta\` (β-wave). When β (#131) merges to its base, this rebases automatically; when α (#123) → β → γ all land, γ targets \`main\` and **closes #110**.

This wave gates regression with a 16-tune structural parity corpus that runs as part of \`pnpm --filter @stave/app test\`. During execution it surfaced — and fixed — three parser gaps that were preventing real-world strudel.cc programs from producing structured IR in Stave.

### What landed (8 atomic commits)

**Corpus + spec + script (γ-1..γ-4):**

| Task | Commit | What |
|---|---|---|
| γ-1 | \`fb0ae64\` | 16 vendored tunes + CORPUS-SOURCE.md @ SHA \`f73b3956\` |
| γ-2 | \`660bbc2\` | vitest spec + \`normalize.ts\` IR-shape normalizer + seeded snapshots |
| γ-3 | \`903b922\` | \`pnpm parity:refresh\` — upstream-drift surfacer, maintainer-only |
| γ-4 | \`e3690af\` | γ-wave SUMMARY |

**Parser-gap fix (surfaced + fixed during γ-2 verification):**

| Commit | What |
|---|---|
| \`1d6a314\` | \`stripParserPrelude\` — skip leading \`//\` comments, blank lines, top-level \`samples()\`, \`useRNG()\`, \`setcps()\`, \`setVoicingRange()\`, \`initAudio()\`, \`aliasBank()\` calls (single + multi-line) |
| \`322d912\` | bare-string-as-pattern arm + multi-line method-chain walker (whitespace + inline-comment tolerant) |
| \`1238ed3\` | regenerate parity snapshots — now assert **structural IR** for 15/16 tunes (up from 0/16) |
| \`7f2bb07\` | parser-gap fix documented in γ-SUMMARY |
| \`42b8e71\` | cite issue #132 for arpoon residual gap |

### Tests

- Editor: **1551/1551** (+15 for prelude strip + clusters A/B + Code-via guard)
- App: **314/314** including the **17 parity tests** (16 corpus snapshots + 1 sanity gate)

### Discovery + fix arc

γ-2's initial run revealed all 16 tunes producing \`Track(d1, Code(<verbatim>))\` — the parser's opaque fallback. Reason: real strudel.cc programs lead with comments + \`samples({...})\` + \`useRNG('legacy')\` before the actual pattern, and Stave's \`parseStrudel\` had no skip handling for these.

Per the AnviDev "fix the parser gap in γ before shipping" decision, we extended \`parseStrudel\`:

1. **Prelude strip** — line walker tracking paren/brace/bracket/string depth, skips known boot-side-effect statements (single and multi-line)
2. **Bare-string-as-pattern arm** — top-level \`\"...\"\` expressions now parse via \`parseMini\`, matching Strudel's transpiler reification
3. **Multi-line method-chain walker** — \`applyChain\` now tolerates whitespace, newlines, and inline \`// ...\` comments between chained methods (matching Strudel's transpiler)
4. **Code-via guard** — \`parseExpression\` no longer discards structural \`wrapAsOpaque\` wrappers (which carry \`.via\`) as if they were bare-Code fallbacks

### Result

- 15/16 tunes produce **structured PatternIR** in their parity snapshots
- 1/16 (\`arpoon\`) still produces Code-fallback because it has a recursive parser shape (\`n(MINI.method().method())\`). Tracked at **#132** (\`parseStrudel: recursive parsing inside note/n/s args\`).
- The Code-fallback still gates structural drift for arpoon — any upstream text change trips a snapshot diff — but the assertion is weaker than full IR parity for that tune. Audible behavior unaffected.

### Maintainer workflow — \`pnpm parity:refresh\`

\`\`\`bash
# Check for drift against current pin
pnpm parity:refresh

# Check against a specific upstream SHA
pnpm parity:refresh --sha <new-sha>

# Output: \"N tunes unchanged, M tunes changed, K missing\" with line-level diffs
# Maintainer applies diffs by hand in a PR titled
# \`corpus: refresh from upstream SHA <new>\`, updates CORPUS-SOURCE.md pin,
# runs vitest -u to regen snapshots in the same PR.
\`\`\`

CI does NOT fetch upstream — D-04 forbids live network at CI. Refresh is maintainer-driven.

### Non-corpus snapshot drift policy

Per PLAN §2: any non-corpus PR that touches \`packages/editor/src/engine/\` or \`packages/editor/src/ir/\` AND causes a γ-2 parity snapshot diff **must call out the diff in the PR body**. The diff itself is the news — explicit acknowledgement gates merge.

### Catalogue candidates (deferred to post-merge)

Captured in γ-SUMMARY:

- **hetvabhasa** — tag-only \`=== 'Code'\` check conflates structural \`wrapAsOpaque\` wrappers with bare-Code fallbacks; discriminator must inspect \`via\`
- **vyapti** — Strudel parser walkers must tolerate inter-element whitespace (incl. newlines) AND inline \`// ...\` line comments; spans applyChain (fixed), stripParserPrelude (fixed), any future splitArgs walker
- **krama** — PK15 (μ-α parse cycle) extends: prelude-strip lives BEFORE splitRootAndChain in the no-\`\$:\` branch

### Decisions honored

- D-01 (structural parity only) — snapshot assertion is parser-level PatternIR shape; no scheduler, no waveform
- D-04 (vendor verbatim, SHA pin, manual refresh) — corpus byte-faithful from upstream; \`pnpm parity:refresh\` is maintainer-only

### Closes #110

The α/β/γ stack ships the parity claim end-to-end:
- α loaded the upstream sample manifests and tier-flag schema
- β lit up the bare-name resolution path + tier toggles
- γ gates regression with a vendored 16-tune corpus + structural snapshots
- \`s(\"piano\")\` audibles correctly. \`.bank(\"tr909\")\` works. \`.piano()\` chains. 15/16 corpus tunes assert structural IR. Drift surfaces.

### Refs

- Phase plan: \`.planning/phases/20-musician-timeline/20-14-PLAN.md\` §5
- γ-SUMMARY: \`.planning/phases/20-musician-timeline/20-14-γ-SUMMARY.md\`
- Stacks on: #131 (β), #123 (α)
- Follow-up parser issue: #132 (arpoon recursive parsing)
- Issue closed: #110

### Test plan

- [x] \`pnpm --filter @stave/editor test\` — 1551/1551
- [x] \`pnpm --filter @stave/app test\` — 314/314 (incl. 17 parity)
- [x] \`pnpm parity:refresh --sha f73b3956...\` reports zero drift
- [ ] Reviewer: manually mutate one corpus file, confirm spec fails with a clear diff (γ-2 mutation gate per PLAN)

closes #110