### PR TITLE
:memo: docs(catalogue): P78–P79 multi-writer regression traps + PV60 stash-and-verify gate

### DIFF
--- a/.anvi/hetvabhasa.md
+++ b/.anvi/hetvabhasa.md
@@ -2767,3 +2767,98 @@ delta is computed against, not from a subset of it.
 
 **REF:** PR #185 (#175) — `StrudelEditorClient.tsx:prevFileIdsRef` seed
 correction; see PV59.
+
+## P78 — Multi-writer regression test trap: fix verified at the wrong layer / wrong timing because N writers exist
+
+**Pattern:** A store is written by N independent code paths. A bug
+exists at writer-A (e.g. clobber-on-every-mount). The fix removes the
+clobber at writer-A. The regression test attempts to probe the fix by
+either (i) probing a layer ABOVE the store (UI text, editor pane) and
+expecting the store-level fix to show through, or (ii) probing the
+store directly but at a TIMING SLICE where writer-B's legitimate sync
+hasn't run yet — so the "fix's effect" isn't observable.
+
+Result: the test fails post-fix and the engineer spends hours
+debugging the test instead of accepting that the fix was correct at a
+different layer.
+
+**Concrete instance (Stave, #189):** `VizPresetStore.code` for the
+bundled Piano Roll preset is written by THREE paths on every mount:
+
+1. `registerAllVizFiles` (StrudelEditorClient.tsx ~line 226) calls
+   `flushToPreset(fileId, presetId)` for every viz workspace file —
+   reads the WORKSPACE FILE content and writes it to VizPresetStore.
+2. `seedPresets` (line 278) clobbered VizPresetStore.code back to
+   `PIANOROLL_P5_CODE` — this was the bug.
+3. `useVizRefWatcher` fires on Y.Text changes (only when an active
+   strudel/sonicpi file references that viz via `.viz("name")`) and
+   re-runs `flushToPreset`.
+
+First test attempt: probe `monaco.textContent` after Monaco type — failed
+mysteriously (marker visible in received string, `toContain` still false;
+Monaco's textContent traversal doesn't preserve insertion order under
+mid-line inserts). Wrong layer.
+
+Second test attempt: write a marker directly into VizPresetStore, reload,
+assert marker survives. Failed because on reload `registerAllVizFiles`
+flushes the unchanged workspace file (bundled) → VizPresetStore reverts
+to bundled regardless of the seedPresets fix. Wrong timing — the
+load-bearing write isn't probed.
+
+**Real fix path:** make the workspace FILE contain the marker (via Monaco
+model `setValue`, which the Yjs binding picks up and persists), reload,
+assert VizPresetStore.code retains the marker. The post-reload mount runs
+writer-1 (flush from workspace = marker), then writer-2 (post-fix:
+no-op). Marker survives. Pre-fix the same test fails because writer-2
+clobbers.
+
+**General rule (PV60):** When testing a fix to one writer of a
+multi-writer store, the test must let the ENTIRE write choreography play
+out before asserting. Trace every writer; probe at the layer that
+captures their COMBINED post-state, not at a layer that misses one of
+them.
+
+**REF:** PR #194 (#189) — `preset-clobber-regression.spec.ts`;
+`StrudelEditorClient.tsx` `seedPresets` + `registerAllVizFiles` +
+`useVizRefWatcher.ts` for the three writers; see PV60.
+
+## P79 — Regression test that doesn't FAIL pre-fix is vestigial — proves nothing
+
+**Pattern:** Engineer writes a regression test alongside a fix; test
+passes; engineer ships. Months later the bug re-appears under a similar
+condition and the test is still green — because the test was probing
+behavior that's true regardless of the fix.
+
+**Why it slips through:** "test green + fix applied" feels like proof,
+but a test that's GREEN both pre-fix and post-fix is testing some other
+contract, not the fix's contract. The author rarely runs the test against
+the unfixed code to verify the test catches the bug.
+
+**Concrete instance (Stave, #189):** my first regression test attempt
+(asserting workspace file content survives reload) would have been green
+without the fix — because workspace files always persisted correctly
+(seedWorkspaceFile is idempotent). The actual bug was at the
+VizPresetStore layer the runtime renders from. Without the
+stash-and-verify step, this test would have shipped as "regression
+protection" for a bug it can't catch.
+
+**The verification gate (PV60):** before declaring a regression test
+shipped, **stash the fix and re-run the test**. If green, the test is
+vestigial — rewrite it to probe the layer where the fix's effect is
+load-bearing. If red, restore the fix and confirm green. That pre/post
+oscillation is the only objective proof the test exercises the right
+contract.
+
+**Concrete oscillation (#189):**
+```bash
+git stash push <fixed-file>           # remove fix
+playwright test <regression-spec>     # MUST fail
+git stash pop                          # restore fix
+playwright test <regression-spec>     # MUST pass
+```
+
+The discipline costs 30 seconds. The cost of a vestigial regression test
+is the next time this bug re-appears.
+
+**REF:** PR #194 (#189) — explicit stash-verify cycle in the commit body;
+see PV60.

--- a/.anvi/vyapti.md
+++ b/.anvi/vyapti.md
@@ -2580,3 +2580,47 @@ workspace into tab adds / closes; the `prevFileIdsRef` is the baseline.
 
 **REF:** PR #185 — `StrudelEditorClient.tsx` `prevFileIdsRef`
 correction; P77 for the diagnostic shape.
+
+## PV60 — Regression tests must FAIL pre-fix (stash-and-verify gate)
+
+**Claim:** Every regression test paired with a bug fix MUST be verified
+to fail when the fix is removed. If the test is green both pre-fix and
+post-fix, it is testing some other contract — not the fix's — and is
+vestigial.
+
+**Why:** "test green + fix applied" feels like proof, but green-without-
+the-fix means the test will be green NEXT time the bug recurs too. A
+regression test that can't tell the difference is structural cargo —
+catches no regression and adds maintenance overhead. (P79.)
+
+For multi-writer stores, the test must also let the ENTIRE write
+choreography play out before asserting (P78); otherwise the assertion
+slot misses the writer whose absence/presence is what the fix changes.
+
+**Span:** every regression test added in the same PR as a fix. The gate
+applies AT TEST WRITE TIME, not at code review — by code review the
+oscillation is harder to perform without disturbing other in-flight
+changes.
+
+**Maintained by:**
+- **Stash-and-verify cycle:**
+  ```
+  git stash push <fixed-file>
+  pnpm test <regression-spec>     # MUST fail
+  git stash pop
+  pnpm test <regression-spec>     # MUST pass
+  ```
+  Logged in the commit body so a reviewer can re-run it later.
+- **Layer choice:** the test probes the layer where the fix's effect is
+  load-bearing. If the bug is in store-writer-A, probe the store's state
+  AFTER all writers have run. Don't probe a UI layer that reads through
+  the store unless that's the actual user-visible contract.
+- **Timing choice:** for fixes inside multi-writer choreography, assert
+  at the post-choreography state, not mid-choreography. In Stave's #189
+  this meant asserting AFTER reload (when `registerAllVizFiles` flush +
+  `seedPresets` no-op together produce the surviving content), not
+  before.
+
+**REF:** PR #194 (#189) — `preset-clobber-regression.spec.ts` validated
+via stash-and-verify oscillation; commit body documents it. See P78 +
+P79 for the diagnostic shapes.


### PR DESCRIPTION
## Summary

Captures the diagnostic knowledge surfaced during the #189/#194 session (seedPresets clobber fix + its regression test). Three catalogue entries that codify regression-test failure modes for multi-writer stores — directly load-bearing for the file-history milestone (#195–#199), where the Yjs/Monaco/named-viz/VizPreset write choreography is the same shape that bit #189.

- **P78** (hetvabhasa) — *Multi-writer regression test trap.* When a store has N writers, a fix to one writer must be probed at the layer/timing that captures their **combined** post-state. Worked example: the three `VizPresetStore` writers in `StrudelEditorClient` (`registerAllVizFiles` flush · `seedPresets` · `useVizRefWatcher`). Documents both failed test attempts (wrong layer, wrong timing) and the real fix path.
- **P79** (hetvabhasa) — *A regression test that doesn't FAIL pre-fix is vestigial.* Green-both-ways proves nothing; it'll be green next time the bug recurs too.
- **PV60** (vyapti) — *Stash-and-verify gate.* Every regression test paired with a fix MUST be shown to fail when the fix is stashed, then pass when restored. The oscillation goes in the commit body. **Applies to every regression test in the file-history milestone.**

## Test plan

Docs-only — `.anvi/` catalogue markdown. No code change, no build impact. REFs trace to PR #194 (#189) and the named source files.

## Notes

`.anvi/` is gitignored locally; committed with `git add -f` per the catalogue-as-living-docs convention (same as #187).
