### PR TITLE
✨ feat: GLSL/ShaderToy renderer — STEP 2, validates the renderer contract (#281)

### DIFF
--- a/packages/app/tests/glsl-path-coverage.spec.ts
+++ b/packages/app/tests/glsl-path-coverage.spec.ts
@@ -1,0 +1,241 @@
+/**
+ * GLSL-PATH COVERAGE (#281) — the GLSL/ShaderToy renderer VALIDATES the engine-
+ * agnostic renderer contract (architecture/renderer-contract.mdx, PR #280). The
+ * GLSL worker path runs the SAME seams as p5/hydra through DIFFERENT code:
+ *   - `mountGLSL`'s raw-WebGL2 `gl()` accessor → #266 glctx accounting,
+ *   - a kind-agnostic `s.draw()` timed for the #230 viz.worker.draw bridge,
+ *   - `shouldUseWorkerRenderer` gate + FallbackVizRenderer (#247) — no
+ *     glsl-specific force-to-main,
+ *   - the audio feed: `mountGLSL` reads the SAME already-refreshed `rawAnalyser`
+ *     hydra reads and uploads it to the `iChannel0` texture (NO new host seam —
+ *     the contract's predicted validation point).
+ * This spec OBSERVES (Lokāyata, not inference) each on a real glsl-in-worker mount.
+ *
+ * CONTROL PROBE (per PK29): every assertion is guarded by `viz.worker > 0 &&
+ * viz.glsl === 0` FIRST — i.e. a GLSL viz is live in the WORKER, not fallen back
+ * to the main-thread `GLSLVizRenderer`. Without it a green check could be vacuous.
+ *
+ * GPU/compositor under test → run HEADED on real GPU (P108); per-test context
+ * isolation so a leaked GL context / worker can't bleed across (PV84):
+ *   E2E_VERIFY=1 pnpm --filter @stave/app exec playwright test glsl-path-coverage.spec.ts --headed --timeout=180000 --workers=1
+ */
+import { test, expect, type Browser, type BrowserContext, type Page } from '@playwright/test'
+import { createHash } from 'node:crypto'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+/** A ShaderToy `mainImage` body: animates off `iTime` (so it moves even in
+ *  silence) AND reads the `iChannel0` audio texture (row 0 = FFT) so it's
+ *  audio-reactive — the wrapped source is a plain transferable string. */
+const GLSL_OK = `void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 uv = fragCoord / iResolution.xy;
+  float a = texture(iChannel0, vec2(uv.x, 0.0)).x;
+  vec3 col = 0.5 + 0.5 * cos(iTime + uv.xyx * 4.0 + vec3(0.0, 2.1, 4.2) + a * 5.0);
+  fragColor = vec4(col, 1.0);
+}`
+
+/** A shader that won't COMPILE (undeclared identifier) → mountGLSL's
+ *  createGLSLProgram throws at mount, BEFORE `ready` → the worker host posts a
+ *  diag error → FallbackVizRenderer degrades to the main-thread GLSLVizRenderer
+ *  (#247), which surfaces the same compile error. The fallback gauge `viz.glsl`
+ *  must go up; `viz.worker` must NOT remain a live GLSL worker. */
+const GLSL_BROKEN = `void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  fragColor = vec4(definitely_not_a_real_symbol, 0.0, 0.0, 1.0);
+}`
+
+async function open(browser: Browser): Promise<{ ctx: BrowserContext; page: Page }> {
+  const ctx = await browser.newContext()
+  const page = await ctx.newPage()
+  await page.addInitScript(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).__STAVE_PERF__ = true
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).__STAVE_E2E__ = true
+    try {
+      localStorage.setItem('stave.viz.worker', '1') // force the worker path
+    } catch {
+      /* ignore */
+    }
+  })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('.monaco-editor').first().waitFor({ timeout: 30000 })
+  await page.waitForTimeout(1500)
+  return { ctx, page }
+}
+
+async function registerGLSL(page: Page, id: string, code: string): Promise<void> {
+  const ok = await page.evaluate(
+    ({ id, code }) =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (window as any).__staveRegisterViz?.({
+        id,
+        name: id,
+        renderer: 'glsl',
+        code,
+        requires: ['audio'],
+        nativeSize: { w: 640, h: 360 },
+        createdAt: 1,
+        updatedAt: 1,
+      }) ?? false,
+    { id, code },
+  )
+  expect(ok, 'glsl viz registered').toBe(true)
+}
+
+async function setCode(page: Page, code: string): Promise<void> {
+  const ok = await page.evaluate((c) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const e = (window as any).monaco?.editor?.getEditors?.()?.[0]
+    if (!e) return false
+    e.getModel()?.setValue(c)
+    return true
+  }, code)
+  expect(ok).toBe(true)
+  await page.waitForTimeout(250)
+}
+
+async function press(page: Page, key: string): Promise<void> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await page.evaluate(() => (window as any).monaco?.editor?.getEditors?.()?.[0]?.focus())
+  await page.keyboard.press(key)
+}
+
+async function scrollTo(page: Page, top: number): Promise<void> {
+  await page.evaluate((t) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).monaco?.editor?.getEditors?.()?.[0]?.setScrollTop(t)
+  }, top)
+}
+
+/** Stop, swap the code, run — a fresh mount, left on-screen (scrollTop 0, PV78). */
+async function remount(page: Page, code: string): Promise<void> {
+  await press(page, `${MOD}+Period`)
+  await page.waitForTimeout(400)
+  await setCode(page, code)
+  await press(page, `${MOD}+Enter`)
+  await page.waitForTimeout(3000)
+  await scrollTo(page, 0)
+  await page.waitForTimeout(1200)
+}
+
+interface Snap {
+  worker: number
+  glsl: number
+  glctx: number
+  draw: { count: number; p95: number; mean: number } | null
+}
+async function snap(page: Page): Promise<Snap> {
+  return page.evaluate(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const s = (window as any).__stavePerf?.snapshot?.()
+    const d = s?.sections?.['viz.worker.draw'] ?? null
+    return {
+      worker: s?.gauges?.['viz.worker'] ?? 0,
+      glsl: s?.gauges?.['viz.glsl'] ?? 0, // main-thread GLSLVizRenderer (fallback) gauge
+      glctx: s?.gauges?.['viz.glctx'] ?? 0,
+      draw: d ? { count: d.count, p95: d.p95, mean: d.mean } : null,
+    }
+  })
+}
+
+async function measure(page: Page): Promise<Snap> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await page.evaluate(() => (window as any).__stavePerf?.reset?.())
+  await page.waitForTimeout(3000)
+  return snap(page)
+}
+
+test.describe('#281 GLSL worker path — contract validation', () => {
+  test.skip(!process.env.E2E_VERIFY, 'acceptance gate — set E2E_VERIFY=1')
+
+  test('(a) #266 — a GLSL worker mount accounts a live GL context (viz.glctx)', async ({ browser }) => {
+    const { ctx, page } = await open(browser)
+    try {
+      await registerGLSL(page, 'gl-glctx', GLSL_OK)
+      await remount(page, `$: s("bd*4, ~ sd, hh*8").bank("RolandTR909").viz('gl-glctx')`)
+      const m = await snap(page)
+      console.log(`[#281 a] ${JSON.stringify(m)}`)
+
+      expect(m.worker, 'GLSL worker viz live (control probe)').toBeGreaterThan(0)
+      expect(m.glsl, 'must NOT have fallen back to the main-thread GLSLVizRenderer').toBe(0)
+      // #266 — accounting fired for the raw-WebGL2 context mountGLSL.gl() returns.
+      expect(m.glctx, 'GLSL mount must account a live GL context (viz.glctx)').toBeGreaterThanOrEqual(1)
+    } finally {
+      await ctx.close()
+    }
+  })
+
+  test('(b) #230 — viz.worker.draw populates from a glsl-kind worker viz', async ({ browser }) => {
+    const { ctx, page } = await open(browser)
+    try {
+      await registerGLSL(page, 'gl-draw', GLSL_OK)
+      await remount(page, `$: s("hh*16").bank("RolandTR909").gain(0.9).viz('gl-draw')`)
+      const m = await measure(page)
+      console.log(`[#281 b] ${JSON.stringify(m)}`)
+
+      expect(m.worker, 'a GLSL worker viz must be live (control probe)').toBeGreaterThanOrEqual(1)
+      expect(m.glsl, 'no main-thread fallback').toBe(0)
+      // The #230 bridge is kind-agnostic — s.draw() is timed for glsl too.
+      expect(m.draw, 'viz.worker.draw must exist for glsl (the bridge fired)').not.toBeNull()
+      expect(m.draw!.count, 'glsl draw samples recorded from the worker').toBeGreaterThan(0)
+      expect(m.draw!.p95, 'a sensible non-negative glsl draw time').toBeGreaterThanOrEqual(0)
+    } finally {
+      await ctx.close()
+    }
+  })
+
+  test('(c) #247 — a GLSL shader that fails to compile falls back to main-thread', async ({ browser }) => {
+    const { ctx, page } = await open(browser)
+    try {
+      await registerGLSL(page, 'gl-broken', GLSL_BROKEN)
+      await remount(page, `$: s("bd*4").bank("RolandTR909").viz('gl-broken')`)
+      const m = await snap(page)
+      console.log(`[#281 c] ${JSON.stringify(m)}`)
+
+      // The worker's createGLSLProgram throws before `ready` → FallbackVizRenderer
+      // mounts the main-thread GLSLVizRenderer. The main gauge goes up; no live
+      // GLSL worker remains (it was torn down on fallback).
+      expect(m.glsl, 'fell back to the main-thread GLSLVizRenderer (#247)').toBeGreaterThanOrEqual(1)
+      expect(m.worker, 'the broken worker did not stay live as a worker viz').toBe(0)
+    } finally {
+      await ctx.close()
+    }
+  })
+
+  test('(d) VISUAL — the GLSL worker canvas actually PAINTS animated frames (not black, not frozen)', async ({ browser }) => {
+    // The gauge tests prove MOUNT + bridge, but a worker can report viz.worker=1
+    // while the transferred canvas shows nothing (context lost, shader no-op). This
+    // is the LOKĀYATA gate: the rendered artifact. Decode-free (high-n-headroom
+    // technique): screenshot the inline canvas N× ~0.6s apart → md5 each. A LIVE
+    // shader animates off iTime (≥3/5 distinct) and fills pixels (large PNG).
+    const { ctx, page } = await open(browser)
+    try {
+      await registerGLSL(page, 'gl-visual', GLSL_OK)
+      await remount(page, `$: s("bd*4, ~ sd, hh*8").bank("RolandTR909").viz('gl-visual')`)
+
+      const g = await snap(page)
+      expect(g.worker, 'worker GLSL viz live (control probe)').toBeGreaterThanOrEqual(1)
+      expect(g.glsl, 'no main-thread fallback').toBe(0)
+
+      const canvas = page.locator('[data-viz-zone] canvas').first()
+      await canvas.waitFor({ timeout: 15000 })
+
+      const shots: { hash: string; bytes: number }[] = []
+      for (let i = 0; i < 5; i++) {
+        const buf = await canvas.screenshot({
+          path: i === 0 || i === 4 ? `test-results/glsl-visual-${i}.png` : undefined,
+        })
+        shots.push({ hash: createHash('md5').update(buf).digest('hex').slice(0, 8), bytes: buf.length })
+        if (i < 4) await page.waitForTimeout(600)
+      }
+      const distinct = new Set(shots.map((s) => s.hash)).size
+      const maxBytes = Math.max(...shots.map((s) => s.bytes))
+      console.log(`[#281 d] distinct frames=${distinct}/5  maxPNG=${maxBytes}B  hashes=${shots.map((s) => s.hash).join(',')}`)
+
+      expect(distinct, 'the GLSL canvas must change frame-to-frame (animating, not frozen)').toBeGreaterThanOrEqual(3)
+      expect(maxBytes, 'the GLSL canvas must paint pixels (not a black/empty surface)').toBeGreaterThan(3000)
+    } finally {
+      await ctx.close()
+    }
+  })
+})

