### PR TITLE
docs(catalogue): P75–P77 + PV57–PV59 from #175 (tab persistence)

### DIFF
--- a/.anvi/hetvabhasa.md
+++ b/.anvi/hetvabhasa.md
@@ -2631,3 +2631,139 @@ highlight, playhead line).
 **REF:** PR #178 / #183 — `packages/app/src/templates.ts` PIANOROLL_P5_CODE
 (commit 37a0d3d); `packages/editor/src/visualizers/sketches/PianorollSketch.ts`
 (retired source — physical removal tracked #184).
+
+## P75 — Playwright `page.addInitScript` re-fires on `page.reload()` and erases test-setup state mid-test
+
+**Pattern:** A test uses `page.addInitScript(...)` to wipe storage / seed a
+fixture / install a shim BEFORE the first `goto`. The test mutates state,
+then calls `page.reload()` to verify the state survived. The assertion
+fails: the reloaded page sees the DEFAULT state.
+
+**Mechanism:** `addInitScript` is registered on the browser **context** —
+Playwright re-runs it on EVERY navigation in that context, including
+`page.reload()`, `page.goBack()`, and any in-page navigation. So when the
+test reloads to verify "state survived," the init script fires AGAIN
+**before** the page boots, wipes the just-persisted state, and the page
+hydrates from nothing.
+
+**Symptom (silent):** a state-survives-reload test fails with "only the
+default present." Direct localStorage / IDB dumps right BEFORE the reload
+show the state IS persisted; dumps right AFTER show it gone. No exception,
+no console warning — the wipe runs successfully, just at the wrong moment.
+
+**Wrong fix:** add `await page.waitForTimeout(...)` before the reload
+(the timing is irrelevant), or move the setup inside the test body
+without re-thinking when it should fire.
+
+**Real fix:** for one-shot setup (clear / seed / cookie), do it BEFORE the
+first real `goto`, not via `addInitScript`:
+
+```ts
+await page.goto('about:blank')
+await page.evaluate(() => { localStorage.removeItem('x') })
+await page.goto('/')         // the test's actual first nav
+// ...mutate state...
+await page.reload()          // now reload preserves the mutated state
+```
+
+`addInitScript` is correct for things that genuinely must run on every
+page (a global shim, a console-error capture). Test fixture setup is not
+one of them.
+
+**Detection signal:** state-survives-reload test failing while the
+persistence layer's own unit tests pass + a direct localStorage dump
+right before reload confirms the state is there.
+
+**REF:** PR #185 (#175 tab persistence) — see
+`packages/app/tests/tab-persistence.spec.ts:wipeShellStateOnce` for the
+correct pattern.
+
+## P76 — `seed-after-mount` race: persistence hydrates from a workspace store that's still being populated
+
+**Pattern:** A component hydrates from a persisted snapshot inside a
+`useRef`/`useState` initializer at first render. The hydrate validator
+prunes any persisted reference whose underlying record is not yet present
+in the data store. But the data store is itself seeded via a sibling
+`useEffect` that runs AFTER the first render. Result: the hydrate
+validator drops every persisted reference as "stale" and falls back to
+the default state — even though the records would have existed by the
+NEXT render.
+
+**Concrete instance (Stave, #175):** `StrudelEditorClient` read its
+persisted tab snapshot inside a `useRef` initializer at mount and
+validated each tab's `fileId` against `listWorkspaceFiles()`. The
+bundled viz preset files were seeded into the workspace store by a
+sibling `useEffect(() => seedMissingPresetFiles(), [])`. Persisted tabs
+referencing those viz files got pruned on every reload → only the
+Strudel tab survived restoration. The persisted state was correct; the
+validation just ran a render too early.
+
+**Symptom (silent):** persistence "doesn't work" — open tabs / set state,
+refresh, only the default subset comes back. The persisted blob itself,
+inspected before reload, contains the FULL state. The bug isn't in
+serialize or persist; it's in WHEN the read happens relative to seed.
+
+**Wrong fix:** call `setTimeout` or `requestAnimationFrame` before the
+hydrate (introduces a flash of default state); guess at a debounce; defer
+hydrate into a `useEffect` (forces an imperative re-open dance for every
+persisted tab, defeating the whole "shell mounts hydrated" model).
+
+**Real fix:** hoist the seed BEFORE the consumer's render — same place,
+same call, just earlier in the lifecycle. For Stave the seed moved from
+`StrudelEditorClient`'s `useEffect` (post-mount) to `EditorWrapper`'s
+dynamic-import bootstrap (pre-mount), alongside the existing
+`seedProjectFromTemplate` call. The seed is idempotent (create-or-load),
+so running it on every session is free.
+
+**General rule (PV58):** persisted-state hydration must run AFTER all
+data sources it references are fully populated. If the consumer reads
+those sources at render time, the seed must complete BEFORE render.
+
+**REF:** PR #185 (#175) — `EditorWrapper.tsx:seedMissingPresetFiles()`
+hoist; see PV58.
+
+## P77 — Delta watcher seeded from the rendered subset, not from the full source — first delta misfires as "add everything new"
+
+**Pattern:** Code subscribes to a data source change feed (`subscribeToFileList`,
+a Yjs observer, etc.) to keep the UI's tab/pane/menu set in sync with the
+underlying source. The subscriber computes deltas as
+`current_source − previous_rendered_subset`. The "previous" baseline is
+seeded from what's CURRENTLY RENDERED, not from what's CURRENTLY IN THE
+SOURCE. Result: items that exist in the source but aren't yet rendered
+(common after shrinking a default) get re-detected as "added" on the
+first delta computation and auto-opened, defeating the shrink.
+
+**Concrete instance (Stave, #175):** `StrudelEditorClient` watched the
+workspace file list and routed adds → `openOrFocusFile`, deletes →
+`closeTabsForFile`. `prevFileIdsRef` was seeded from
+`initialTabs.map(t => t.fileId)` (the rendered tab subset). When the
+default shrank from 11 tabs → 1 tab, the first `subscribeToFileList` fire
+saw the other 10 workspace files (which existed but weren't tabs) as
+"added" → re-opened all 10 → 11 tabs anyway. The persistence layer was
+fine; the file-list watcher quietly undid the shrink.
+
+**Symptom (silent):** changing a UI default (fewer tabs, fewer rows,
+fewer menu items) "doesn't work" — the user-visible default reverts on
+the first source-change fire (often within the same tick of mount).
+
+**Wrong fix:** suppress the watcher for the first fire ("skip initial");
+add a flag that distinguishes "initial mount" from "real change"
+(brittle, race-prone, and breaks tests of the real change path).
+
+**Real fix:** seed the baseline from the FULL UNDERLYING SOURCE, not
+from the rendered subset:
+
+```ts
+// before: prevIdsRef = new Set(initialTabs.map(t => t.fileId))   ← rendered subset
+// after:  prevIdsRef = new Set(listWorkspaceFiles().map(f => f.id))  ← full source
+```
+
+The watcher now computes a true delta — items added or removed AFTER
+mount — and the rendered subset is free to be smaller than the source
+without re-explosion.
+
+**General rule (PV59):** delta watchers seed from the GROUND TRUTH the
+delta is computed against, not from a subset of it.
+
+**REF:** PR #185 (#175) — `StrudelEditorClient.tsx:prevFileIdsRef` seed
+correction; see PV59.

--- a/.anvi/vyapti.md
+++ b/.anvi/vyapti.md
@@ -2458,3 +2458,125 @@ useEffect) running before inline resolution — which is the case today.
 misattributed; observation revealed the true cause) and P74 (the
 consolidation-downgrade trap surfaced HERE — solving P73 silently broke
 note-name patterns until porting the rich logic).
+
+## PV57 — Workspace UI-shell state is local-first, per-project, persisted across reloads
+
+**Claim:** The user's open-tab set, tab order, per-group active tab,
+pane-split layout, active group, and per-group `backgroundFileId` are
+preferences of THIS device for THIS project and must survive a page
+refresh. They are NOT part of the Y.Doc (the cross-device data model),
+and they MUST be scoped per project so switching projects loads each
+project's own state.
+
+**Why:** without persistence the user re-arranges the shell on every
+reload — work lost on every save-tab-close-coffee-break cycle. Not
+persisting also forces a "show everything by default" fallback that
+overwhelms first-time visitors (the 11-tab wall before #175). Choosing
+localStorage over Yjs reflects that tab state is per-device (a user's
+phone often wants different open tabs from their laptop) and avoids the
+`whenSynced` race the Yjs path would otherwise need to navigate.
+
+**Span:** `packages/editor/src/workspace/tabPersistence.ts` (storage +
+validate/hydrate helpers), `packages/editor/src/workspace/WorkspaceShell.tsx`
+(`initialGroups`/`initialLayout`/`initialActiveGroupId` props and the
+`onGroupsChange` sink), `packages/app/src/components/StrudelEditorClient.tsx`
+(hydrate-at-mount + save-on-change wiring with `projectId` scoping),
+`packages/app/src/components/EditorWrapper.tsx` (pre-mount seed of the
+files the snapshot may reference — see PV58).
+
+**Maintained by:**
+- Storage key `stave:workspace:${projectId}:state`. ProjectId scoping
+  comes from `StaveApp`'s existing `key={activeProject.id}` remount on
+  project switch — within a mount, the project is stable.
+- Schema-versioned snapshot (`SHELL_STATE_VERSION`). Version mismatch on
+  read returns null so future format changes degrade gracefully (user
+  loses tab state once instead of crashing on the load path).
+- Single sink: `WorkspaceShell.onGroupsChange` fires reactively via a
+  single `useEffect([groups, layout, activeGroupId])`. Every internal
+  mutation (open / close / reorder / split / active-change / backdrop
+  transition) flows through ONE save call.
+- Read-time validation: every persisted `fileId` and `backgroundFileId`
+  is checked against the live workspace; stale references are pruned,
+  empty layout columns collapsed, `activeTabId`/`activeGroupId`
+  reassigned to live targets. If nothing usable remains, the loader
+  returns null and the consumer falls back to `buildDefaultSnapshot`
+  (a single tab on the project's Strudel file, or empty).
+- Preview tabs are DROPPED at write time — they're transient by design
+  (VSCode parity); resurrecting them across reload would invent
+  "pinned" tabs the user never asked for.
+- SSR-safe everywhere (`typeof window === 'undefined'` guards), and
+  every storage call is wrapped in try/catch so Safari private-mode /
+  quota errors degrade to "no persistence this session" not to a crash.
+
+**REF:** PR #185 (#175). Related: PV58 (the hydrate-after-seed
+discipline that makes this work), PV59 (the delta-watcher seeding
+discipline that makes the shrunk default stick).
+
+## PV58 — Persisted-state hydration runs AFTER all data sources it references are fully populated
+
+**Claim:** When a component hydrates from a persisted snapshot at render
+time (inside `useRef` / `useState` initializers), every data source the
+hydrate validator consults — workspace stores, registries, IDB-backed
+caches — must already contain the records the snapshot might reference.
+Any seed step that populates those sources MUST complete BEFORE the
+component that hydrates renders.
+
+**Why:** if the seed runs in a sibling `useEffect`, it fires AFTER the
+first render's hydrate. The hydrate validator drops every persisted
+reference whose record doesn't yet exist — silently — and falls back to
+the default state. The persisted blob is correct; the validation just
+ran a render too early. (P76.)
+
+**Span:** any pair `(hydrate, seed)` where the hydrate validates
+against the seed's output. In Stave: `tabPersistence.loadShellState`
+validates against `listWorkspaceFiles()`; `seedMissingPresetFiles` is
+what populates the workspace file store. The pair lives across the
+editor/app boundary — the hydrate is inside `@stave/editor` consumed
+by `@stave/app`, the seed is inside `@stave/app`'s `EditorWrapper`.
+
+**Maintained by:**
+- Seeds hoisted to the pre-mount bootstrap path. In Stave that's
+  `EditorWrapper`'s dynamic-import async closure (same place as
+  `seedProjectFromTemplate`), which `await`s `initProjectDoc` before
+  the inner closure returns the StaveApp component to render.
+- Seed idempotency. `seedMissingPresetFiles` uses
+  `seedWorkspaceFile`'s create-or-load semantics, so re-running it on
+  every session is free. Idempotency is what lets us safely move the
+  seed to a path that fires on every load (not just first-run).
+- A defense-in-depth duplicate (the existing post-mount
+  `useEffect(() => seedMissingPresetFiles(), [])` in
+  `StrudelEditorClient`) is retained for callers that mount the
+  client outside the `EditorWrapper` bootstrap path.
+
+**REF:** PR #185 — `EditorWrapper.tsx` seed hoist; P76 for the
+diagnostic shape; `tabPersistence.validatePersistedState` for the
+validation path that triggers the trap when this invariant breaks.
+
+## PV59 — Delta watchers seed their baseline from the GROUND TRUTH, not from a derived subset
+
+**Claim:** A watcher that computes `added = current − previous` on every
+source change must seed `previous` from the FULL underlying source, not
+from a smaller subset currently rendered. Otherwise the first fire
+treats the complement of the subset as "added" and re-creates exactly
+the state the consumer wanted to avoid.
+
+**Why:** the delta semantics are "items added or removed AFTER mount" —
+implemented as a set-difference against a baseline. If the baseline is a
+subset of the source, the difference produces the unrendered remainder
+as a false-positive add. (P77.)
+
+**Span:** every place a watcher subscribes to a data-source change feed
+and maintains a `prev*Ref` snapshot. In Stave: `StrudelEditorClient`
+watches `subscribeToFileList` to mirror create / delete events from the
+workspace into tab adds / closes; the `prevFileIdsRef` is the baseline.
+
+**Maintained by:**
+- The baseline seed reads the FULL source at mount, not the rendered
+  subset: `new Set(listWorkspaceFiles().map(f => f.id))`, NOT
+  `new Set(initialTabs.map(t => t.fileId))`.
+- The watcher is therefore safe under a shrunk default (#175): tabs
+  start as a subset of the workspace, the watcher sees no delta until
+  the user actually adds or removes a file.
+
+**REF:** PR #185 — `StrudelEditorClient.tsx` `prevFileIdsRef`
+correction; P77 for the diagnostic shape.


### PR DESCRIPTION
Three new hetvabhāsa entries + three new vyāpti entries earned during PR #185 (#175 — workspace tab persistence). Documentation-only; no runtime change.

## hetvabhāsa (error patterns)
- **P75** — Playwright \`page.addInitScript\` re-fires on \`page.reload()\` and silently erases test-setup state mid-test.
- **P76** — Seed-after-mount race: persistence hydrates from a workspace store that's still being populated.
- **P77** — Delta watcher seeded from the rendered subset, not from the full source.

## vyāpti (invariants)
- **PV57** — Workspace UI-shell state is local-first, per-project, persisted across reloads.
- **PV58** — Persisted-state hydration runs AFTER all data sources it references are fully populated.
- **PV59** — Delta watchers seed their baseline from the GROUND TRUTH the delta is computed against, not from a derived subset.

All six cross-reference PR #185 and the affected source files.