### PR TITLE
:bug: fix(build): cache @stave/app's .next as a turbo build output (re-land dropped #212 fix)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
One-line infra fix that was made + verified on PR #212 (commit `fccc49b`) but **dropped by the squash merge** — the squash captured #212's stale PR head (`454effe`; GitHub hadn't synced the head to the later push), so this never reached `main`.

## Problem
Root `turbo.json` `build` outputs were `["dist/**"]` only — correct for `@stave/editor` (tsup → `dist/`), but it omits `@stave/app`'s `.next/`. On a Turbo cache **hit** for the app, nothing is restored into `.next`, and Vercel fails with *"The file `.next/routes-manifest.json` couldn't be found."* Deploys are non-deterministic: a cache **miss** runs a real `next build` and passes; a cache **hit** restores an empty `.next` and fails. Main is currently carrying this latent landmine.

## Fix
Add `.next/**` (excluding `!.next/cache/**`) to the build outputs — the documented Vercel+Turborepo pattern.

## Test plan
Reproduced the Vercel scenario locally: `turbo run build` → wipe `.next` → rebuild hits **FULL TURBO** and **restores** `.next/routes-manifest.json` (was MISSING before the fix). No runtime/code surface touched.