--- a/packages/editor/src/engine/engineLog.ts
+++ b/packages/editor/src/engine/engineLog.ts
@@ -21,6 +21,7 @@ export type RuntimeId =
   | 'sonicpi'
   | 'p5'
   | 'hydra'
+  | 'glsl'
   /** Stave-itself errors (engine init, host-side failures). */
   | 'stave'
 

--- a/packages/editor/src/visualizers/__tests__/glslShaderSource.test.ts
+++ b/packages/editor/src/visualizers/__tests__/glslShaderSource.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildGLSLFragmentSource,
+  GLSL_FULLSCREEN_VERT,
+} from '../renderers/glslShaderSource'
+
+/**
+ * Pure-logic unit tests for the GLSL renderer (#281) — only the string
+ * composition (the wrapped shader source), which has no heavy deps. The WebGL
+ * pipeline (glslCore), the worker/main mounts, AND the `compilePreset` glsl
+ * routing all need a real GL context / drag in the p5+gifenc chain → covered by
+ * the Playwright e2e `glsl-path-coverage.spec.ts` (which exercises
+ * register→compilePreset→makeGLSLRenderer→worker mount end to end).
+ */
+describe('buildGLSLFragmentSource', () => {
+  const body = `void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    fragColor = vec4(1.0);
+  }`
+
+  it('declares the v1 uniform set so a ShaderToy body compiles', () => {
+    const src = buildGLSLFragmentSource(body)
+    expect(src).toContain('uniform vec3 iResolution;')
+    expect(src).toContain('uniform float iTime;')
+    expect(src).toContain('uniform vec4 iMouse;')
+    expect(src).toContain('uniform sampler2D iChannel0;')
+  })
+
+  it('targets GLSL ES 3.00 with a high-precision float', () => {
+    const src = buildGLSLFragmentSource(body)
+    expect(src.startsWith('#version 300 es')).toBe(true)
+    expect(src).toContain('precision highp float;')
+  })
+
+  it('embeds the user body verbatim and calls mainImage from main()', () => {
+    const src = buildGLSLFragmentSource(body)
+    expect(src).toContain(body)
+    expect(src).toContain('mainImage(color, gl_FragCoord.xy)')
+    expect(src).toContain('out vec4 stave_FragColor;')
+  })
+
+  it('the fullscreen vertex shader needs no attribute buffer (gl_VertexID)', () => {
+    expect(GLSL_FULLSCREEN_VERT).toContain('gl_VertexID')
+    expect(GLSL_FULLSCREEN_VERT.startsWith('#version 300 es')).toBe(true)
+    // No `in`/attribute declarations — positions are computed from the vertex id.
+    expect(GLSL_FULLSCREEN_VERT).not.toMatch(/\bin\s+vec/)
+  })
+})

