### PR TITLE
:bug: fix(viz): stop seedPresets clobbering user edits to bundled Piano Roll preset (#189)

### DIFF
--- a/packages/app/src/components/StrudelEditorClient.tsx
+++ b/packages/app/src/components/StrudelEditorClient.tsx
@@ -272,9 +272,13 @@ export default function StrudelEditorClient({
     registerPresetAsNamedViz(hydraPreset);
   }, [seedState.p5PresetId, seedState.hydraPresetId]);
 
-  // Persist bundled presets to IndexedDB (non-blocking, fire-and-forget).
-  // IMPORTANT: merge with existing presets to preserve user-set fields
-  // like cropRegion that aren't part of the bundled code template.
+  // Persist bundled presets to IndexedDB on FIRST seed only — never
+  // overwrite an existing entry. Earlier the bundled `code` was put
+  // back every mount, which silently erased user edits to the bundled
+  // Piano Roll preset on every reload (#189). Workspace files follow
+  // the same seed-when-missing rule via `seedWorkspaceFile`; bringing
+  // VizPresetStore in line removes the "bundled preset is privileged"
+  // duality at the data layer.
   useEffect(() => {
     async function seedPresets() {
       const LEGACY_IDS = ["pianoroll-p5-custom", "pianoroll-hydra-custom"];
@@ -284,21 +288,23 @@ export default function StrudelEditorClient({
       }
       const now = Date.now();
       const existingP5 = await VizPresetStore.get(seedState.p5PresetId);
-      await VizPresetStore.put({
-        ...existingP5,
-        id: seedState.p5PresetId, name: "Piano Roll", renderer: "p5",
-        code: PIANOROLL_P5_CODE, requires: ["streaming"],
-        nativeSize: existingP5?.nativeSize ?? { w: 1400, h: 350 },
-        createdAt: existingP5?.createdAt ?? now, updatedAt: now,
-      });
+      if (!existingP5) {
+        await VizPresetStore.put({
+          id: seedState.p5PresetId, name: "Piano Roll", renderer: "p5",
+          code: PIANOROLL_P5_CODE, requires: ["streaming"],
+          nativeSize: { w: 1400, h: 350 },
+          createdAt: now, updatedAt: now,
+        });
+      }
       const existingHydra = await VizPresetStore.get(seedState.hydraPresetId);
-      await VizPresetStore.put({
-        ...existingHydra,
-        id: seedState.hydraPresetId, name: "Piano Roll (Hydra)", renderer: "hydra",
-        code: PIANOROLL_HYDRA_CODE, requires: ["audio"],
-        nativeSize: existingHydra?.nativeSize ?? { w: 1400, h: 400 },
-        createdAt: existingHydra?.createdAt ?? now, updatedAt: now,
-      });
+      if (!existingHydra) {
+        await VizPresetStore.put({
+          id: seedState.hydraPresetId, name: "Piano Roll (Hydra)", renderer: "hydra",
+          code: PIANOROLL_HYDRA_CODE, requires: ["audio"],
+          nativeSize: { w: 1400, h: 400 },
+          createdAt: now, updatedAt: now,
+        });
+      }
     }
     seedPresets();
   }, [seedState.p5PresetId, seedState.hydraPresetId]);

--- a/packages/app/tests/preset-clobber-regression.spec.ts
+++ b/packages/app/tests/preset-clobber-regression.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect, type Page } from '@playwright/test'
+
+// Issue #189 — `StrudelEditorClient.seedPresets` used to `VizPresetStore.put`
+// the bundled `code` on every mount, erasing user edits to the bundled
+// Piano Roll preset on every reload. The fix: only put when no entry
+// exists ("seed-when-missing", matching `seedWorkspaceFile`).
+//
+// Realistic flow this test exercises:
+//   1. Fresh wipe → `seedPresets` creates the bundled entry.
+//   2. We edit the workspace file `preset/viz/Piano Roll.p5` via Monaco's
+//      model API. The edit lives in Yjs and persists across reloads.
+//   3. Reload — on the new mount, `registerAllVizFiles` runs `flushToPreset`,
+//      which reads the workspace file (with our marker) and writes it to
+//      `VizPresetStore`. Pre-fix, `seedPresets` then clobbered that
+//      flushed content back to the bundled `PIANOROLL_P5_CODE`. Post-fix,
+//      `seedPresets` is a no-op when the entry exists, so the user's
+//      edit survives.
+//
+// Note: the live-edit propagation (before reload) goes through
+// `useVizRefWatcher`, which only fires when an active strudel/sonicpi
+// file references the viz. We don't assert on that path — the
+// load-bearing contract is "after-reload, VizPresetStore reflects the
+// workspace file content," and that's what this test pins.
+
+const VIZ_DB = 'stave-viz-presets'
+const VIZ_STORE = 'presets'
+const BUNDLED_P5_ID = '__bundled_piano_roll_p5__'
+const MARKER = '// USER-EDIT-MARKER-189'
+
+async function wipeAllAppDbs(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.evaluate(async (vizDb) => {
+    try {
+      const keys: string[] = []
+      for (let i = 0; i < localStorage.length; i++) {
+        const k = localStorage.key(i)
+        if (k && k.startsWith('stave:')) keys.push(k)
+      }
+      for (const k of keys) localStorage.removeItem(k)
+    } catch {
+      // private mode, ignore
+    }
+    await new Promise<void>((resolve) => {
+      const req = indexedDB.deleteDatabase(vizDb)
+      req.onsuccess = () => resolve()
+      req.onerror = () => resolve()
+      req.onblocked = () => resolve()
+    })
+  }, VIZ_DB)
+}
+
+async function readPresetCode(
+  page: Page,
+  id: string,
+): Promise<string | undefined> {
+  return page.evaluate(
+    ({ db, store, id }) =>
+      new Promise<string | undefined>((resolve) => {
+        const req = indexedDB.open(db)
+        req.onsuccess = () => {
+          const d = req.result
+          if (!d.objectStoreNames.contains(store)) {
+            d.close()
+            resolve(undefined)
+            return
+          }
+          const t = d.transaction(store, 'readonly').objectStore(store).get(id)
+          t.onsuccess = () => {
+            d.close()
+            const rec = t.result as { code?: string } | undefined
+            resolve(rec?.code)
+          }
+          t.onerror = () => {
+            d.close()
+            resolve(undefined)
+          }
+        }
+        req.onerror = () => resolve(undefined)
+      }),
+    { db: VIZ_DB, store: VIZ_STORE, id },
+  )
+}
+
+async function editPianoRollViaMonacoModel(
+  page: Page,
+  marker: string,
+): Promise<void> {
+  await page.evaluate(async (m) => {
+    const w = window as unknown as {
+      monaco?: {
+        editor?: {
+          getModels?: () => Array<{
+            getValue: () => string
+            setValue: (s: string) => void
+          }>
+        }
+      }
+    }
+    const deadline = Date.now() + 5000
+    while (
+      (!w.monaco?.editor?.getModels ||
+        w.monaco.editor.getModels().length === 0) &&
+      Date.now() < deadline
+    ) {
+      await new Promise((r) => setTimeout(r, 100))
+    }
+    const models = w.monaco?.editor?.getModels?.() ?? []
+    const target = models.find((x) =>
+      x.getValue().includes('Stave p5 viz — Piano Roll'),
+    )
+    if (!target) throw new Error('Piano Roll model not loaded')
+    target.setValue(m + '\n' + target.getValue())
+  }, marker)
+}
+
+test.beforeEach(async ({ page }) => {
+  await wipeAllAppDbs(page)
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await page.locator('.monaco-editor').first().waitFor({ timeout: 15000 })
+  await page.waitForTimeout(1500)
+})
+
+test('user edits to the bundled Piano Roll preset survive a reload', async ({
+  page,
+}) => {
+  // 1. Open Piano Roll.p5 so Monaco loads its model.
+  await page
+    .locator('[data-file-tree-item]')
+    .filter({ hasText: 'Piano Roll.p5' })
+    .first()
+    .dblclick()
+  await page.waitForTimeout(800)
+
+  // 2. Inject the marker via Monaco's model API. The Y.Doc binding picks
+  //    it up and persists to IndexedDB.
+  await editPianoRollViaMonacoModel(page, MARKER)
+  await page.waitForTimeout(800)
+
+  // 3. Reload. Pre-fix this is where `seedPresets` clobbered VizPresetStore
+  //    after `registerAllVizFiles` had just populated it from the workspace.
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await page.locator('.monaco-editor').first().waitFor({ timeout: 15000 })
+  await page.waitForTimeout(2500)
+
+  // 4. Load-bearing assertion: VizPresetStore.code retains the user edit
+  //    after reload — proving `seedPresets` no longer clobbers.
+  const afterReload = await readPresetCode(page, BUNDLED_P5_ID)
+  expect(afterReload).toBeDefined()
+  expect(afterReload).toContain(MARKER)
+})


### PR DESCRIPTION
## Summary

Closes #189. Phase A of the file-history MVP (#189 → #191 → #192 → #193).

`StrudelEditorClient.seedPresets` ran on every mount and unconditionally `VizPresetStore.put`-d the bundled Piano Roll preset with `code: PIANOROLL_P5_CODE`. It ran AFTER `registerAllVizFiles` had just flushed the user's workspace-file edit into the same store, so the user's edit lasted milliseconds before being overwritten on every reload.

Workspace files always persisted (seedWorkspaceFile is idempotent). The bug was at the VizPresetStore layer the runtime renders from.

## Fix

One change: only `VizPresetStore.put` when no entry exists. Brings VizPresetStore in line with workspace files' seed-when-missing semantics, removing the "bundled preset is privileged" duality from the data layer.

## Test plan

- [x] New Playwright spec `preset-clobber-regression.spec.ts` opens Piano Roll.p5, injects a marker via Monaco's model API (Yjs picks it up), reloads, and asserts `VizPresetStore.code` retains the marker.
- [x] Verified the test exercises the right contract: stashed the fix, re-ran — test fails. Restored the fix — test passes.
- [x] Editor unit tests 1662/1662 green.
- [x] `pnpm --filter @stave/app build` clean (P72).

## What this unblocks

Phase B (#191) — per-file initial-content store + `revertFileToOriginal` API. After Phase A, the bundled code is a true one-time seed; Phase B adds the architectural piece that lets ANY file (bundled or user-created) revert to its original content. The "bundled viz is privileged" model dissolves entirely.