### PR TITLE
Publish Stave on Vercel — unblock production build + monorepo deploy config

### DIFF
--- a/packages/app/src/components/IRInspectorPanel.tsx
+++ b/packages/app/src/components/IRInspectorPanel.tsx
@@ -135,6 +135,14 @@ const TAG_COLOR: Record<PatternIR["tag"], string> = {
   // pink (#ec4899) or Param's orange (#fb923c). 20-12 design-system pass
   // lands the final swatch token.
   Track:    "var(--ir-track, #94a3b8)",
+  // Phase 20-18 — Signal/Builder Layer-1/2 IR substrate tags. Signal =
+  // continuous signals (sine/perlin/irand/…); Builder = chord/arrange/
+  // cat/transpose construction roots. Distinct placeholder hues (indigo-400
+  // / green-400) that don't collide with neighbours (Cycle #06b6d4,
+  // Play #10b981); the final swatch tokens (--ir-signal / --ir-builder)
+  // land in the design-system pass, same as Track's placeholder.
+  Signal:   "var(--ir-signal, #818cf8)",
+  Builder:  "var(--ir-builder, #4ade80)",
 };
 
 // summarize / children moved to IRInspectorChrome.ts (Phase 20-04 wave δ)

--- a/packages/app/vercel.json
+++ b/packages/app/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "cd ../.. && pnpm turbo run build --filter=@stave/app"
+}


### PR DESCRIPTION
## Summary

Prep for the first production deploy of Stave (Vercel, git-connected auto-deploy, default subdomain first).

Two changes:

1. **`fix(app)` — unblock the production build (`closes #169`).** `next build`'s full `tsc` pass was failing: `TAG_COLOR` (IRInspectorPanel) wasn't exhaustive over the `PatternIR["tag"]` union after Phase 20-18 added `Signal`/`Builder`. Latent because only `next build` full-typechecks the app — the vitest suites are transform-only. Added the two missing color tokens.
2. **`chore(deploy)` — `packages/app/vercel.json`.** Build command override `cd ../.. && pnpm turbo run build --filter=@stave/app` so turbo rebuilds `@stave/editor` before the app on every deploy (self-contained; no reliance on committed-dist freshness).

## Test plan / observation

- `pnpm --filter @stave/app build` → **compiles + typechecks clean**, 4 static pages prerendered (`/` is static; no API routes, no SSR runtime).
- Exact Vercel build command run locally from a clean `.next`: 2 turbo tasks (editor→app) succeed, `packages/app/.next/BUILD_ID` present.
- editor **1640/1640**, app **430/430** green.
- The WASM/audio-worker dynamic-URL risk flagged in `next.config.ts` was a non-issue — compiled fine.

## Not in this PR (post-merge, dashboard)

Connecting the GitHub repo to Vercel + setting Root Directory = `packages/app` (auth/dashboard steps). Custom domain (`stave.live`) deferred — shipping on the default `*.vercel.app` subdomain first to confirm the live build before DNS.