--- a/packages/editor/src/visualizers/defaultDescriptors.ts
+++ b/packages/editor/src/visualizers/defaultDescriptors.ts
@@ -16,6 +16,8 @@ import {
   HYDRA_SCOPE_CODE,
   HYDRA_KALEID_CODE,
 } from './renderers/builtinHydraCode'
+import { makeGLSLRenderer } from './renderers/makeGLSLRenderer'
+import { GLSL_DEFAULT_CODE, GLSL_SPECTRUM_CODE } from './renderers/builtinGLSLCode'
 
 /**
  * All built-in visualization modes.
@@ -56,4 +58,12 @@ export const DEFAULT_VIZ_DESCRIPTORS: VizDescriptor[] = [
   { id: 'pianoroll:hydra',    label: 'Piano Roll (Hydra)', renderer: 'hydra', requires: ['audio'], factory: () => makeHydraRenderer(HYDRA_PIANOROLL_CODE, 'pianoroll:hydra') },
   { id: 'scope:hydra',        label: 'Scope (Hydra)',      renderer: 'hydra', requires: ['audio'], factory: () => makeHydraRenderer(HYDRA_SCOPE_CODE, 'scope:hydra') },
   { id: 'kaleidoscope:hydra', label: 'Kaleidoscope',       renderer: 'hydra', requires: ['audio'], factory: () => makeHydraRenderer(HYDRA_KALEID_CODE, 'kaleidoscope:hydra') },
+
+  // GLSL renderers (#281) — single-pass ShaderToy `mainImage`, raw WebGL2, the
+  // Tier-1 ZERO-library reference + perf floor. The wrapped fragment source is a
+  // plain transferable string, so `makeGLSLRenderer` offloads it to the worker
+  // (direct-to-OffscreenCanvas, no blit) with the main-thread GLSLVizRenderer as
+  // the fallback. Built against the renderer contract (architecture/renderer-contract).
+  { id: 'glsl',          label: 'GLSL',          renderer: 'glsl', requires: ['audio'], factory: () => makeGLSLRenderer(GLSL_DEFAULT_CODE, 'glsl') },
+  { id: 'spectrum:glsl', label: 'Spectrum (GLSL)', renderer: 'glsl', requires: ['audio'], factory: () => makeGLSLRenderer(GLSL_SPECTRUM_CODE, 'spectrum:glsl') },
 ]

--- a/packages/editor/src/visualizers/renderers/GLSLVizRenderer.ts
+++ b/packages/editor/src/visualizers/renderers/GLSLVizRenderer.ts
@@ -1,0 +1,147 @@
+/**
+ * GLSLVizRenderer — the MAIN-THREAD `VizRenderer` for a single-pass GLSL/ShaderToy
+ * sketch (issue #281). It is the ALWAYS-available path: used directly when the
+ * worker path is off / unsupported, and as the `FallbackVizRenderer` target when a
+ * GLSL worker fails to start (#247). The worker counterpart is `mountGLSL` in
+ * `hostP5Worker.ts`; both drive the SAME `glslCore` pipeline (one implementation).
+ *
+ * Loop ownership mirrors `HydraVizRenderer`: we own a single rAF that reads the
+ * master analyser and draws exactly one frame, so `pause()` (cancel the rAF) truly
+ * halts rendering. There is no per-frame user JS — the shader runs on the GPU — so
+ * `draw()` can't throw post-mount; the only failure point is shader compile/link,
+ * caught at mount and surfaced via `onError` (→ fallback when wrapped).
+ *
+ * REF: glslCore.ts (the shared pipeline), HydraVizRenderer (the loop/gauge/pause
+ *      idiom mirrored here), makeGLSLRenderer (#247 wrapping), perf.gauge('viz.glsl').
+ */
+
+import type { EngineComponents } from '../../engine/LiveCodingEngine'
+import type { VizRenderer } from '../types'
+import { perf } from '../../perf/profiler'
+import { createGLSLProgram, type GLSLProgram, type AudioByteSource, type GL2 } from './glslCore'
+
+/** Monotone id source for a stable per-instance profiler key (`glsl#N`). */
+let glslPerfSeq = 0
+
+export class GLSLVizRenderer implements VizRenderer {
+  private canvas: HTMLCanvasElement | null = null
+  private gl: GL2 | null = null
+  private program: GLSLProgram | null = null
+  private analyser: AnalyserNode | null = null
+  private rafId: number | null = null
+  private paused = false
+  private destroyed = false
+  private startMs = 0
+  private size = { w: 400, h: 300 }
+  private readonly perfId = `glsl#${++glslPerfSeq}`
+
+  constructor(private readonly code: string) {}
+
+  mount(
+    container: HTMLDivElement,
+    components: Partial<EngineComponents>,
+    size: { w: number; h: number },
+    onError: (e: Error) => void,
+  ): void {
+    perf.gauge('viz.glsl', 1) // live GLSL-instance gauge; -1 in destroy()
+    try {
+      this.size = { w: size.w, h: size.h }
+      this.analyser = (components.audio?.analyser as AnalyserNode | undefined) ?? null
+
+      const canvas = document.createElement('canvas')
+      canvas.width = Math.max(1, Math.round(size.w))
+      canvas.height = Math.max(1, Math.round(size.h))
+      canvas.style.width = '100%'
+      canvas.style.height = '100%'
+      canvas.style.display = 'block'
+      container.appendChild(canvas)
+      this.canvas = canvas
+
+      const gl = canvas.getContext('webgl2')
+      if (!gl) throw new Error('GLSLVizRenderer: WebGL2 not available')
+      this.gl = gl
+      // Throws on a shader compile/link error → onError (fallback when wrapped).
+      this.program = createGLSLProgram(gl, this.code)
+
+      this.startMs = performance.now()
+      if (!this.paused && !this.destroyed && this.rafId == null) {
+        this.rafId = requestAnimationFrame(this.loop)
+      }
+    } catch (e) {
+      onError(e as Error)
+    }
+  }
+
+  private loop = (now: number): void => {
+    if (this.paused || this.destroyed || !this.program) {
+      this.rafId = null
+      return
+    }
+    perf.frame(this.perfId)
+    perf.begin('glsl.draw')
+    try {
+      this.program.draw(this.analyser as AudioByteSource | null, {
+        width: this.size.w,
+        height: this.size.h,
+        timeMs: now - this.startMs,
+      })
+    } finally {
+      perf.end('glsl.draw')
+    }
+    this.rafId = requestAnimationFrame(this.loop)
+  }
+
+  update(components: Partial<EngineComponents>): void {
+    // Only the analyser is live data for GLSL; rebind it so a re-evaluate that
+    // swaps the audio node keeps the shader reactive (mirror HydraVizRenderer).
+    this.analyser = (components.audio?.analyser as AnalyserNode | undefined) ?? null
+  }
+
+  resize(w: number, h: number): void {
+    this.size = { w, h }
+    if (this.canvas) {
+      this.canvas.width = Math.max(1, Math.round(w))
+      this.canvas.height = Math.max(1, Math.round(h))
+    }
+  }
+
+  pause(): void {
+    this.paused = true
+    if (this.rafId != null) {
+      cancelAnimationFrame(this.rafId)
+      this.rafId = null
+    }
+  }
+
+  resume(): void {
+    this.paused = false
+    // iTime tracks wall-clock from mount; a pause lets it advance (v1 — shaders
+    // are continuous-time, no freeze needed). Just re-arm the loop.
+    if (this.rafId == null && !this.destroyed) {
+      this.rafId = requestAnimationFrame(this.loop)
+    }
+  }
+
+  destroy(): void {
+    this.destroyed = true
+    perf.gauge('viz.glsl', -1)
+    perf.dropFrames(this.perfId)
+    if (this.rafId != null) {
+      cancelAnimationFrame(this.rafId)
+      this.rafId = null
+    }
+    this.program?.dispose()
+    this.program = null
+    // Release the WebGL context explicitly (mirrors #266 hygiene on the worker
+    // path) — p5/hydra rely on lazy GC, but a raw context we own we can free.
+    try {
+      this.gl?.getExtension('WEBGL_lose_context')?.loseContext()
+    } catch {
+      /* already lost / unsupported — ignore */
+    }
+    this.gl = null
+    this.canvas?.remove()
+    this.canvas = null
+    this.analyser = null
+  }
+}

