### PR TITLE
🧪 perf: Phase B pre-flight — Q2 (COOP/COEP+SAB) ✅ + Q3 (hydra-in-worker) ✅ (#237)

### DIFF
--- a/packages/app/next.config.ts
+++ b/packages/app/next.config.ts
@@ -7,6 +7,26 @@ const nextConfig: NextConfig = {
   // their internal new URL("assets/...", import.meta.url) worker references and
   // fail with "Module not found: Can't resolve <dynamic>".
   transpilePackages: ["@stave/editor"],
+
+  // ── Phase B pre-flight Q2 (#237) — cross-origin isolation for SharedArrayBuffer.
+  // SAB is the planned per-frame viz-signal transport between the main thread and
+  // the OffscreenCanvas worker; it requires `crossOriginIsolated`, which needs
+  // COOP + COEP. We use COEP `credentialless` (NOT `require-corp`) so cross-origin
+  // subresources (e.g. strudel.cc sample packs) still load without needing CORP
+  // headers from the remote — `require-corp` would block them and silence drums.
+  // OBSERVE (b-preflight-coep.spec.ts): crossOriginIsolated true + SAB allocatable
+  // AND AudioWorklet/superdough still boots + triggers fire.
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: [
+          { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
+          { key: "Cross-Origin-Embedder-Policy", value: "credentialless" },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/packages/app/public/spike/.gitignore
+++ b/packages/app/public/spike/.gitignore
@@ -1,4 +1,4 @@
-# Vendored p5 standalone ESM bundle (1MB) — NOT committed. The spike test
-# (tests/b0-worker-spike.spec.ts) copies it from
-# packages/editor/node_modules/p5/lib/p5.esm.min.js in beforeAll.
+# Vendored renderer bundles — NOT committed. The spike tests copy them from
+# packages/editor/node_modules/{p5,hydra-synth} in beforeAll.
 p5.esm.min.js
+hydra-synth.js

--- a/packages/app/public/spike/README.md
+++ b/packages/app/public/spike/README.md
@@ -60,14 +60,50 @@ one fresh OffscreenCanvas per canvas element, each augmented in place with DOM p
 pnpm --filter @stave/app exec playwright test b0-worker-spike.spec.ts --reporter=line
 ```
 
-## Not yet proven (Phase B pre-flight, not the fork)
+---
 
-- **Direct render into the *transferred* canvas** (on-screen): proven feasible in principle
-  (transferControlToOffscreen available; p5 renders into worker OffscreenCanvases fine) but the
-  spike reads back a worker-local canvas. Phase B wires the transferred canvas as p5's main
-  WEBGL surface (route it to the canvas whose `getContext` is `webgl2`).
-- **COOP/COEP for SharedArrayBuffer** (Q2): Next 16.2.1 supports `async headers()` in
-  `next.config.ts` (mechanism confirmed). Whether it breaks superdough/AudioWorklet/fonts/embeds
-  must be observed — make it the first Phase B task.
-- **hydra-synth in a worker** (Q3, fallback path): not spiked; lower priority now that the
-  primary (p5) path is YES.
+# Phase B pre-flight — Q2 + Q3 (issue #237)
+
+## Q3 — hydra-synth in a worker: **YES**
+
+`hydra-worker.js` (classic worker, `importScripts` the self-contained UMD bundle) renders an
+`osc().rotate().out()` into the **transferred** OffscreenCanvas — 12 ticks, full rainbow
+gradient, `nonBlank=2048/2048`. Driver: `tests/b-preflight-hydra.spec.ts`.
+
+**Confirmed the prediction: hydra needs a far smaller shim than p5 — only 2 conditions vs p5's 6:**
+1. install the shim **before** `importScripts` (hydra touches `window` at module-eval —
+   `mouseListen` adds a mousemove listener, hydra-synth.js:3926).
+2. `window = self` alias + a thin `document` + size props. That's it.
+
+No FES, no multi-canvas dance, no Proxy-vs-native issue — because hydra takes the canvas
+**explicitly** (`new Hydra({ canvas })`, hydra-synth.js:235 `if (canvas) this.canvas = canvas`)
+and `makeGlobal/autoLoop/detectAudio/enableStreamCapture = false` strip the rest. Note hydra
+rendered **directly into the transferred canvas** (the real on-screen path), unlike the p5 spike
+which read back a worker-local surface.
+
+## Q2 — COOP/COEP for SharedArrayBuffer without breaking audio: **YES (with credentialless)**
+
+`next.config.ts` sets `COOP=same-origin` + `COEP=credentialless`. Observed
+(`tests/b-preflight-coep.spec.ts`, dev server restarted with the headers):
+`crossOriginIsolated=true`, `SharedArrayBuffer` allocatable, `audioContext.state=running`,
+`audio.triggers=15 (~4.3/s)`, **COEP-blocked requests = 0** (the strudel.cc sample packs still load).
+
+**Key: `credentialless`, NOT `require-corp`.** `require-corp` would block every cross-origin
+subresource lacking a CORP header — including the CDN sample packs — silencing drums.
+`credentialless` sends cross-origin no-cors requests without credentials but allows them, so
+isolation + samples coexist. ⇒ SAB is viable for Phase B's per-frame signal transport.
+
+### ⚠️ NOT yet tested under isolation (Phase B must check before performance→main)
+- **OAuth popups / `window.opener`.** COOP `same-origin` (required for `crossOriginIsolated`)
+  can break popup-based OAuth (`window.opener`/`postMessage`). The app has Google OAuth (PM
+  signup) — **untested here.** If it's a popup flow, COOP same-origin breaks it; a redirect flow
+  is fine. Verify; if it breaks, the SAB plan must reconcile with OAuth (or use a redirect flow).
+- **Fonts / embeds / images** from cross-origin origins — credentialless should be fine, but only
+  audio + samples were exercised.
+- **Browser support:** COEP `credentialless` is Chromium-only-ish (no Safari < 16.4). Phase B must
+  feature-detect `crossOriginIsolated` and **degrade to transferable-ArrayBuffer postMessage** when SAB is absent.
+
+## Still open for Phase B proper (not the forks)
+- **Direct render into the transferred canvas for p5** (hydra already proven): route the transferred
+  canvas to the surface whose `getContext` is `webgl2`.
+- **One shared worker vs a pool** — decide by the matrix (`trig/s` recovery + frameP95).

--- a/packages/app/public/spike/hydra-worker.js
+++ b/packages/app/public/spike/hydra-worker.js
@@ -1,0 +1,173 @@
+/* eslint-disable */
+// ── Q3 PRE-FLIGHT SPIKE — hydra-synth in a Web Worker on an OffscreenCanvas ──
+//
+// Issue #237. The worker-friendly second renderer. Same observe-first PK21 ladder
+// as the B-0 p5 spike. GROUNDED expectation: hydra needs a SMALLER shim than p5 —
+// `_initCanvas` (hydra-synth.js:235) does `if (canvas) this.canvas = canvas`, so
+// passing an OffscreenCanvas skips p5's createElement/appendChild dance; and
+// makeGlobal/autoLoop/detectAudio/enableStreamCapture=false strip the rest.
+//
+// Classic worker: importScripts() the self-contained UMD bundle (it falls back to
+// `self` as global → `self.Hydra`). Shim = alias window→self (workers already have
+// addEventListener/setTimeout/URL/navigator) + a thin document + size props.
+
+const reports = []
+function emit(stage, status, detail) {
+  reports.push({ stage, status, detail })
+  self.postMessage({ type: 'stage', stage, status, detail })
+}
+function errInfo(e) {
+  return {
+    message: String((e && e.message) || e),
+    name: String((e && e.name) || ''),
+    stack: String((e && e.stack) || '').split('\n').slice(0, 8).join('\n'),
+  }
+}
+self.addEventListener('unhandledrejection', (e) =>
+  self.postMessage({ type: 'workerlog', line: '[unhandledrejection] ' + String(e.reason && e.reason.stack || e.reason) })
+)
+for (const k of ['error', 'warn']) {
+  const orig = console[k]?.bind(console)
+  console[k] = (...a) => {
+    self.postMessage({ type: 'workerlog', line: `[console.${k}] ` + a.map(String).join(' ') })
+    orig?.(...a)
+  }
+}
+
+// Read pixels off the (webgl) OffscreenCanvas via a 2D probe (drawImage accepts
+// an OffscreenCanvas regardless of its own context type).
+function probePixels(oc) {
+  const w = oc.width
+  const h = oc.height
+  const probe = new OffscreenCanvas(w, h)
+  const ctx = probe.getContext('2d')
+  ctx.drawImage(oc, 0, 0)
+  const { data } = ctx.getImageData(0, 0, w, h)
+  let nonBlank = 0
+  const colors = new Set()
+  const step = Math.max(1, Math.floor((w * h) / 2000))
+  for (let i = 0; i < w * h; i += step) {
+    const o = i * 4
+    if (data[o] || data[o + 1] || data[o + 2] || data[o + 3]) nonBlank++
+    if (colors.size < 12) colors.add(`${data[o]},${data[o + 1]},${data[o + 2]},${data[o + 3]}`)
+  }
+  return { nonBlank, sampledColors: [...colors], w, h }
+}
+
+function installShim(W, H) {
+  // Make `window` an alias of the worker global — hydra reads window.innerWidth /
+  // window.addEventListener / window.URL / window.navigator, all of which then
+  // resolve to `self` (workers natively provide most; we add the few missing).
+  self.window = self
+  if (typeof self.requestAnimationFrame !== 'function') {
+    self.requestAnimationFrame = (cb) => setTimeout(() => cb(performance.now()), 16)
+    self.cancelAnimationFrame = (id) => clearTimeout(id)
+  }
+  if (!('innerWidth' in self)) self.innerWidth = W
+  if (!('innerHeight' in self)) self.innerHeight = H
+  if (!('devicePixelRatio' in self)) self.devicePixelRatio = 1
+  // Thin document — only the createElement/body/head paths hydra might touch
+  // (the canvas path is skipped because we pass an explicit OffscreenCanvas).
+  const noopEl = () => ({
+    style: {},
+    appendChild: () => {},
+    removeChild: () => {},
+    remove: () => {},
+    setAttribute: () => {},
+    addEventListener: () => {},
+  })
+  self.document = {
+    createElement: (tag) =>
+      String(tag).toLowerCase() === 'canvas' ? new OffscreenCanvas(W, H) : noopEl(),
+    createElementNS: () => noopEl(),
+    body: noopEl(),
+    head: noopEl(),
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    getElementById: () => null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    readyState: 'complete',
+  }
+  self.screen = { width: W, height: H }
+}
+
+self.onmessage = (ev) => {
+  const { canvas, scriptUrl, width = 256, height = 256 } = ev.data || {}
+  const W = width
+  const H = height
+
+  // ── S3: install the (thin) shim FIRST ──
+  // hydra touches window at module-eval (e.g. `mouseListen` adds a mousemove
+  // listener — hydra-synth.js:3926), so the shim must precede importScripts.
+  // window=self means the UMD picks g=window=self → self.Hydra.
+  try {
+    installShim(W, H)
+    emit('S3-shim', 'ok', { note: 'window=self alias + thin document + size props' })
+  } catch (e) {
+    emit('S3-shim', 'throw', errInfo(e))
+  }
+
+  // ── S1: load the hydra UMD bundle in a worker ──
+  try {
+    importScripts(scriptUrl || './hydra-synth.js')
+    emit('S1-import', 'ok', { hasHydra: typeof self.Hydra })
+  } catch (e) {
+    emit('S1-import', 'throw', errInfo(e))
+    return self.postMessage({ type: 'done', verdict: 'NO', at: 'S1-import', reports })
+  }
+  if (typeof self.Hydra !== 'function') {
+    emit('S1-import', 'throw', { note: 'self.Hydra is not a constructor after importScripts' })
+    return self.postMessage({ type: 'done', verdict: 'NO', at: 'S1-import', reports })
+  }
+
+  // ── S4: construct hydra against the OffscreenCanvas, run osc().out(), readback ──
+  if (!canvas) {
+    emit('S4-draw', 'skip', { reason: 'no OffscreenCanvas transferred' })
+    return self.postMessage({ type: 'done', verdict: 'INCONCLUSIVE', at: 'S4-draw', reports })
+  }
+  canvas.width = W
+  canvas.height = H
+  try {
+    const h = new self.Hydra({
+      canvas, // explicit surface → skips hydra's createElement/appendChild (hydra-synth.js:235)
+      width: W,
+      height: H,
+      makeGlobal: false, // no global synth writes / window.loadScript
+      autoLoop: false, // we drive tick() ourselves (no rAF dependency)
+      detectAudio: false, // no Meyda / getUserMedia / AudioContext in the worker
+      enableStreamCapture: false, // OffscreenCanvas has no captureStream
+    })
+    emit('S4-construct', 'ok', { synthKeys: Object.keys(h.synth || {}).slice(0, 12) })
+
+    // A trivial generative sketch — a coloured oscillator. With makeGlobal:false
+    // the generators live on h.synth.
+    const s = h.synth
+    s.osc(60, 0.1, 1.5).rotate(0.2).out(s.o0)
+
+    // Drive a handful of frames manually (autoLoop is off).
+    let ticks = 0
+    let tickErr = null
+    for (let i = 0; i < 12; i++) {
+      try {
+        h.tick(16)
+        ticks++
+      } catch (e) {
+        tickErr = e
+        break
+      }
+    }
+    if (tickErr) {
+      emit('S4-draw', 'throw', { ...errInfo(tickErr), ticks })
+      return self.postMessage({ type: 'done', verdict: 'NO', at: 'S4-draw', reports })
+    }
+
+    const pixels = probePixels(canvas)
+    const pass = ticks > 0 && pixels.nonBlank > 0
+    emit('S4-draw', pass ? 'ok' : 'blank', { ticks, pixels })
+    self.postMessage({ type: 'done', verdict: pass ? 'YES' : 'PARTIAL', at: 'S4-draw', reports, pixels })
+  } catch (e) {
+    emit('S4-draw', 'throw', errInfo(e))
+    self.postMessage({ type: 'done', verdict: 'NO', at: 'S4-draw', reports })
+  }
+}

--- a/packages/app/tests/b-preflight-coep.spec.ts
+++ b/packages/app/tests/b-preflight-coep.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect, type Page } from '@playwright/test'
+
+// ── Q2 PRE-FLIGHT SPIKE (issue #237) ────────────────────────────────────────
+// Can Next 16.2.1 enable cross-origin isolation (→ SharedArrayBuffer, the planned
+// Phase B per-frame viz-signal transport) WITHOUT breaking audio? COOP+COEP added
+// in next.config.ts (COEP=credentialless). OBSERVE with the headers on:
+//   1. crossOriginIsolated === true + SharedArrayBuffer allocatable
+//   2. AudioContext running + audio.triggers > 0 (superdough/AudioWorklet survives)
+//   3. no cross-origin subresource (sample pack) blocked by COEP
+//
+// REQUIRES the dev server restarted with the new next.config.ts headers.
+// Run: pnpm --filter @stave/app exec playwright test b-preflight-coep.spec.ts
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+async function setCode(page: Page, code: string): Promise<void> {
+  const ok = await page.evaluate((c) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const e = (window as any).monaco?.editor?.getEditors?.()?.[0]
+    if (!e) return false
+    e.getModel()?.setValue(c)
+    return true
+  }, code)
+  expect(ok).toBe(true)
+  await page.waitForTimeout(150)
+}
+
+async function runCode(page: Page): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await page.evaluate(() => (window as any).monaco?.editor?.getEditors?.()?.[0]?.focus())
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(2500)
+}
+
+test('Q2: COOP/COEP enables crossOriginIsolated+SAB without breaking audio', async ({
+  page,
+}) => {
+  const blocked: string[] = []
+  const consoleErrs: string[] = []
+  page.on('requestfailed', (r) => {
+    const f = r.failure()?.errorText ?? ''
+    // COEP blocks surface as net::ERR_BLOCKED_BY_RESPONSE / NotSameOriginAfterDefaultedToSameOriginByCoep
+    blocked.push(`${r.url()} — ${f}`)
+  })
+  page.on('console', (m) => {
+    if (m.type() === 'error') consoleErrs.push(m.text())
+  })
+
+  await page.addInitScript(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).__STAVE_PERF__ = true
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).__STAVE_E2E__ = true
+  })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('.monaco-editor').first().waitFor({ timeout: 15000 })
+  await page.waitForTimeout(1000)
+
+  // ── 1. isolation + SAB (platform observation) ──
+  const iso = await page.evaluate(() => {
+    let sabOk = false
+    let sabErr = ''
+    try {
+      const sab = new SharedArrayBuffer(1024)
+      sabOk = sab.byteLength === 1024
+    } catch (e) {
+      sabErr = String((e as Error)?.message || e)
+    }
+    return {
+      crossOriginIsolated: (globalThis as { crossOriginIsolated?: boolean })
+        .crossOriginIsolated,
+      hasSAB: typeof SharedArrayBuffer === 'function',
+      sabOk,
+      sabErr,
+    }
+  })
+
+  // ── 2. boot audio: a SAMPLE sound (bank → CDN samples) + a SYNTH sound ──
+  await setCode(
+    page,
+    [
+      `$: s("bd*4, ~ sd").bank("RolandTR909")`,
+      `$: note("c2 eb2 g2 c3").s("sawtooth").lpf(800)`,
+    ].join('\n')
+  )
+  await runCode(page)
+
+  const acState = await page.evaluate(() => {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (window as any).getAudioContext?.()?.state ?? 'none'
+    } catch {
+      return 'error'
+    }
+  })
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await page.evaluate(() => (window as any).__stavePerf?.reset?.())
+  await page.waitForTimeout(3500)
+  const snap = await page.evaluate(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    () => (window as any).__stavePerf?.snapshot?.()
+  )
+  const triggers = snap?.counters?.['audio.triggers'] ?? 0
+  const trigPerSec = snap?.uptimeMs ? (triggers / snap.uptimeMs) * 1000 : 0
+
+  // COEP-blocked subresources (samples/fonts). credentialless should NOT block.
+  const coepBlocked = blocked.filter(
+    (b) => /coep|ERR_BLOCKED_BY_RESPONSE|NotSameOrigin/i.test(b)
+  )
+
+  // ── REPORT (the output IS the finding) ──
+  console.log('\n══════════ Q2 COOP/COEP + AUDIO — OBSERVED ══════════')
+  console.log('crossOriginIsolated :', iso.crossOriginIsolated)
+  console.log('SharedArrayBuffer   :', iso.hasSAB, '| allocatable:', iso.sabOk, iso.sabErr)
+  console.log('audioContext.state  :', acState)
+  console.log('audio.triggers      :', triggers, `(~${trigPerSec.toFixed(1)}/s)`)
+  console.log('COEP-blocked reqs   :', coepBlocked.length)
+  if (coepBlocked.length) console.log('  ' + coepBlocked.slice(0, 10).join('\n  '))
+  if (blocked.length) {
+    console.log('\nALL failed requests (' + blocked.length + '):')
+    console.log('  ' + blocked.slice(0, 15).join('\n  '))
+  }
+  if (consoleErrs.length)
+    console.log('\nconsole errors:\n  ' + consoleErrs.slice(0, 10).join('\n  '))
+  console.log('═══════════════════════════════════════════════\n')
+
+  // ── ASSERT ──
+  expect(iso.crossOriginIsolated, 'cross-origin isolation enabled by COOP/COEP').toBe(true)
+  expect(iso.sabOk, 'SharedArrayBuffer allocatable under isolation').toBe(true)
+  expect(acState, 'AudioContext is running (AudioWorklet booted under isolation)').toBe(
+    'running'
+  )
+  expect(triggers, 'audio scheduler fired triggers (superdough survives isolation)').toBeGreaterThan(
+    0
+  )
+  expect(
+    coepBlocked.length,
+    `credentialless COEP did not block subresources: ${coepBlocked.join(', ')}`
+  ).toBe(0)
+})

--- a/packages/app/tests/b-preflight-hydra.spec.ts
+++ b/packages/app/tests/b-preflight-hydra.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '@playwright/test'
+import { copyFileSync, existsSync, mkdirSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+// ── Q3 PRE-FLIGHT SPIKE (issue #237) ────────────────────────────────────────
+// Does hydra-synth render to an OffscreenCanvas inside a Web Worker? Drives
+// packages/app/public/spike/hydra-worker.js with a real transferred
+// OffscreenCanvas and reads pixels back. OBSERVE, don't infer.
+//
+// Run: pnpm --filter @stave/app exec playwright test b-preflight-hydra.spec.ts
+
+const SPIKE_DIR = join(__dirname, '..', 'public', 'spike')
+const HYDRA_DST = join(SPIKE_DIR, 'hydra-synth.js')
+const HYDRA_SRC = join(
+  __dirname,
+  '..',
+  '..',
+  'editor',
+  'node_modules',
+  'hydra-synth',
+  'dist',
+  'hydra-synth.js'
+)
+
+test.beforeAll(() => {
+  if (!existsSync(HYDRA_DST)) {
+    mkdirSync(dirname(HYDRA_DST), { recursive: true })
+    copyFileSync(HYDRA_SRC, HYDRA_DST)
+  }
+})
+
+test('Q3: hydra-synth renders to an OffscreenCanvas inside a Web Worker', async ({
+  page,
+}) => {
+  const logs: string[] = []
+  page.on('console', (m) => logs.push(`[page:${m.type()}] ${m.text()}`))
+  page.on('pageerror', (e) => logs.push(`[pageerror] ${e.message}`))
+
+  await page.goto('/')
+
+  const result = await page.evaluate(async () => {
+    const W = 256
+    const H = 256
+    const canvas = document.createElement('canvas')
+    canvas.width = W
+    canvas.height = H
+    const offscreen = canvas.transferControlToOffscreen()
+
+    // hydra worker is a CLASSIC worker (importScripts the UMD bundle).
+    const worker = new Worker('/spike/hydra-worker.js')
+    const stages: unknown[] = []
+    const workerLogs: string[] = []
+
+    const done = await new Promise<Record<string, unknown>>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error('worker timed out (no done in 10s)')), 10000)
+      worker.onmessage = (e) => {
+        const d = e.data
+        if (d?.type === 'stage') stages.push(d)
+        if (d?.type === 'workerlog') workerLogs.push(d.line)
+        if (d?.type === 'done') {
+          clearTimeout(t)
+          resolve({ ...d, workerLogs })
+        }
+      }
+      worker.onerror = (e) => {
+        clearTimeout(t)
+        reject(new Error(`worker error: ${e.message} @ ${e.filename}:${e.lineno}`))
+      }
+      worker.postMessage(
+        { canvas: offscreen, scriptUrl: '/spike/hydra-synth.js', width: W, height: H },
+        [offscreen]
+      )
+    }).catch((err) => ({ type: 'error', error: String(err?.message || err) }))
+
+    worker.terminate()
+    return { done, stages }
+  })
+
+  console.log('\n══════════ Q3 HYDRA WORKER SPIKE — OBSERVED ══════════')
+  for (const s of result.stages as Array<Record<string, unknown>>) {
+    console.log(`\n[${s.stage}] ${s.status}`)
+    console.log('  ', JSON.stringify(s.detail))
+  }
+  const done = result.done as Record<string, unknown> | null
+  const wl = (done?.workerLogs as string[]) || []
+  if (wl.length) console.log('\n── worker diagnostics ──\n' + wl.join('\n'))
+  console.log('\n── VERDICT ──')
+  console.log(JSON.stringify({ verdict: done?.verdict, at: done?.at, pixels: done?.pixels }, null, 2))
+  if (logs.length) console.log('\n── page console ──\n' + logs.join('\n'))
+  console.log('═══════════════════════════════════════════════\n')
+
+  expect(done, 'worker produced a verdict').not.toBeNull()
+  expect(done?.type, 'worker did not hard-error in the harness').not.toBe('error')
+  expect(done?.verdict, 'hydra rendered in the worker').toBe('YES')
+  const px = done?.pixels as { nonBlank: number } | undefined
+  expect(px?.nonBlank ?? 0, 'rendered non-blank pixels').toBeGreaterThan(0)
+})


### PR DESCRIPTION
Two feasibility observations that gate the Phase B worker architecture (after B-0 #236 proved p5-in-worker = YES). **Both passed — observed, not inferred.**

## Q3 — hydra-synth renders to an OffscreenCanvas in a worker = **YES** (833b45b)
`public/spike/hydra-worker.js` (classic worker, `importScripts` the self-contained UMD bundle) renders `osc().rotate().out()` **directly into the transferred OffscreenCanvas** — 12 ticks, full rainbow gradient, `nonBlank=2048/2048`. Driver: `tests/b-preflight-hydra.spec.ts`.

Confirmed the prediction: **only a 2-condition shim vs p5's 6** —
1. install the shim **before** `importScripts` (hydra touches `window` at module-eval — `mouseListen`, hydra-synth.js:3926)
2. `window=self` alias + a thin `document` + size props

hydra takes the canvas explicitly (`new Hydra({ canvas })`, hydra-synth.js:235) and `makeGlobal/autoLoop/detectAudio/enableStreamCapture=false` strip the rest — no FES, no multi-canvas, no Proxy-vs-native issue. Confirms the renderer-portability thesis (a renderer that accepts the canvas as a param is near-trivial to move off-thread).

## Q2 — COOP/COEP for SharedArrayBuffer without breaking audio = **YES with `credentialless`** (496528f)
`next.config.ts` sets `COOP=same-origin` + `COEP=credentialless`. Observed (`tests/b-preflight-coep.spec.ts`, dev restarted with headers):
- `crossOriginIsolated=true`, `SharedArrayBuffer` allocatable
- `audioContext.state=running`, `audio.triggers=15 (~4.3/s)` — AudioWorklet/superdough survives
- **COEP-blocked requests = 0** — the strudel.cc sample packs still load

**Key: `credentialless`, NOT `require-corp`** — require-corp blocks cross-origin CDN subresources lacking CORP (the sample packs) → silent broken drums. (Catalogued as the require-corp trap.)

## ⚠️ Review notes — this PR changes the LIVE app config
- `next.config.ts` now sets **global COOP/COEP headers** (not just throwaway spike files). Verified: dev server boots + serves the headers + audio works.
- **Untested under isolation (Phase B must check before performance→main):** OAuth popups under COOP `same-origin` (the app has Google OAuth — a popup flow would break `window.opener`; a redirect flow is fine); fonts/embeds; COEP-credentialless browser support → Phase B should feature-detect `crossOriginIsolated` and degrade to transferable-ArrayBuffer postMessage when SAB is absent.
- Full production `next build` not run (config change is a trivial `headers()` fn, observed working in dev). Two new Playwright specs pass; eslint clean.

## Test plan
```
pnpm --filter @stave/app exec playwright test b-preflight-hydra.spec.ts
pnpm --filter @stave/app exec playwright test b-preflight-coep.spec.ts   # needs dev restarted w/ the new headers
```

Both renderer forks (p5, hydra) + the SAB-transport fork are now grounded → Phase B can be planned. Part of perf epic #228. Targets `performance` (not `main`).

closes #237