### PR TITLE
🧪 perf: B-0 spike — p5 v2 renders to OffscreenCanvas in a Web Worker = YES (#235)

### DIFF
--- a/packages/app/public/spike/.gitignore
+++ b/packages/app/public/spike/.gitignore
@@ -1,0 +1,4 @@
+# Vendored p5 standalone ESM bundle (1MB) — NOT committed. The spike test
+# (tests/b0-worker-spike.spec.ts) copies it from
+# packages/editor/node_modules/p5/lib/p5.esm.min.js in beforeAll.
+p5.esm.min.js

--- a/packages/app/public/spike/README.md
+++ b/packages/app/public/spike/README.md
@@ -1,0 +1,73 @@
+# B-0 feasibility spike — p5 v2 in a Web Worker on an OffscreenCanvas
+
+Issue **#235** (perf epic #228). Branch `perf/b0-worker-spike` → PRs into `performance`.
+
+## The question (the fork that decides Phase B)
+
+The #232 ablation pinned the viz bottleneck: the p5 WEBGL `draw()` is **CPU per-segment
+line tessellation on the main thread**, and it **starves the audio scheduler**
+(`trig/s` 8.4→4.8 — PV69/P101). The only architectural fix left is moving the renderer
+**off the main thread → an OffscreenCanvas Web Worker (Phase B)**. But p5 expects
+`window`/`document` and does NOT run in a worker out of the box — **unproven**. Spike
+before architecting.
+
+## Result: **YES** — observed, not inferred
+
+`p5 v2.2.3` renders WEBGL into an OffscreenCanvas inside a dedicated Web Worker. The
+sketch painted a green rect on a red field; the worker read back the canvas centre pixel
+as `[0,255,0,255]` (green), `nonBlank=2048/2048` sampled, ~55fps (22 frames/400ms). The
+per-frame draws are entirely worker-side — the main thread is free.
+
+## What it takes (the minimal shim — grounded at each p5 source line)
+
+p5 fails progressively; each failure was read in `p5.js` and fixed with the smallest shim:
+
+1. **`window is not defined` at import** — `registerAddon(Ge)` calls `window.performance.now()`
+   at module-eval (p5.js `Ge`). → install the `window`/`document` shim on the worker global
+   **before** importing p5.
+2. **Workers have no `requestAnimationFrame`** — p5's draw loop needs one. → setTimeout-backed
+   rAF on the worker global.
+3. **FES `fetchScript` → `reading 'src'`** (presetup) — p5's Friendly Error System reads a
+   `<script>`'s `.src` (p5.js:97021), meaningless in a worker. → `p5.disableFriendlyErrors = true`
+   (gated at p5.js:97043).
+4. **`createCanvas` → `reading 'appendChild'`** — p5 creates `<main>`, then does
+   `getElementsByTagName('main')[0].appendChild(canvas)` (p5.js:71123). → `getElementsByTagName`
+   must actually **walk the fake DOM tree**, not return `[]`.
+5. **`getContext('experimental-webgl')` invalid enum** — p5 creates a default **P2D** canvas
+   first, then the user's **WEBGL** canvas. A single surface holds one context type, so the 2nd
+   `getContext` returned null and p5 fell through to `experimental-webgl` (throws on OffscreenCanvas).
+   → mint a **distinct** OffscreenCanvas per `createElement('canvas')`.
+6. **`texImage2D … Overload resolution failed`** — native WebGL does a **branded** internal-slot
+   check on its texture source; a `Proxy`-wrapped OffscreenCanvas is not recognised. → augment the
+   **real** OffscreenCanvas instance in place (no Proxy); native APIs see a genuine OffscreenCanvas,
+   p5's JS reads hit the patched DOM props.
+
+Net shim surface (small, stable): a `window` (performance/innerWidth/addEventListener/rAF/
+devicePixelRatio/screen), a `document` (createElement, tree-walking getElementsByTagName,
+getElementById/querySelectorAll, readyState='complete', body/documentElement), `disableFriendlyErrors`,
+one fresh OffscreenCanvas per canvas element, each augmented in place with DOM props.
+
+## Files
+
+- `p5-worker.js` — the staged, observe-first worker (S1 import → S2 bare → S3 shim → S4 draw+readback).
+- `../../tests/b0-worker-spike.spec.ts` — Playwright driver: transfers a real OffscreenCanvas,
+  collects the verdict, asserts the green-rect render. Self-provisions `p5.esm.min.js`.
+- `p5.esm.min.js` — gitignored; copied from `packages/editor/node_modules/p5/lib/` by the test.
+
+## Run
+
+```
+pnpm --filter @stave/app exec playwright test b0-worker-spike.spec.ts --reporter=line
+```
+
+## Not yet proven (Phase B pre-flight, not the fork)
+
+- **Direct render into the *transferred* canvas** (on-screen): proven feasible in principle
+  (transferControlToOffscreen available; p5 renders into worker OffscreenCanvases fine) but the
+  spike reads back a worker-local canvas. Phase B wires the transferred canvas as p5's main
+  WEBGL surface (route it to the canvas whose `getContext` is `webgl2`).
+- **COOP/COEP for SharedArrayBuffer** (Q2): Next 16.2.1 supports `async headers()` in
+  `next.config.ts` (mechanism confirmed). Whether it breaks superdough/AudioWorklet/fonts/embeds
+  must be observed — make it the first Phase B task.
+- **hydra-synth in a worker** (Q3, fallback path): not spiked; lower priority now that the
+  primary (p5) path is YES.

--- a/packages/app/public/spike/p5-worker.js
+++ b/packages/app/public/spike/p5-worker.js
@@ -1,0 +1,520 @@
+/* eslint-disable */
+// ── B-0 FEASIBILITY SPIKE — p5 v2 in a Web Worker on an OffscreenCanvas ──
+//
+// Question (issue #235): can the p5 WEBGL renderer (the measured main-thread
+// bottleneck — PV69/P101) move off-thread into a worker via OffscreenCanvas?
+//
+// This worker is OBSERVE-FIRST. It runs staged probes and posts a structured
+// report for EACH stage. We never assume p5 works in a worker — p5 expects
+// `window`/`document`, which a WorkerGlobalScope does not have. The job is to
+// observe exactly WHERE it breaks and, via a recording DOM shim, discover the
+// MINIMAL surface p5 actually touches (the "how minimal is the shim" answer).
+//
+// Stages:
+//   S1  import p5 in a worker          — does module-eval touch document/window?
+//   S2  bare `new p5()` WEBGL, no shim — what does it throw, and where?
+//   S3  minimal recording DOM shim     — point p5 at the transferred canvas;
+//                                         record every non-OffscreenCanvas prop
+//                                         p5 reaches for (the shim surface).
+//   S4  draw a frame → read pixels     — non-blank = PASS.
+
+const reports = []
+function emit(stage, status, detail) {
+  const r = { stage, status, detail }
+  reports.push(r)
+  self.postMessage({ type: 'stage', ...r })
+}
+
+// Forward worker-side diagnostics to the driver — p5's async #_setup rejects
+// out-of-band (it's not awaited by our `new p5()`), so without this the real
+// error is invisible. Also capture p5's FES console output.
+const workerLogs = []
+function wlog(kind, args) {
+  const line = `[${kind}] ` + args.map((a) => {
+    try {
+      if (a instanceof Error) return `${a.name}: ${a.message}\n${String(a.stack || '').split('\n').slice(0, 6).join('\n')}`
+      return typeof a === 'string' ? a : JSON.stringify(a)
+    } catch {
+      return String(a)
+    }
+  }).join(' ')
+  workerLogs.push(line)
+  self.postMessage({ type: 'workerlog', line })
+}
+self.addEventListener('error', (e) => wlog('error', [e.message, `${e.filename}:${e.lineno}:${e.colno}`]))
+self.addEventListener('unhandledrejection', (e) => wlog('unhandledrejection', [e.reason]))
+for (const k of ['error', 'warn', 'log']) {
+  const orig = console[k]?.bind(console)
+  console[k] = (...a) => {
+    wlog('console.' + k, a)
+    orig?.(...a)
+  }
+}
+function errInfo(e) {
+  return {
+    message: String((e && e.message) || e),
+    name: String((e && e.name) || ''),
+    // first few stack frames — enough to cite the p5 internal that died
+    stack: String((e && e.stack) || '').split('\n').slice(0, 8).join('\n'),
+  }
+}
+
+// ── Recording DOM shim ───────────────────────────────────────────────────
+// Every property p5 reads off `document` / `window` / the canvas that is NOT
+// natively present gets recorded in `touched`. That set, post-run, is the
+// grounded minimal-shim surface. Stubs are benign (no-op fn / 0 / empty),
+// so we observe how FAR p5 gets, not how fast it dies.
+const touched = { document: new Set(), window: new Set(), canvas: new Set() }
+
+// Recursively collect elements matching a tagName from the fake DOM tree we
+// build via appendChild — backs getElementsByTagName so p5's created <main>
+// (and the canvas) are findable.
+function collectByTag(root, TAG, out) {
+  const kids = root && (root.children || root.childNodes)
+  if (!Array.isArray(kids)) return
+  for (const c of kids) {
+    if (c && c.tagName === TAG) out.push(c)
+    collectByTag(c, TAG, out)
+  }
+}
+
+function makeStyle() {
+  // p5 reads/writes canvas.style.* and element.style.*
+  return new Proxy(
+    {},
+    {
+      get: (t, k) => (k in t ? t[k] : ''),
+      set: (t, k, v) => {
+        t[k] = v
+        return true
+      },
+    }
+  )
+}
+
+// A fake DOM element good enough for p5's container / wrapper plumbing.
+function makeElement(tag) {
+  const children = []
+  const listeners = {}
+  const el = {
+    tagName: String(tag || 'div').toUpperCase(),
+    nodeType: 1,
+    style: makeStyle(),
+    dataset: {},
+    classList: { add() {}, remove() {}, contains: () => false, toggle() {} },
+    attributes: {},
+    children,
+    childNodes: children,
+    parentNode: null,
+    ownerDocument: null, // set below
+    clientWidth: 0,
+    clientHeight: 0,
+    offsetWidth: 0,
+    offsetHeight: 0,
+    scrollWidth: 0,
+    scrollHeight: 0,
+    setAttribute(k, v) {
+      this.attributes[k] = v
+    },
+    getAttribute(k) {
+      return this.attributes[k] ?? null
+    },
+    removeAttribute(k) {
+      delete this.attributes[k]
+    },
+    hasAttribute(k) {
+      return k in this.attributes
+    },
+    appendChild(c) {
+      children.push(c)
+      if (c) c.parentNode = el
+      return c
+    },
+    removeChild(c) {
+      const i = children.indexOf(c)
+      if (i >= 0) children.splice(i, 1)
+      return c
+    },
+    insertBefore(c) {
+      children.push(c)
+      if (c) c.parentNode = el
+      return c
+    },
+    remove() {},
+    addEventListener(type, fn) {
+      ;(listeners[type] ||= []).push(fn)
+    },
+    removeEventListener() {},
+    dispatchEvent: () => true,
+    getBoundingClientRect: () => ({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      width: 0,
+      height: 0,
+    }),
+    getElementsByTagName: () => [],
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    elt: undefined, // p5.Element compat — set by p5 itself
+  }
+  return el
+}
+
+// Augment the REAL OffscreenCanvas with the DOM surface p5 reaches for, WITHOUT
+// a Proxy. A Proxy fails: native WebGL `texImage2D(source)` does a BRANDED
+// internal-slot check on its source, and a Proxy-wrapped OffscreenCanvas is not
+// recognised as an OffscreenCanvas → "Overload resolution failed". So we define
+// the extra props directly on the genuine instance — native APIs (getContext,
+// texImage2D, drawImage) see a real OffscreenCanvas; p5's JS reads hit our shims.
+function wrapCanvas(offscreen) {
+  const def = (k, v) =>
+    Object.defineProperty(offscreen, k, { value: v, writable: true, configurable: true })
+  const getr = (k, fn) =>
+    Object.defineProperty(offscreen, k, { get: fn, configurable: true })
+  const attributes = {}
+  def('tagName', 'CANVAS') // getElementsByTagName('canvas') (touchAction loop)
+  def('nodeName', 'CANVAS')
+  def('nodeType', 1)
+  def('style', makeStyle())
+  def('dataset', {})
+  def('id', '')
+  def('className', '')
+  def('classList', { add() {}, remove() {}, contains: () => false, toggle() {} })
+  def('parentNode', null)
+  def('parentElement', null)
+  def('ownerDocument', null)
+  def('children', [])
+  def('childNodes', [])
+  def('elt', undefined)
+  getr('clientWidth', () => offscreen.width)
+  getr('clientHeight', () => offscreen.height)
+  getr('offsetWidth', () => offscreen.width)
+  getr('offsetHeight', () => offscreen.height)
+  def('offsetLeft', 0)
+  def('offsetTop', 0)
+  getr('scrollWidth', () => offscreen.width)
+  getr('scrollHeight', () => offscreen.height)
+  def('setAttribute', (k, v) => {
+    attributes[k] = v
+  })
+  def('getAttribute', (k) => (k in attributes ? attributes[k] : null))
+  def('removeAttribute', (k) => {
+    delete attributes[k]
+  })
+  def('hasAttribute', (k) => k in attributes)
+  def('addEventListener', () => {})
+  def('removeEventListener', () => {})
+  def('dispatchEvent', () => true)
+  def('getBoundingClientRect', () => ({
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    width: offscreen.width,
+    height: offscreen.height,
+  }))
+  def('remove', () => {})
+  touched.canvas.add('augmented-real-OffscreenCanvas (no Proxy)')
+  return offscreen
+}
+
+function installShim(makeCanvasEl) {
+  const doc = {
+    nodeType: 9,
+    createElement(tag) {
+      touched.document.add('createElement(' + tag + ')')
+      // p5 creates MULTIPLE canvases: an unconditional default P2D canvas in
+      // #_setup (p5.js:72546), then the user's WEBGL canvas in setup(). Each
+      // must be a DISTINCT surface — a canvas can hold only ONE context type, so
+      // reusing one surface makes the 2nd getContext() return null and p5 falls
+      // through to the invalid 'experimental-webgl' enum (throws on OffscreenCanvas).
+      if (String(tag).toLowerCase() === 'canvas') return makeCanvasEl()
+      const el = makeElement(tag)
+      el.ownerDocument = doc
+      return el
+    },
+    createElementNS(_ns, tag) {
+      touched.document.add('createElementNS(' + tag + ')')
+      return this.createElement(tag)
+    },
+    createTextNode: (t) => ({ nodeType: 3, textContent: t }),
+    getElementById(id) {
+      touched.document.add('getElementById(' + id + ')')
+      return null
+    },
+    getElementsByTagName(t) {
+      touched.document.add('getElementsByTagName(' + t + ')')
+      // p5 creates <main>, appends it to body, then immediately does
+      // getElementsByTagName('main')[0].appendChild(canvas) (p5.js:71123-71128).
+      // A flat [] makes [0] undefined → the appendChild crash. So actually walk
+      // the fake tree we've been building via appendChild.
+      const out = []
+      const TAG = String(t).toUpperCase()
+      collectByTag(doc.body, TAG, out)
+      return out
+    },
+    querySelector(s) {
+      touched.document.add('querySelector(' + s + ')')
+      return null
+    },
+    querySelectorAll(s) {
+      touched.document.add('querySelectorAll(' + s + ')')
+      return []
+    },
+    addEventListener() {
+      touched.document.add('addEventListener')
+    },
+    removeEventListener() {},
+    hasFocus: () => true,
+    elementFromPoint: () => null,
+  }
+  const body = makeElement('body')
+  const docEl = makeElement('html')
+  body.ownerDocument = doc
+  docEl.ownerDocument = doc
+  doc.body = body
+  doc.documentElement = docEl
+  doc.head = makeElement('head')
+  doc.readyState = 'complete'
+
+  // Recording wrappers so unexpected document/window props are captured.
+  const docProxy = new Proxy(doc, {
+    get(t, p) {
+      if (p in t) {
+        const v = t[p]
+        return typeof v === 'function' ? v.bind(t) : v
+      }
+      touched.document.add(String(p) + ' (UNHANDLED)')
+      return undefined
+    },
+  })
+
+  const win = {
+    document: docProxy,
+    devicePixelRatio: 1,
+    innerWidth: 800,
+    innerHeight: 600,
+    screen: { width: 800, height: 600 },
+    location: { href: self.location ? self.location.href : 'about:blank' },
+    navigator: self.navigator,
+    addEventListener() {
+      touched.window.add('addEventListener')
+    },
+    removeEventListener() {},
+    requestAnimationFrame:
+      self.requestAnimationFrame?.bind(self) ||
+      ((cb) => setTimeout(() => cb(performance.now()), 16)),
+    cancelAnimationFrame: self.cancelAnimationFrame?.bind(self) || ((id) => clearTimeout(id)),
+    getComputedStyle: () => makeStyle(),
+    matchMedia: () => ({ matches: false, addListener() {}, removeListener() {} }),
+    performance: self.performance,
+    setTimeout: self.setTimeout.bind(self),
+    clearTimeout: self.clearTimeout.bind(self),
+  }
+  const winProxy = new Proxy(win, {
+    get(t, p) {
+      if (p in t) {
+        const v = t[p]
+        return typeof v === 'function' ? v.bind(t) : v
+      }
+      // fall through to the worker global for anything else p5 reads
+      if (p in self) {
+        touched.window.add(String(p) + ' (->self)')
+        const v = self[p]
+        return typeof v === 'function' ? v.bind(self) : v
+      }
+      touched.window.add(String(p) + ' (UNHANDLED)')
+      return undefined
+    },
+  })
+
+  // Install on the worker global so p5's bare `document` / `window` resolve.
+  self.window = winProxy
+  self.document = docProxy
+  self.screen = win.screen
+  if (!('devicePixelRatio' in self)) self.devicePixelRatio = 1
+  // Workers have NO requestAnimationFrame — p5's draw loop needs one. Provide a
+  // setTimeout-backed shim globally so both bare `requestAnimationFrame` and
+  // `window.requestAnimationFrame` resolve and p5's loop ticks (~60fps).
+  if (typeof self.requestAnimationFrame !== 'function') {
+    self.requestAnimationFrame = (cb) => setTimeout(() => cb(performance.now()), 16)
+    self.cancelAnimationFrame = (id) => clearTimeout(id)
+  }
+  return { winProxy, docProxy }
+}
+
+// Read pixels off the (webgl) offscreen canvas via a 2D probe canvas —
+// drawImage accepts an OffscreenCanvas regardless of its own context type.
+function probePixels(offscreen) {
+  const w = offscreen.width
+  const h = offscreen.height
+  const probe = new OffscreenCanvas(w, h)
+  const ctx = probe.getContext('2d')
+  ctx.drawImage(offscreen, 0, 0)
+  const { data } = ctx.getImageData(0, 0, w, h)
+  let nonBlank = 0
+  const colors = new Set()
+  const step = Math.max(1, Math.floor((w * h) / 2000)) // sample ~2000 px
+  for (let i = 0; i < w * h; i += step) {
+    const o = i * 4
+    const r = data[o]
+    const g = data[o + 1]
+    const b = data[o + 2]
+    const a = data[o + 3]
+    if (r || g || b || a) nonBlank++
+    if (colors.size < 12) colors.add(`${r},${g},${b},${a}`)
+  }
+  // center pixel — the sketch paints a known green rect there over red bg
+  const co = (Math.floor(h / 2) * w + Math.floor(w / 2)) * 4
+  const center = [data[co], data[co + 1], data[co + 2], data[co + 3]]
+  return { nonBlank, sampledColors: [...colors], center, w, h }
+}
+
+self.onmessage = async (ev) => {
+  const { canvas, width = 256, height = 256 } = ev.data || {}
+  const W = width
+  const H = height
+
+  // ── S1-bare: import p5 in a worker WITHOUT a shim ──
+  // GROUNDED (first run): p5 throws `window is not defined` at module-eval —
+  // `registerAddon(Ge)` immediately calls `window.performance.now()`
+  // (p5.esm.min.js Ge body). A cache-busted specifier gives this a fresh module
+  // evaluation so the result is recorded independently of the shimmed import.
+  try {
+    await import('./p5.esm.min.js?bare=' + Date.now())
+    emit('S1-bare', 'ok', { note: 'imported with NO shim — unexpected; p5 did not touch window at eval' })
+  } catch (e) {
+    emit('S1-bare', 'throw', errInfo(e))
+  }
+
+  // ── S3: install the recording shim BEFORE importing p5 ──
+  // (registerAddon touches window at eval, so the shim must pre-exist.)
+  if (!canvas) {
+    emit('S3-shim', 'skip', { reason: 'no OffscreenCanvas was transferred' })
+    self.postMessage({ type: 'done', verdict: 'INCONCLUSIVE', at: 'S3-shim', reports, touched: snapshot() })
+    return
+  }
+  canvas.width = W
+  canvas.height = H
+  // p5 creates SEVERAL canvases — the default P2D, the user's WEBGL renderer,
+  // AND internal helpers (1×1 empty texture, image buffers). EACH must be its
+  // own fresh surface (a canvas holds one context type). We render into
+  // worker-local OffscreenCanvases and read the WEBGL one back; wiring the
+  // *transferred* canvas as p5's main render target is a Phase B detail
+  // (transferControlToOffscreen availability already proven on the main side).
+  const createdCanvases = []
+  let canvasCalls = 0
+  const makeCanvasEl = () => {
+    canvasCalls++
+    const oc = new OffscreenCanvas(1, 1) // p5 sizes it via createCanvas
+    createdCanvases.push(oc)
+    return wrapCanvas(oc)
+  }
+  let shimErr = null
+  try {
+    installShim(makeCanvasEl)
+    emit('S3-shim', 'ok', { note: 'window/document/rAF shim installed; canvas factory wired (throwaway P2D → transferred WEBGL)' })
+  } catch (e) {
+    shimErr = e
+    emit('S3-shim', 'throw', errInfo(e))
+  }
+
+  // ── S1-shimmed: import p5 with the shim in place ──
+  let P5
+  try {
+    const mod = await import('./p5.esm.min.js?shim=' + Date.now())
+    P5 = mod.default || mod.p5 || mod
+    // Kill the Friendly Error System — its presetup hook does
+    // `querySelectorAll('script')[last].src` (p5.js:97021) to fetch user source,
+    // which has no meaning in a worker and crashes on undefined. Gated by this
+    // flag (p5.js:97043). FES is dev-ergonomics only; irrelevant to rendering.
+    P5.disableFriendlyErrors = true
+    emit('S1-shimmed', 'ok', { typeofDefault: typeof P5, fesDisabled: true })
+  } catch (e) {
+    emit('S1-shimmed', 'throw', errInfo(e))
+    self.postMessage({ type: 'done', verdict: 'NO', at: 'S1-shimmed', reports, touched: snapshot() })
+    return
+  }
+
+  // ── S4: construct p5 against the shim + draw a frame + read pixels ──
+  try {
+    let setupRan = false
+    let drawCount = 0
+    let drawErr = null
+    const sketch = (p) => {
+      p.setup = () => {
+        setupRan = true
+        p.createCanvas(W, H, p.WEBGL)
+        p.noStroke()
+      }
+      p.draw = () => {
+        try {
+          p.background(255, 0, 0) // red field
+          p.fill(0, 255, 0) // green rect dead center
+          p.rectMode(p.CENTER)
+          p.rect(0, 0, W / 2, H / 2)
+          drawCount++
+        } catch (e) {
+          drawErr = e
+          p.noLoop?.()
+        }
+      }
+    }
+    const inst = new P5(sketch)
+    // Wait for p5's deferred setup + a few draw frames.
+    await new Promise((r) => setTimeout(r, 400))
+
+    if (drawErr) {
+      emit('S4-draw', 'throw', { ...errInfo(drawErr), setupRan, drawCount })
+      self.postMessage({ type: 'done', verdict: 'NO', at: 'S4-draw', reports, touched: snapshot() })
+      return
+    }
+
+    // p5's main render canvas is whichever worker OffscreenCanvas has the
+    // rendered scene. Probe each W×H-ish surface; pick the one with the most
+    // non-blank pixels (the others are the 1×1 texture / default P2D).
+    let pixels = { nonBlank: 0, sampledColors: [], center: [0, 0, 0, 0], w: 0, h: 0 }
+    const sizes = []
+    for (const oc of createdCanvases) {
+      sizes.push(`${oc.width}x${oc.height}`)
+      if (oc.width < 8 || oc.height < 8) continue
+      try {
+        const p = probePixels(oc)
+        if (p.nonBlank > pixels.nonBlank) pixels = p
+      } catch {
+        /* a webgl-only canvas may reject 2d drawImage in some engines */
+      }
+    }
+    const pass = setupRan && drawCount > 0 && pixels.nonBlank > 0
+    emit('S4-draw', pass ? 'ok' : 'blank', { setupRan, drawCount, canvasCalls, canvasSizes: sizes, pixels })
+    try {
+      inst.remove?.()
+    } catch {}
+
+    self.postMessage({
+      type: 'done',
+      verdict: pass ? 'YES' : 'PARTIAL',
+      at: 'S4-draw',
+      reports,
+      touched: snapshot(),
+      pixels,
+    })
+  } catch (e) {
+    emit('S4-draw', 'throw', { ...errInfo(e), shimErr: shimErr ? errInfo(shimErr) : null })
+    self.postMessage({ type: 'done', verdict: 'NO', at: 'S4-draw', reports, touched: snapshot() })
+  }
+}
+
+function snapshot() {
+  return {
+    document: [...touched.document],
+    window: [...touched.window],
+    canvas: [...touched.canvas],
+  }
+}

--- a/packages/app/tests/b0-worker-spike.spec.ts
+++ b/packages/app/tests/b0-worker-spike.spec.ts
@@ -1,0 +1,144 @@
+import { test, expect } from '@playwright/test'
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+// ── B-0 FEASIBILITY SPIKE (issue #235) ──────────────────────────────────────
+// Can the p5 WEBGL renderer move off the main thread into a Web Worker via an
+// OffscreenCanvas? This drives packages/app/public/spike/p5-worker.js with a
+// REAL transferred OffscreenCanvas in a REAL browser worker and reads the
+// verdict + the recording-shim surface. OBSERVE pixels-out, don't infer.
+//
+// Run: PERF_SPIKE=1 pnpm --filter @stave/app exec playwright test b0-worker-spike.spec.ts
+//
+// Self-provisioning: copies the standalone p5 ESM bundle into public/spike so
+// the 1MB vendor file need not be committed.
+
+const SPIKE_DIR = join(__dirname, '..', 'public', 'spike')
+const P5_DST = join(SPIKE_DIR, 'p5.esm.min.js')
+const P5_SRC = join(
+  __dirname,
+  '..',
+  '..',
+  'editor',
+  'node_modules',
+  'p5',
+  'lib',
+  'p5.esm.min.js'
+)
+
+test.beforeAll(() => {
+  if (!existsSync(P5_DST)) {
+    mkdirSync(dirname(P5_DST), { recursive: true })
+    copyFileSync(P5_SRC, P5_DST)
+  }
+})
+
+test('B-0: p5 v2 renders to an OffscreenCanvas inside a Web Worker', async ({
+  page,
+}) => {
+  const logs: string[] = []
+  page.on('console', (m) => logs.push(`[page:${m.type()}] ${m.text()}`))
+  page.on('pageerror', (e) => logs.push(`[pageerror] ${e.message}`))
+
+  await page.goto('/')
+
+  const result = await page.evaluate(async () => {
+    // Verify the platform supports the transfer at all (Phase B fallback gate).
+    const probe = document.createElement('canvas')
+    const canTransfer = typeof probe.transferControlToOffscreen === 'function'
+    if (!canTransfer) {
+      return {
+        platform: { canTransfer: false },
+        done: null as Record<string, unknown> | null,
+        stages: [] as unknown[],
+        mainThread: { longtasks: 0, maxLongtask: 0 },
+      }
+    }
+
+    const W = 256
+    const H = 256
+    const canvas = document.createElement('canvas')
+    canvas.width = W
+    canvas.height = H
+    const offscreen = canvas.transferControlToOffscreen()
+
+    // Observe whether the worker draw blocks the MAIN thread (PV69 goal):
+    // count main-thread long tasks while the worker renders.
+    let longtasks = 0
+    let maxLongtask = 0
+    try {
+      const po = new PerformanceObserver((list) => {
+        for (const e of list.getEntries()) {
+          longtasks++
+          maxLongtask = Math.max(maxLongtask, e.duration)
+        }
+      })
+      po.observe({ entryTypes: ['longtask'] })
+    } catch {
+      /* longtask API may be unavailable */
+    }
+
+    const worker = new Worker('/spike/p5-worker.js', { type: 'module' })
+    const stages: unknown[] = []
+    const workerLogs: string[] = []
+
+    const done = await new Promise<Record<string, unknown>>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error('worker timed out (no done message in 10s)')),
+        10000
+      )
+      worker.onmessage = (e) => {
+        const d = e.data
+        if (d?.type === 'stage') stages.push(d)
+        if (d?.type === 'workerlog') workerLogs.push(d.line)
+        if (d?.type === 'done') {
+          clearTimeout(timeout)
+          resolve({ ...d, workerLogs })
+        }
+      }
+      worker.onerror = (e) => {
+        clearTimeout(timeout)
+        reject(new Error(`worker error: ${e.message} @ ${e.filename}:${e.lineno}`))
+      }
+      worker.postMessage({ canvas: offscreen, width: W, height: H }, [offscreen])
+    }).catch((err) => ({ type: 'error', error: String(err?.message || err) }))
+
+    worker.terminate()
+    return { platform: { canTransfer: true }, done, stages, mainThread: { longtasks, maxLongtask } }
+  })
+
+  // ── Report everything (this is a spike; the OUTPUT is the finding) ──
+  console.log('\n══════════ B-0 WORKER SPIKE — OBSERVED ══════════')
+  console.log('platform.canTransferControlToOffscreen:', result.platform.canTransfer)
+  for (const s of result.stages as Array<Record<string, unknown>>) {
+    console.log(`\n[${s.stage}] ${s.status}`)
+    console.log('  ', JSON.stringify(s.detail))
+  }
+  const done = result.done as Record<string, unknown> | null
+  const wl = (done?.workerLogs as string[]) || []
+  if (wl.length) {
+    console.log('\n── worker diagnostics (p5 FES / rejections) ──')
+    console.log(wl.join('\n'))
+  }
+  console.log('\n── touched DOM surface (the minimal-shim answer) ──')
+  console.log(JSON.stringify((done?.touched as unknown) ?? {}, null, 2))
+  console.log('\n── VERDICT ──')
+  console.log(JSON.stringify({ verdict: done?.verdict, at: done?.at, pixels: done?.pixels }, null, 2))
+  console.log('\n── main thread while worker drew ──')
+  console.log(JSON.stringify(result.mainThread))
+  if (logs.length) console.log('\n── page console ──\n' + logs.join('\n'))
+  console.log('═══════════════════════════════════════════════\n')
+
+  // The spike PROVED p5 v2 renders WEBGL to an OffscreenCanvas in a worker.
+  // Lock it as a regression guard: verdict YES + the sketch's green rect
+  // (0,255,0) is at the canvas centre over a red field.
+  expect(done, 'worker produced a verdict').not.toBeNull()
+  expect(done?.type, 'worker did not hard-error in the harness').not.toBe('error')
+  expect(result.platform.canTransfer, 'transferControlToOffscreen available').toBe(true)
+  expect(done?.verdict, 'p5 rendered in the worker').toBe('YES')
+  const px = done?.pixels as { nonBlank: number; center: number[] } | undefined
+  expect(px?.nonBlank ?? 0, 'rendered non-blank pixels').toBeGreaterThan(0)
+  // centre is the green rect: G dominant, R/B low
+  expect(px?.center?.[1] ?? 0, 'centre green channel high').toBeGreaterThan(200)
+  expect(px?.center?.[0] ?? 255, 'centre red channel low').toBeLessThan(80)
+})