--- a/packages/editor/src/visualizers/renderers/WorkerVizRenderer.ts
+++ b/packages/editor/src/visualizers/renderers/WorkerVizRenderer.ts
@@ -120,10 +120,10 @@ export class WorkerVizRenderer implements VizRenderer {
    *  happens after we've detached its listener, so we account it main-side). */
   private glAccounted = false
 
-  /** @param kind renderer kind (`'p5'` B-3 / `'hydra'` B-5). @param code raw
-   *  sketch source. @param name workspace path (error attribution). */
+  /** @param kind renderer kind (`'p5'` B-3 / `'hydra'` B-5 / `'glsl'` #281).
+   *  @param code raw sketch source. @param name workspace path (error attribution). */
   constructor(
-    private readonly kind: 'p5' | 'hydra',
+    private readonly kind: 'p5' | 'hydra' | 'glsl',
     private readonly code: string,
     private readonly name: string,
   ) {}

--- a/packages/editor/src/visualizers/renderers/builtinGLSLCode.ts
+++ b/packages/editor/src/visualizers/renderers/builtinGLSLCode.ts
@@ -1,0 +1,52 @@
+/**
+ * builtinGLSLCode — bundled ShaderToy `mainImage` presets for the GLSL renderer
+ * (issue #281). Each is a v1-scope single-pass shader: `iResolution`, `iTime`,
+ * and the `iChannel0` audio texture (row 0 = FFT, row 1 = waveform). They are the
+ * GLSL analog of the built-in hydra/p5 sketches — the zero-library Tier-1
+ * reference visuals + the perf floor.
+ *
+ * REF: glslShaderSource.ts (the wrapper), defaultDescriptors.ts (registration).
+ */
+
+/** Default GLSL preset — an audio-reactive plasma whose hue and warp ride the
+ *  low/mid FFT bins, with a waveform line across the centre. */
+export const GLSL_DEFAULT_CODE = `// Stave GLSL — audio-reactive plasma.
+// iChannel0: row 0 (y≈0.0) = FFT, row 1 (y≈1.0) = waveform.
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 uv = fragCoord / iResolution.xy;
+  vec2 p = (uv - 0.5) * vec2(iResolution.x / iResolution.y, 1.0);
+
+  // Audio: bass from low FFT, treble from high FFT.
+  float bass = texture(iChannel0, vec2(0.03, 0.0)).x;
+  float treble = texture(iChannel0, vec2(0.7, 0.0)).x;
+
+  float t = iTime * 0.3;
+  float v = 0.0;
+  v += sin(p.x * 6.0 + t + bass * 6.0);
+  v += sin((p.y * 6.0 + t) + cos(p.x * 4.0));
+  v += sin(length(p) * 10.0 - t * 2.0 - bass * 8.0);
+  v *= 0.5;
+
+  vec3 col = 0.5 + 0.5 * cos(vec3(0.0, 2.1, 4.2) + v * 3.1416 + iTime * 0.2);
+  col *= 0.6 + 0.8 * bass;
+
+  // Waveform line across the middle.
+  float wave = texture(iChannel0, vec2(uv.x, 1.0)).x * 2.0 - 1.0;
+  float d = abs((uv.y - 0.5) - wave * 0.25);
+  col += smoothstep(0.02, 0.0, d) * vec3(1.0, 0.9, 0.7) * (0.5 + treble);
+
+  fragColor = vec4(col, 1.0);
+}
+`
+
+/** A minimal spectrum-bars shader — each column's height is its FFT bin. The
+ *  clearest possible "is audio reaching the shader?" reference. */
+export const GLSL_SPECTRUM_CODE = `// Stave GLSL — FFT spectrum bars.
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 uv = fragCoord / iResolution.xy;
+  float mag = texture(iChannel0, vec2(uv.x, 0.0)).x;
+  float bar = step(uv.y, mag);
+  vec3 col = mix(vec3(0.04, 0.05, 0.1), vec3(0.2 + uv.x, 0.8, 1.0 - uv.x), bar);
+  fragColor = vec4(col, 1.0);
+}
+`

--- a/packages/editor/src/visualizers/renderers/glslCore.ts
+++ b/packages/editor/src/visualizers/renderers/glslCore.ts
@@ -1,0 +1,227 @@
+/**
+ * glslCore — the SHARED, host-agnostic WebGL2 renderer for a single-pass
+ * ShaderToy sketch. ONE implementation drives BOTH viz hosts (PV56 spirit — one
+ * concept, one implementation):
+ *   - the worker (`hostP5Worker.ts` mountGLSL) — context from the transferred
+ *     `OffscreenCanvas` (Tier-1: render DIRECT, no blit);
+ *   - the main thread (`GLSLVizRenderer.ts`) — context from a `<canvas>` (the
+ *     fallback + non-OffscreenCanvas path).
+ * Only the canvas type and the audio source differ; the GL pipeline is identical,
+ * so it lives here once.
+ *
+ * Pipeline (v1, issue #281): a fullscreen triangle (no VBO — `gl_VertexID`) runs
+ * the wrapped fragment shader; the master analyser is uploaded each frame to a
+ * 2-row `R8` texture bound as `iChannel0` (row 0 = FFT, row 1 = waveform — the
+ * ShaderToy convention). Uniforms: `iResolution`, `iTime`, `iMouse`, `iChannel0`.
+ *
+ * Throw discipline: compile/link errors throw from `create` (mount-time) — the
+ * worker host catches them and the FallbackVizRenderer degrades to main (#247).
+ * `draw()` runs a GPU shader with NO per-frame user JS, so it does not throw —
+ * the #257 draw-swallow seam is satisfied trivially (a notable contract finding).
+ *
+ * REF: glslShaderSource.ts (the wrapped sources), architecture/renderer-contract.mdx
+ *      (the contract), rawShims.ts (the worker AudioByteSource), HydraVizRenderer
+ *      (the main-thread analyser source — same getByte* surface).
+ */
+
+import { GLSL_FULLSCREEN_VERT, buildGLSLFragmentSource } from './glslShaderSource'
+
+/** The per-frame audio surface — the SAME shape exposed by the worker's
+ *  `RawAnalyserShim` AND a Web Audio `AnalyserNode`, so the core feeds from
+ *  either host with no branch (the audio-feed seam the contract is tested on). */
+export interface AudioByteSource {
+  frequencyBinCount: number
+  getByteFrequencyData(arr: Uint8Array): void
+  getByteTimeDomainData(arr: Uint8Array): void
+}
+
+/** A WebGL2 context from either a `<canvas>` (main) or an `OffscreenCanvas`
+ *  (worker) — structurally identical for our use. */
+export type GL2 = WebGL2RenderingContext
+
+export interface GLSLDrawState {
+  /** Backing-store width in device px. */
+  width: number
+  /** Backing-store height in device px. */
+  height: number
+  /** Milliseconds since mount → `iTime = ms / 1000`. */
+  timeMs: number
+  /** `iMouse` (x, y, clickX, clickY); zeros in the worker (no pointer events). */
+  mouse?: readonly [number, number, number, number]
+}
+
+/** Width (texels) of each row of the `iChannel0` audio texture. */
+const AUDIO_TEX_W = 512
+const AUDIO_TEX_H = 2
+
+function compileShader(gl: GL2, type: number, src: string, label: string): WebGLShader {
+  const sh = gl.createShader(type)
+  if (!sh) throw new Error(`glsl: could not create ${label} shader`)
+  gl.shaderSource(sh, src)
+  gl.compileShader(sh)
+  if (!gl.getShaderParameter(sh, gl.COMPILE_STATUS)) {
+    const log = gl.getShaderInfoLog(sh) ?? ''
+    gl.deleteShader(sh)
+    // Strip the injected preamble's line offset from messages where we can — the
+    // user body starts after the preamble, but raw GLSL line numbers are still
+    // the most useful signal; surface the log verbatim.
+    throw new Error(`glsl ${label} compile error:\n${log.trim()}`)
+  }
+  return sh
+}
+
+/** Resample `src[0..srcLen)` byte data into `dst[0..dstLen)` by box-averaging —
+ *  maps an analyser buffer (1024 bins / 2048 samples) onto the texture row. */
+function resampleByteRow(src: Uint8Array, srcLen: number, dst: Uint8Array, dstLen: number): void {
+  if (srcLen <= 0) {
+    dst.fill(0, 0, dstLen)
+    return
+  }
+  const bucket = srcLen / dstLen
+  for (let i = 0; i < dstLen; i++) {
+    const start = Math.floor(i * bucket)
+    const end = Math.max(start + 1, Math.floor((i + 1) * bucket))
+    let sum = 0
+    let n = 0
+    for (let j = start; j < end && j < srcLen; j++) {
+      sum += src[j]
+      n++
+    }
+    dst[i] = n > 0 ? Math.round(sum / n) : 0
+  }
+}
+
+/**
+ * A compiled, drawable single-pass GLSL program bound to one WebGL2 context.
+ * Construct with `createGLSLProgram(gl, userSource)` (throws on compile/link
+ * error); drive with `draw(audio, state)`; release with `dispose()`.
+ */
+export class GLSLProgram {
+  private readonly program: WebGLProgram
+  private readonly vao: WebGLVertexArrayObject
+  private readonly audioTex: WebGLTexture
+  private readonly uResolution: WebGLUniformLocation | null
+  private readonly uTime: WebGLUniformLocation | null
+  private readonly uMouse: WebGLUniformLocation | null
+  private readonly uChannel0: WebGLUniformLocation | null
+  /** Scratch buffers, allocated once (no per-frame alloc). */
+  private readonly freqScratch = new Uint8Array(AUDIO_TEX_W * 4)
+  private readonly waveScratch = new Uint8Array(AUDIO_TEX_W * 4)
+  /** The 2-row texel buffer uploaded each frame (row 0 FFT, row 1 wave). */
+  private readonly texRows = new Uint8Array(AUDIO_TEX_W * AUDIO_TEX_H)
+  private disposed = false
+
+  constructor(
+    private readonly gl: GL2,
+    userSource: string,
+  ) {
+    const vert = compileShader(gl, gl.VERTEX_SHADER, GLSL_FULLSCREEN_VERT, 'vertex')
+    const frag = compileShader(
+      gl,
+      gl.FRAGMENT_SHADER,
+      buildGLSLFragmentSource(userSource),
+      'fragment',
+    )
+    const program = gl.createProgram()
+    if (!program) throw new Error('glsl: could not create program')
+    gl.attachShader(program, vert)
+    gl.attachShader(program, frag)
+    gl.linkProgram(program)
+    // Shaders can be flagged for deletion once linked.
+    gl.deleteShader(vert)
+    gl.deleteShader(frag)
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+      const log = gl.getProgramInfoLog(program) ?? ''
+      gl.deleteProgram(program)
+      throw new Error(`glsl link error:\n${log.trim()}`)
+    }
+    this.program = program
+    this.uResolution = gl.getUniformLocation(program, 'iResolution')
+    this.uTime = gl.getUniformLocation(program, 'iTime')
+    this.uMouse = gl.getUniformLocation(program, 'iMouse')
+    this.uChannel0 = gl.getUniformLocation(program, 'iChannel0')
+
+    // WebGL2 core requires a bound VAO for drawArrays, even with no attributes.
+    const vao = gl.createVertexArray()
+    if (!vao) throw new Error('glsl: could not create VAO')
+    this.vao = vao
+
+    // The audio texture — single-channel R8, 512×2, linear-filtered, clamped.
+    const tex = gl.createTexture()
+    if (!tex) throw new Error('glsl: could not create audio texture')
+    this.audioTex = tex
+    gl.bindTexture(gl.TEXTURE_2D, tex)
+    gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1) // R8 rows aren't 4-byte aligned
+    gl.texImage2D(
+      gl.TEXTURE_2D, 0, gl.R8, AUDIO_TEX_W, AUDIO_TEX_H, 0, gl.RED, gl.UNSIGNED_BYTE, null,
+    )
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+    gl.bindTexture(gl.TEXTURE_2D, null)
+  }
+
+  /** Render one frame. `audio` may be null (no analyser yet) → the texture stays
+   *  at its current contents (or zero) and the shader still animates off iTime. */
+  draw(audio: AudioByteSource | null, state: GLSLDrawState): void {
+    if (this.disposed) return
+    const gl = this.gl
+    const w = Math.max(1, Math.round(state.width))
+    const h = Math.max(1, Math.round(state.height))
+
+    // Upload the audio texture (row 0 = FFT, row 1 = waveform).
+    if (audio) {
+      const bins = Math.min(audio.frequencyBinCount, this.freqScratch.length)
+      const freq = this.freqScratch.subarray(0, bins)
+      const wave = this.waveScratch.subarray(0, bins)
+      audio.getByteFrequencyData(freq)
+      audio.getByteTimeDomainData(wave)
+      resampleByteRow(freq, bins, this.texRows.subarray(0, AUDIO_TEX_W), AUDIO_TEX_W)
+      resampleByteRow(wave, bins, this.texRows.subarray(AUDIO_TEX_W), AUDIO_TEX_W)
+      gl.bindTexture(gl.TEXTURE_2D, this.audioTex)
+      gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1)
+      gl.texSubImage2D(
+        gl.TEXTURE_2D, 0, 0, 0, AUDIO_TEX_W, AUDIO_TEX_H, gl.RED, gl.UNSIGNED_BYTE, this.texRows,
+      )
+    }
+
+    gl.viewport(0, 0, w, h)
+    gl.useProgram(this.program)
+    gl.bindVertexArray(this.vao)
+
+    if (this.uResolution) gl.uniform3f(this.uResolution, w, h, 1)
+    if (this.uTime) gl.uniform1f(this.uTime, state.timeMs / 1000)
+    if (this.uMouse) {
+      const m = state.mouse ?? [0, 0, 0, 0]
+      gl.uniform4f(this.uMouse, m[0], m[1], m[2], m[3])
+    }
+    if (this.uChannel0) {
+      gl.activeTexture(gl.TEXTURE0)
+      gl.bindTexture(gl.TEXTURE_2D, this.audioTex)
+      gl.uniform1i(this.uChannel0, 0)
+    }
+
+    gl.drawArrays(gl.TRIANGLES, 0, 3)
+    gl.bindVertexArray(null)
+  }
+
+  dispose(): void {
+    if (this.disposed) return
+    this.disposed = true
+    const gl = this.gl
+    try {
+      gl.deleteProgram(this.program)
+      gl.deleteVertexArray(this.vao)
+      gl.deleteTexture(this.audioTex)
+    } catch {
+      /* context may already be lost — ignore */
+    }
+  }
+}
+
+/** Compile + link a ShaderToy `mainImage` body against `gl`. Throws on a compile
+ *  or link error (the message carries the GLSL info log). */
+export function createGLSLProgram(gl: GL2, userSource: string): GLSLProgram {
+  return new GLSLProgram(gl, userSource)
+}

