### PR TITLE
fix(parity): parameterize parity-bakery.mjs offset — close the fixed-window blind spot

### DIFF
--- a/packages/app/scripts/parity-bakery.mjs
+++ b/packages/app/scripts/parity-bakery.mjs
@@ -55,9 +55,20 @@ const SUPABASE_BASE = 'https://pidxdsxphlhzjnzmifth.supabase.co'
 
 const args = process.argv.slice(2)
 let N = 50
+// OFFSET (2026-05-22): the pull was historically pinned at offset 0, so every
+// measurement across the 20-1x parity cadence sampled the SAME hash-ascending
+// first ~N rows — a fixed WINDOW, not the distribution. A 2026-05-22 N=500
+// sweep measured the TRUE real-world parity at 90.4% (vs 100% on the offset=0
+// window). `--offset M` lets a maintainer measure any window; stepping
+// `--offset 0,N,2N,…` (or a single large `--n`) sweeps the distribution. The
+// artifact stamp records the offset so runs at different windows don't collide.
+let OFFSET = 0
 for (let i = 0; i < args.length; i++) {
   if (args[i] === '--n' && args[i + 1]) {
     N = Number(args[i + 1])
+    i++
+  } else if (args[i] === '--offset' && args[i + 1]) {
+    OFFSET = Number(args[i + 1])
     i++
   }
 }
@@ -78,13 +89,14 @@ async function resolveUpstream() {
   return { column: colM[1], anonKey: keyM[1] }
 }
 
-async function fetchSamples(anonKey, column, n) {
+async function fetchSamples(anonKey, column, n, offset) {
   // PostgREST: public rows only, paged. We over-fetch slightly then trim,
   // because some rows are empty / whitespace-only and don't count as a
-  // measurable sample.
+  // measurable sample. `offset` selects the distribution window (default 0;
+  // historically the ONLY window measured — see the OFFSET note above).
   const url =
     `${SUPABASE_BASE}/rest/v1/code_v1?public=eq.true&select=hash,${column}` +
-    `&order=hash.asc&limit=${n * 2}&offset=0`
+    `&order=hash.asc&limit=${n * 2}&offset=${offset}`
   const res = await fetch(url, {
     headers: { apikey: anonKey, Authorization: `Bearer ${anonKey}` },
   })
@@ -106,11 +118,12 @@ async function main() {
   console.log('# parity:bakery — real-world Bakery parity (20-15 D-03)')
   console.log(`# upstream pin:  ${UPSTREAM_SHA}`)
   console.log(`# target N:      ${N}`)
+  console.log(`# offset window: ${OFFSET}${OFFSET === 0 ? ' (default — the historically-pinned window; NOT the full distribution)' : ''}`)
   console.log('')
 
   const { column, anonKey } = await resolveUpstream()
   console.log(`# resolved body column (R5): "${column}"`)
-  const { samples, rawCount } = await fetchSamples(anonKey, column, N)
+  const { samples, rawCount } = await fetchSamples(anonKey, column, N, OFFSET)
   console.log(`# Supabase returned ${rawCount} rows; ${samples.length} non-empty samples`)
   if (samples.length === 0) throw new Error('No non-empty samples — refusing to report a %')
 
@@ -126,9 +139,9 @@ async function main() {
   // Persist the FRESH pull as the dated/SHA'd reproducible artifact
   // BEFORE classifying (so a classifier crash still leaves the raw data).
   await fs.mkdir(runsDir, { recursive: true })
-  const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+  const stamp = `${OFFSET === 0 ? '' : `offset${OFFSET}-`}${new Date().toISOString().replace(/[:.]/g, '-')}`
   const samplesPath = path.join(runsDir, `samples-${stamp}.json`)
-  await fs.writeFile(samplesPath, JSON.stringify({ stamp, UPSTREAM_SHA, column, samples }, null, 2))
+  await fs.writeFile(samplesPath, JSON.stringify({ stamp, UPSTREAM_SHA, column, offset: OFFSET, samples }, null, 2))
 
   // Classify through the PURE parseStrudel. The parser source path import
   // only works under vite-node (the @stave/editor barrel crashes


### PR DESCRIPTION
## Summary

- `parity-bakery.mjs` hard-coded `offset=0` in the Supabase pull, so every real-world parity measurement across the entire 20-1x cadence sampled the **same** hash-ascending first ~N rows — a fixed window, not the distribution. The cadence reached "100% N=50" against this blind spot.
- A 2026-05-22 N=500 sweep measured the **true real-world parity at 90.4%** (dominated by the #141/#140 binding-ref class, 50% of fallbacks). Full analysis + ranked gap-class backlog in #165.
- This PR adds a `--offset M` flag (default 0, prior behaviour preserved) threaded through the fetch + the artifact stamp + the result JSON. The run header now flags `offset=0` as "the historically-pinned window; NOT the full distribution." Stepping `--offset 0,N,2N,…` sweeps the true distribution.

Addresses the measurement-methodology half of #165 (the gap-class fixes are separate phases).

## Test plan

- [x] `pnpm parity:bakery --n 10 --offset 300` → header prints `offset window: 300`; fetches the offset-300 window; artifact stamped `samples-offset300-<iso>.json`
- [x] Default `--n 50` path byte-behaviour unchanged (offset 0, unprefixed stamp, `offset:0` in result JSON)
- [x] Editor 1627/1627 + app 417/417 unaffected (maintainer-tool-only change; not in the product build)