### PR DESCRIPTION
## The fork it decides

Phase B (move the viz renderer off the main thread so it stops starving the audio scheduler — PV69/P101) rests on an **unproven** assumption: p5 expects `window`/`document` and does not run in a Web Worker out of the box. Designing the worker blind would be the wrong-layer trap one level up. **Spike before architecting.**

## Result: **YES** — observed, not inferred

`p5 v2.2.3` renders WEBGL into an OffscreenCanvas inside a dedicated Web Worker. The sketch drew a green rect on a red field; the worker read the canvas centre pixel back as `[0,255,0,255]`, `nonBlank=2048/2048`, ~55fps (23 frames/400ms), per-frame draws entirely worker-side (main thread free).

## How (the minimal shim — each failure grounded at its `p5.js` line)

Staged, observe-first ladder (S1 import → S2 bare → S3 shim → S4 draw+readback). Six progressive failures, each fixed with the smallest shim:

1. `window` at import (`registerAddon`/`Ge` → `window.performance.now()`) → install the `window`/`document` shim **before** importing p5.
2. workers have no `requestAnimationFrame` → setTimeout-backed rAF on the worker global.
3. FES `fetchScript` reads `<script>.src` (p5.js:97021) → `p5.disableFriendlyErrors = true` (gated p5.js:97043).
4. `getElementsByTagName('main')[0].appendChild` (p5.js:71123) → `getElementsByTagName` must **walk the fake DOM tree**, not return `[]`.
5. p5 makes a default **P2D** canvas then the user **WEBGL** canvas (+ a 1×1 empty texture) → a **distinct** OffscreenCanvas per `createElement('canvas')` (a surface holds one context type, else the 2nd `getContext` is null → invalid `experimental-webgl` enum throw).
6. native `texImage2D` does a **branded internal-slot** check on its source → a Proxy-wrapped OffscreenCanvas is rejected → **augment the REAL OffscreenCanvas in place, no Proxy**.

## Files

- `packages/app/public/spike/p5-worker.js` — the staged, observe-first worker.
- `packages/app/tests/b0-worker-spike.spec.ts` — Playwright driver: transfers a real OffscreenCanvas, asserts the green-rect render (regression guard). Self-provisions the p5 ESM bundle.
- `packages/app/public/spike/README.md` — the full grounded write-up.
- `packages/app/public/spike/.gitignore` — the 1MB vendored `p5.esm.min.js` is not committed (the test copies it).

## Test plan

```
pnpm --filter @stave/app exec playwright test b0-worker-spike.spec.ts --reporter=line
```
→ 1 passed; verdict YES, centre pixel green. eslint clean.

## Not the fork — Phase B pre-flight (next session)

- Render directly into the **transferred** (on-screen) canvas — same OffscreenCanvas API; route the transferred canvas to the `getContext('webgl2')` surface.
- **COOP/COEP for SharedArrayBuffer**: Next 16.2.1 `async headers()` mechanism confirmed; **must observe** it doesn't break superdough/AudioWorklet — make it Phase B task 1.
- hydra-synth in a worker (Q3) — lower priority now p5 is YES.

Part of perf epic #228. Targets the `performance` integration branch (not `main`).

closes #235