--- a/packages/editor/src/visualizers/renderers/glslShaderSource.ts
+++ b/packages/editor/src/visualizers/renderers/glslShaderSource.ts
@@ -1,0 +1,68 @@
+/**
+ * glslShaderSource — build the WebGL2 (GLSL ES 3.00) program sources for a
+ * ShaderToy-style sketch. The user writes ONLY the body:
+ *
+ *   void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+ *     vec2 uv = fragCoord / iResolution.xy;
+ *     fragColor = vec4(uv, 0.5 + 0.5 * sin(iTime), 1.0);
+ *   }
+ *
+ * We wrap it with the GLSL ES 3.00 preamble, the v1 uniform set, and a `main()`
+ * that calls `mainImage`. There is NO transpile — this is string composition, so
+ * a `.glsl` sketch crosses to the worker as a plain transferable string (the same
+ * property that lets p5/hydra source cross — workerMessages.ts MountMessage.code).
+ *
+ * v1 uniform set (HARD scope — Vairagya, issue #281):
+ *   - `iResolution` (vec3)  — viewport px in .xy, 1.0 in .z
+ *   - `iTime`       (float) — seconds since mount
+ *   - `iMouse`      (vec4)  — pointer; zero in the worker (no pointer events reach
+ *                            an OffscreenCanvas) — declared so shaders compile
+ *   - `iChannel0`   (sampler2D) — the master analyser as a 2-row audio texture:
+ *       row v≈0.25 = FFT magnitude, row v≈0.75 = waveform (ShaderToy convention)
+ * NO iChannelResolution / iFrame / iTimeDelta / multipass in v1 (deferred).
+ *
+ * REF: glslCore.ts (consumes these), hostP5Worker.ts mountGLSL, GLSLVizRenderer,
+ *      architecture/renderer-contract.mdx (the contract this renderer validates).
+ */
+
+/** Fullscreen-triangle vertex shader — covers the clip volume with 3 verts and
+ *  NO attribute buffer (positions come from `gl_VertexID`), so the core needs no
+ *  VBO/VAO setup. Draw with `gl.drawArrays(TRIANGLES, 0, 3)`. */
+export const GLSL_FULLSCREEN_VERT = `#version 300 es
+void main() {
+  vec2 p = vec2((gl_VertexID << 1) & 2, gl_VertexID & 2);
+  gl_Position = vec4(p * 2.0 - 1.0, 0.0, 1.0);
+}
+`
+
+/** The fragment preamble injected before the user's `mainImage`. Declares the v1
+ *  uniforms and the GLSL ES 3.00 output. */
+const FRAG_PREAMBLE = `#version 300 es
+precision highp float;
+precision highp int;
+uniform vec3 iResolution;
+uniform float iTime;
+uniform vec4 iMouse;
+uniform sampler2D iChannel0;
+out vec4 stave_FragColor;
+`
+
+/** The entry appended after the user's `mainImage` — calls it with the pixel
+ *  coord (origin bottom-left, matching ShaderToy / `gl_FragCoord`). */
+const FRAG_ENTRY = `
+void main() {
+  vec4 color = vec4(0.0, 0.0, 0.0, 1.0);
+  mainImage(color, gl_FragCoord.xy);
+  stave_FragColor = color;
+}
+`
+
+/**
+ * Compose the full fragment shader source from a user `mainImage` body. The user
+ * source is inserted verbatim between the preamble and the entry — a syntax error
+ * surfaces as a shader compile error (reported by `glslCore`), attributed to the
+ * sketch.
+ */
+export function buildGLSLFragmentSource(userSource: string): string {
+  return `${FRAG_PREAMBLE}\n${userSource}\n${FRAG_ENTRY}`
+}

--- a/packages/editor/src/visualizers/renderers/makeGLSLRenderer.ts
+++ b/packages/editor/src/visualizers/renderers/makeGLSLRenderer.ts
@@ -1,0 +1,38 @@
+/**
+ * makeGLSLRenderer — the GLSL renderer factory that chooses, per mount, between
+ * the OffscreenCanvas-worker renderer and the main-thread renderer (issue #281).
+ * The symmetric analog of `makeHydraRenderer` / `makeP5Renderer`.
+ *
+ * Worker rendering is selected on the SAME condition (`shouldUseWorkerRenderer`):
+ * flag on + worker factory registered + browser can offload. When selected it's
+ * wrapped in a `FallbackVizRenderer` so a worker that fails to start (e.g. a
+ * shader that won't compile in the worker GL) degrades to the proven main-thread
+ * `GLSLVizRenderer` (#247). Otherwise — old/non-isolated browser or flag off —
+ * the main-thread renderer runs.
+ *
+ * GLSL is the Tier-1, ZERO-library reference: a `.glsl` sketch is a plain
+ * transferable string (the wrapped fragment source), so it crosses to the worker
+ * with no closure-serialization problem (unlike built-in hydra closures), and the
+ * worker renders DIRECT into the transferred OffscreenCanvas with no blit (PV73).
+ *
+ * REF: makeHydraRenderer (the analog), FallbackVizRenderer (#247), hostVizWorker
+ *      (kind 'glsl'), GLSLVizRenderer (the main-thread target), glslCore.
+ */
+
+import type { VizRenderer } from '../types'
+import { GLSLVizRenderer } from './GLSLVizRenderer'
+import { WorkerVizRenderer } from './WorkerVizRenderer'
+import { FallbackVizRenderer } from './FallbackVizRenderer'
+import { shouldUseWorkerRenderer } from './makeP5Renderer'
+
+/** Build a GLSL `VizRenderer` for a `.glsl` sketch — worker-offloaded (with
+ *  main-thread fallback) when supported + enabled, else main-thread. `name` is the
+ *  workspace path (error attribution). */
+export function makeGLSLRenderer(code: string, name: string): VizRenderer {
+  return shouldUseWorkerRenderer()
+    ? new FallbackVizRenderer(
+        () => new WorkerVizRenderer('glsl', code, name),
+        () => new GLSLVizRenderer(code),
+      )
+    : new GLSLVizRenderer(code)
+}

--- a/packages/editor/src/visualizers/vizCompiler.ts
+++ b/packages/editor/src/visualizers/vizCompiler.ts
@@ -2,6 +2,7 @@ import type { VizDescriptor } from './types'
 import type { VizPreset } from './vizPreset'
 import { makeP5Renderer } from './renderers/makeP5Renderer'
 import { makeHydraRenderer } from './renderers/makeHydraRenderer'
+import { makeGLSLRenderer } from './renderers/makeGLSLRenderer'
 import { compileP5Code, isFullLifecycleSketch } from './p5Compiler'
 import { compileHydraCode } from './hydraCompiler'
 
@@ -46,6 +47,21 @@ export function compilePreset(preset: VizPreset): VizDescriptor {
       // the main-thread HydraVizRenderer. User `.hydra` code is a transferable
       // string, so it can cross to the worker (built-in hydra closures can't yet).
       factory: () => makeHydraRenderer(code, name),
+    }
+  }
+
+  if (renderer === 'glsl') {
+    return {
+      id,
+      label: name,
+      renderer: 'glsl',
+      requires,
+      ...(preset.nativeSize ? { nativeSize: preset.nativeSize } : {}),
+      // #281: `makeGLSLRenderer` returns a worker-offloaded renderer (with
+      // main-thread fallback) when the flag is on + the browser is capable, else
+      // the main-thread GLSLVizRenderer. A `.glsl` sketch is the wrapped fragment
+      // source — a plain transferable string, so it crosses to the worker cleanly.
+      factory: () => makeGLSLRenderer(code, name),
     }
   }
 

--- a/packages/editor/src/visualizers/vizPreset.ts
+++ b/packages/editor/src/visualizers/vizPreset.ts
@@ -18,7 +18,7 @@ export interface CropRegion {
 export interface VizPreset {
   id: string
   name: string
-  renderer: 'hydra' | 'p5'
+  renderer: 'hydra' | 'p5' | 'glsl'
   code: string
   requires: (keyof EngineComponents)[]
   createdAt: number
@@ -102,7 +102,7 @@ export function sanitizePresetName(name: string): string {
  * Bundled IDs never collide with user IDs because user IDs follow the
  * `<name>_<renderer>_v<N>` format and never start with `__`.
  */
-export function bundledPresetId(name: string, renderer: 'hydra' | 'p5'): string {
+export function bundledPresetId(name: string, renderer: 'hydra' | 'p5' | 'glsl'): string {
   return `${BUNDLED_PREFIX}${sanitizePresetName(name)}_${renderer}__`
 }
 
@@ -125,7 +125,7 @@ export function isBundledPresetId(id: string): boolean {
  */
 export function generateUniquePresetId(
   name: string,
-  renderer: 'hydra' | 'p5',
+  renderer: 'hydra' | 'p5' | 'glsl',
   existingIds: Iterable<string>,
 ): string {
   const slug = sanitizePresetName(name)

--- a/packages/editor/src/visualizers/worker/hostP5Worker.ts
+++ b/packages/editor/src/visualizers/worker/hostP5Worker.ts
@@ -44,6 +44,7 @@ import { buildStaveUniforms } from '../signals/staveUniforms'
 import { buildHydraStaveBag } from '../renderers/hydraStaveBag'
 import { compileP5Code } from '../p5Compiler'
 import { compileHydraCode } from '../hydraCompiler'
+import { createGLSLProgram, type GLSLProgram } from '../renderers/glslCore'
 import { subscribeLog, type LogEntry } from '../../engine/engineLog'
 import { getVizConfig, updateVizConfig } from '../vizConfig'
 import {
@@ -255,7 +256,9 @@ export function hostVizWorker(scope: WorkerScope): void {
     const strategy =
       msg.kind === 'hydra'
         ? await mountHydra(msg, feed, rawAnalyser, rawScheduler, dpr)
-        : await mountP5(msg, feed, rawAnalyser, rawScheduler, containerSizeRef, dpr)
+        : msg.kind === 'glsl'
+          ? mountGLSL(msg, rawAnalyser)
+          : await mountP5(msg, feed, rawAnalyser, rawScheduler, containerSizeRef, dpr)
 
     const reader = createPostMessageReader(scope as any)
     state = {
@@ -482,6 +485,51 @@ export function hostVizWorker(scope: WorkerScope): void {
       teardown: () => {
         try {
           hydra?.synth?.hush?.()
+        } catch {
+          /* ignore */
+        }
+      },
+    }
+  }
+
+  // ── glsl (Tier 1: raw WebGL2 on the canvas → render direct, no blit, no lib) ──
+  function mountGLSL(msg: MountMessage, rawAnalyser: RawAnalyserShim): RendererStrategy {
+    // Size the presenting canvas to CSS px (match HydraVizRenderer / mountHydra —
+    // the Tier-1 direct-render sibling; maxDpr is 1 so backing == CSS anyway).
+    msg.canvas.width = Math.max(1, Math.round(msg.size.w))
+    msg.canvas.height = Math.max(1, Math.round(msg.size.h))
+
+    const gl = msg.canvas.getContext('webgl2') as WebGL2RenderingContext | null
+    if (!gl) throw new Error('glsl: WebGL2 unavailable in worker')
+    // Compile/link NOW (sync) — a shader error throws here, propagates to mount's
+    // caller → diag('error') → main onError → FallbackVizRenderer degrades to the
+    // main-thread GLSLVizRenderer (#247), exactly like a p5/hydra compile error.
+    const program: GLSLProgram = createGLSLProgram(gl, msg.code)
+    const startMs = globalThis.performance?.now?.() ?? 0
+
+    return {
+      setupDone: () => true, // program built synchronously above; draw on first frame
+      // #266 — raw WebGL2 context we own; re-get returns the same context for the
+      // host's accountGL/releaseGL. The EASIEST gl() of the three kinds (no search).
+      gl: () => (msg.canvas.getContext('webgl2') as GLLoseCtx | null),
+      draw: () => {
+        // Feed the master analyser straight into the core (it uploads it to the
+        // iChannel0 audio texture). rawAnalyser is refreshed by applyAndDraw before
+        // this runs — the SAME already-refreshed shim mountHydra reads. No new seam.
+        const timeMs = (globalThis.performance?.now?.() ?? 0) - startMs
+        program.draw(rawAnalyser, {
+          width: msg.canvas.width,
+          height: msg.canvas.height,
+          timeMs,
+        })
+      },
+      resizeKind: (w, h) => {
+        msg.canvas.width = Math.max(1, Math.round(w))
+        msg.canvas.height = Math.max(1, Math.round(h))
+      },
+      teardown: () => {
+        try {
+          program.dispose()
         } catch {
           /* ignore */
         }

--- a/packages/editor/src/visualizers/worker/workerMessages.ts
+++ b/packages/editor/src/visualizers/worker/workerMessages.ts
@@ -12,9 +12,10 @@ import type { LogEntry } from '../../engine/engineLog'
 /** MAIN → WORKER: create the renderer instance against a transferred OffscreenCanvas. */
 export interface MountMessage {
   type: 'mount'
-  /** Renderer kind — `'p5'` (B-3) or `'hydra'` (B-5). The host installs the
-   *  matching DOM shim + imports the matching library + drives the matching draw. */
-  kind: 'p5' | 'hydra'
+  /** Renderer kind — `'p5'` (B-3), `'hydra'` (B-5), or `'glsl'` (#281). The host
+   *  installs the matching shim (none for glsl — raw WebGL2) + imports the matching
+   *  library (none for glsl) + drives the matching draw. */
+  kind: 'p5' | 'hydra' | 'glsl'
   /** The sketch source (a transferable string, compiled in-worker — PLAN §7.3). */
   code: string
   /** Source label for error attribution (the workspace path). */

--- a/packages/editor/src/workspace/preview/registry.ts
+++ b/packages/editor/src/workspace/preview/registry.ts
@@ -79,6 +79,8 @@ function extensionToLanguage(ext: string): string | undefined {
       return 'hydra'
     case '.p5':
       return 'p5js'
+    case '.glsl':
+      return 'glsl'
     case '.md':
       return 'markdown'
     default:


### PR DESCRIPTION
## What this is
**STEP 2** of the perf-docs/GLSL arc (#279, PK31). The engine-agnostic
`RendererStrategy` contract was written first (PR #280). This PR builds the
**simplest possible new renderer against it** — and observes whether it slots in
clean (contract proven) or needs a new seam (contract gap). It slots in clean.

## The renderer
A single-pass GLSL/ShaderToy renderer: **Tier-1, zero-library, no-DOM-shim, pure
WebGL2** — a fullscreen triangle (`gl_VertexID`, no VBO) + the user's `mainImage`
fragment shader, rendering **direct to the transferred OffscreenCanvas, no blit**.

**v1 scope (HARD — Vairagya):** `mainImage(out vec4, in vec2)` + `iResolution` /
`iTime` / `iMouse` / `iChannel0` (the master analyser as a 2-row audio texture:
FFT + waveform). NO multipass / buffers / cubemaps / keyboard / mic.

One shared `glslCore` drives **both** hosts (PV56 — one implementation):
- `mountGLSL` (worker) — raw WebGL2 on the transferred canvas;
- `GLSLVizRenderer` (main) — the `#247` fallback + non-OffscreenCanvas path.

Wired via `kind:'glsl'`, `makeGLSLRenderer` (mirrors `makeHydraRenderer`),
`compilePreset` routing, the `vizPreset`/`RuntimeId` unions, two builtin presets,
and the `.glsl` preview-language mapping.

## The validation result (the whole point)
**GLSL slots into all seven contract seams with ZERO new host seam.** The
predicted watch point — the audio feed — held exactly: `mountGLSL` reads the
**same** already-refreshed `rawAnalyser` hydra reads and uploads it to the
`iChannel0` texture *internally*. No new seam. A bonus finding: GLSL's `draw()` is
a GPU shader with no per-frame user JS, so it **can't throw post-mount** → the
`#257` draw-swallow seam is satisfied trivially.

## Test plan — OBSERVED (Lokāyata)
Unit: 195 visualizer tests green + 4 new pure shader-source tests.

E2E `glsl-path-coverage.spec.ts` (real GL, against the live app) — **4/4 green**:
| Test | Seam | Observed |
|---|---|---|
| (a) | #266 glctx | `worker:1 glsl:0 glctx:1` — raw-WebGL2 `gl()` accounted, no fallback |
| (b) | #230 bridge | `viz.worker.draw count:171` — kind-agnostic `s.draw` timed for glsl |
| (c) | #247 fallback | broken shader → `worker:0 glsl:1` — degraded to main-thread |
| (d) | **VISUAL** | `distinct 5/5, maxPNG 119KB` — the canvas **paints + animates** |

Run: `E2E_VERIFY=1 pnpm --filter @stave/app exec playwright test glsl-path-coverage.spec.ts --headed --timeout=180000 --workers=1`

## Scope notes (deliberate)
- The full user-authored **`.glsl`-file editing surface** (a dedicated Monaco
  language, a `glslViz` preview provider, app-side preset seeding) is **out of
  scope** here — the built-in descriptors + `.viz('glsl')` route through the same
  `compilePreset`→`makeGLSLRenderer`→worker path that this PR validates. Tracked
  as a follow-up; the engine-specific GLSL **dev chapter** is STEP 3.

Part of #279. Closes #281.