### PR TITLE
📚 Viz docs STEP 3–5: engine renderer chapters + GLSL user doc + contract validation loop

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -44,6 +44,7 @@ export default defineConfig({
             { label: 'Sonic Pi', link: '/runtimes/sonicpi/' },
             { label: 'p5.js', link: '/runtimes/p5/' },
             { label: 'Hydra', link: '/runtimes/hydra/' },
+            { label: 'GLSL / ShaderToy', link: '/runtimes/glsl/' },
           ],
         },
         {
@@ -54,6 +55,9 @@ export default defineConfig({
           label: 'Architecture',
           items: [
             { label: 'The viz renderer contract', link: '/architecture/renderer-contract/' },
+            { label: 'Renderer: GLSL', link: '/architecture/glsl/' },
+            { label: 'Renderer: Hydra', link: '/architecture/hydra/' },
+            { label: 'Renderer: p5.js', link: '/architecture/p5/' },
           ],
         },
         {

--- a/packages/docs/src/content/docs/architecture/glsl.mdx
+++ b/packages/docs/src/content/docs/architecture/glsl.mdx
@@ -1,0 +1,206 @@
+---
+title: 'Renderer: GLSL'
+description: How the single-pass GLSL/ShaderToy renderer satisfies the viz contract — the Tier-1, zero-library reference. Raw WebGL2, the iChannel0 audio texture, and the u* pattern-event uniforms, shared by the worker and the main thread.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+This is the **developer** chapter for the GLSL renderer. Read
+[The viz renderer contract](/architecture/renderer-contract/) first — this page
+only covers the *kind-specific* half: how a single-pass GLSL/ShaderToy shader
+fills in the five `RendererStrategy` members and where its audio and event feeds
+come from. Every claim cites `file:line` in
+`packages/editor/src/visualizers/`.
+
+<Aside type="tip" title="The reference renderer">
+GLSL is the **simplest possible** instance of the contract: raw WebGL2, a
+fullscreen triangle, one fragment shader, **zero library**, and Tier-1
+direct-to-canvas (no blit). That's why it was built to *test* the contract — if
+the simplest kind slots into every seam with no new shared machinery, the
+abstraction is genuinely engine-agnostic. It does (see
+[the validation result](/architecture/renderer-contract/#validated-by-the-glsl-renderer)).
+It is also the **performance floor**: no CPU tessellation (unlike p5) and no
+library overhead (unlike hydra) — just GPU fill.
+</Aside>
+
+## One core, two hosts
+
+Both host paths drive a single shared pipeline, `GLSLProgram` in
+`renderers/glslCore.ts` (`glslCore.ts:116`) — one concept, one implementation
+(PV56). Only the canvas type and the audio source differ:
+
+| Host | Canvas | Audio source | File |
+| --- | --- | --- | --- |
+| **Worker** (default) | the transferred `OffscreenCanvas` | `rawAnalyser` shim | `hostP5Worker.ts:497` (`mountGLSL`) |
+| **Main thread** (fallback / unsupported) | a `<canvas>` it creates | a Web Audio `AnalyserNode` | `GLSLVizRenderer.ts:32` |
+
+The two audio sources are structurally identical — both expose
+`AudioByteSource` (`glslCore.ts:32`: `frequencyBinCount` +
+`getByteFrequencyData` + `getByteTimeDomainData`) — so the core feeds from
+either with **no branch**. That shared interface is the audio-feed seam the
+contract was tested on, and it needed no generalizing.
+
+The main-thread factory chooses between them per mount with the same gate the
+other kinds use (`makeGLSLRenderer.ts:32`, `shouldUseWorkerRenderer()`), wrapping
+the worker renderer in a `FallbackVizRenderer` so a worker that can't compile the
+shader degrades to the proven `GLSLVizRenderer` (#247).
+
+## The pipeline — a fullscreen triangle + one fragment shader
+
+There is no geometry to manage. A single triangle covers the clip volume using
+`gl_VertexID` for its three positions, so the core needs **no VBO and no
+attributes** (`glslShaderSource.ts:31`). The whole draw is one
+`gl.drawArrays(TRIANGLES, 0, 3)` (`glslCore.ts:236`) with a bound (empty) VAO —
+WebGL2 core requires a VAO even with no attributes (`glslCore.ts:168`).
+
+The user controls only the **fragment** shader. There is no transpile — the
+program source is plain string composition (`buildGLSLFragmentSource`,
+`glslShaderSource.ts:82`), which is also why a `.glsl` sketch crosses to the
+worker as a plain transferable string (the same property that lets p5/hydra
+*source* cross — `MountMessage.code`), with none of the closure-serialization
+problem built-in hydra sketches have.
+
+### Two conventions, auto-detected (#283)
+
+`buildGLSLFragmentSource` supports both shapes, detected from the
+comment-stripped source (`glslShaderSource.ts:83`):
+
+- **ShaderToy** — the user writes only `void mainImage(out vec4 fragColor, in
+  vec2 fragCoord)`; Stave owns the `main()` entry and the fragment output
+  (`glslShaderSource.ts:92`).
+- **Raw GLSL** — the user writes their own `void main()` and their own `out`;
+  Stave prepends only the version, precision, and uniforms, and strips a user
+  `#version` so ours stays canonical first (`glslShaderSource.ts:96`).
+
+<Aside type="caution" title="Ambiguity and emptiness are friendly errors, not GLSL errors">
+Both-present (`mainImage` *and* `main`) and neither-present are caught with a
+human message *before* compilation (`glslShaderSource.ts:87`,
+`glslShaderSource.ts:101`) — not a cryptic duplicate-symbol or undefined-`main`
+link error. Detection runs on a comment-blanked copy
+(`stripComments`, `glslShaderSource.ts:64`) so a `// uses mainImage` line or a
+`/* main() */` block can't fool it.
+</Aside>
+
+## The audio feed — `iChannel0`, the ShaderToy convention
+
+The master analyser is uploaded each frame to a single-channel `R8` texture,
+512×2, bound as `iChannel0` (`glslCore.ts:71` sizes; `glslCore.ts:179` allocates;
+`glslCore.ts:209` uploads with `texSubImage2D`):
+
+- **row 0** (`y ≈ 0.0`) = FFT magnitude,
+- **row 1** (`y ≈ 1.0`) = waveform,
+
+matching ShaderToy's audio-texture convention, so an off-the-shelf shader reads
+`texture(iChannel0, vec2(uv.x, 0.0)).x` for the spectrum unchanged. The analyser
+buffer (1024 bins / 2048 samples) is box-averaged onto the 512-texel rows by
+`resampleByteRow` (`glslCore.ts:92`), into scratch buffers allocated **once**
+(`glslCore.ts:127`) — no per-frame allocation.
+
+The other v1 uniforms are `iResolution` (vec3, viewport px in `.xy`), `iTime`
+(seconds since mount), and `iMouse` (vec4, zero in the worker — no pointer
+events) (`glslShaderSource.ts:45`).
+
+## The event feed — `u*` uniforms (the kind-specific marshal, #284)
+
+This is the one seam GLSL adds. Beyond the mixed FFT in `iChannel0`, a shader can
+react to **pattern events** — per-drum envelope levels + master DSP — through
+`float` uniforms (`glslShaderSource.ts:49`):
+
+```glsl
+uniform float uKick, uSnare, uHat, uOpenHat, uClap, uRim, uTom, uVelocity;
+uniform float uRms, uBass, uMid, uTreble;
+```
+
+These are read from the named-signal bus once per frame by `readGLSLEvents`
+(`glslEvents.ts:21`) — the **same** `bus.envValue()` / `bus.master()` API that
+`hydraStaveBag` and the p5 `buildStaveUniforms` path use, so a kick is a kick in
+every engine. The values are set with `uniform1f` only for the uniforms the
+shader actually references; GLSL strips unused uniforms, so their location is
+`null` and the set is a cheap no-op (`glslCore.ts:162`, `glslCore.ts:232`).
+
+<Aside type="note" title="Audio feed: no new seam. Event feed: a kind-specific marshal (PV87 addendum)">
+The contract chapter predicted exactly this split, and the GLSL build confirmed
+it. The **audio** feed reused the existing kind-agnostic source — `mountGLSL`
+reads the same already-refreshed `rawAnalyser` hydra reads, and uploads it to a
+texture *internally* (`hostP5Worker.ts:517`). No host change. The **event** feed
+is genuinely kind-specific — turning bus signals into shader uniforms is GLSL's
+analog of p5's blit: it lives entirely inside the strategy's `draw()`, not in the
+shared host. Both feeds are sourced from data the host already prepares
+(`rawAnalyser` + the ticked `feed.bus`); neither required a new *shared* seam.
+</Aside>
+
+## Draw cadence — one frame per signal frame
+
+The worker draws only when the host calls `draw()` (PK22) — there is no internal
+loop. Inside `mountGLSL`'s `draw()` (`hostP5Worker.ts:516`), the audio shim is
+already refreshed and the bus already ticked by `applyAndDraw`
+(`hostP5Worker.ts:545`), so the strategy just reads and renders:
+
+```ts
+// hostP5Worker.ts:524 — read the already-prepared feeds; render one frame
+const timeMs = (globalThis.performance?.now?.() ?? 0) - startMs
+program.draw(
+  rawAnalyser,                                  // → iChannel0 texture (audio)
+  { width: msg.canvas.width, height: msg.canvas.height, timeMs },
+  readGLSLEvents(feed.bus),                      // → u* uniforms (events)
+)
+```
+
+On the main thread the loop is owned by `GLSLVizRenderer` and mirrors
+`HydraVizRenderer`: a single `requestAnimationFrame` that ticks the bus **once**
+per frame (`GLSLVizRenderer.ts:110`: `tick()` → `refreshActive()` → `readAudio()`)
+then reads the events and draws, so `pause()` (cancel the rAF) truly halts
+rendering.
+
+## The five strategy members for GLSL
+
+| Member | GLSL implementation | Where |
+| --- | --- | --- |
+| `setupDone()` | `true` immediately — the program is compiled+linked *synchronously* at mount | `hostP5Worker.ts:512` |
+| `draw()` | upload audio texture, set uniforms, draw 3 verts — **no per-frame user JS** | `hostP5Worker.ts:516` → `glslCore.ts:192` |
+| `resizeKind(w,h)` | resize the transferred canvas directly (Tier-1; `maxDpr` is 1 so backing == CSS) | `hostP5Worker.ts:531` |
+| `teardown()` | `program.dispose()` — delete program, VAO, texture | `hostP5Worker.ts:535` → `glslCore.ts:240` |
+| `gl?()` | re-get the WebGL2 context — **the easiest of all three kinds** (the context we created; no search) | `hostP5Worker.ts:515` |
+
+<Aside type="tip" title="GLSL satisfies #257 for free">
+Two seams are trivially satisfied by GLSL's nature. (1) `setupDone()` is
+synchronous because compile/link runs at mount — so there's no async-readiness
+dance. (2) `draw()` runs a GPU shader with **no per-frame user JavaScript**, so it
+cannot throw post-mount — the #257 draw-error surfacing seam has nothing to catch
+(`glslCore.ts:18`). The only failure point is shader compile/link, which throws
+at mount (`glslCore.ts:85`, `glslCore.ts:155`) → caught by the host → `onError` →
+`FallbackVizRenderer` degrades to main (#247). Contrast p5 (async setup, `draw()`
+can throw a user typo — P114) and hydra (library swallows user throws — P116).
+</Aside>
+
+## GL-context release (#266 hygiene)
+
+Because GLSL owns its `WebGLRenderingContext` directly, both paths release it
+explicitly on teardown rather than waiting for GC: the worker's `gl()` accessor
+feeds the host's `accountGL`/`releaseGL` (`hostP5Worker.ts:515`), and the
+main-thread renderer calls `WEBGL_lose_context.loseContext()` in `destroy()`
+(`GLSLVizRenderer.ts:173`). This keeps a pooled warm worker from retaining a
+context toward Chrome's ~16-context cap.
+
+## Built-in presets
+
+Four bundled shaders (`builtinGLSLCode.ts`), registered in
+`defaultDescriptors.ts`:
+
+| Preset | What it shows | Reads |
+| --- | --- | --- |
+| `glsl` | audio-reactive plasma + waveform line | `iChannel0` (FFT + wave) |
+| `spectrum:glsl` | FFT spectrum bars — the clearest "is audio reaching the shader?" | `iChannel0` row 0 |
+| `creation` | "Creation" by Silexars/Danguafer, ported audio-reactive | `iChannel0` (bass/treble) |
+| `pulse` | red flash on kick, blue rings on snare, white rim on hat | `u*` events |
+
+`pulse` is the clearest "events, not just FFT" reference — it reads **no**
+`iChannel0`, only `uKick`/`uSnare`/`uHat`.
+
+**Verified by** `glsl-path-coverage.spec.ts` (a–f) — a GLSL viz live in the
+*worker* (`viz.worker > 0 && viz.glsl === 0`) exercising each seam: (a) #266
+`glctx` accounting, (b) #230 `viz.worker.draw` timing, (c) #247 fallback on a
+broken shader, (d) a 5-frame visual-distinct gate, (e) raw `void main()` mode,
+(f) a **pure-`uKick`** shader (no `iTime`/`iChannel0`) proven distinct under
+`bd*4` — events reach the GPU. Plus `glsl-creation-4up.spec.ts` — four concurrent
+audio-reactive GLSL worker viz, all painting (PV86).

--- a/packages/docs/src/content/docs/architecture/hydra.mdx
+++ b/packages/docs/src/content/docs/architecture/hydra.mdx
@@ -1,0 +1,123 @@
+---
+title: 'Renderer: Hydra'
+description: How the Hydra renderer satisfies the viz contract — Tier-1 direct-to-canvas, the s.a.fft audio bridge, host-driven tick(), and the library-swallowed-error and GPU-async-dispatch gotchas.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+This is the **developer** chapter for the Hydra renderer. Read
+[The viz renderer contract](/architecture/renderer-contract/) first — this page
+covers only the kind-specific half: how a `hydra-synth` instance fills in the
+five `RendererStrategy` members and where its quirks bite. Every claim cites
+`file:line` in `packages/editor/src/visualizers/`.
+
+## Canvas tier — Tier-1 direct (PV73)
+
+Hydra **accepts the transferred `OffscreenCanvas`** and renders into it directly,
+no blit. `mountHydra` constructs the synth with `{ canvas: msg.canvas }`
+(`hostP5Worker.ts:423`) after sizing the presenting canvas to CSS px
+(`hostP5Worker.ts:420`) — it does **not** dpr-scale, matching the main-thread
+`HydraVizRenderer`. Because it's the worker's presenting surface, the GL context
+hydra (regl) creates is exactly the one the host accounts.
+
+The instance is configured for worker life (`hostP5Worker.ts:423`):
+
+- `detectAudio: false` — no Meyda / `getUserMedia` / `AudioContext` in the worker
+  (we feed `s.a.fft` ourselves, below);
+- `makeGlobal: false` — generators live on `hydra.synth`, not the global scope;
+- `autoLoop: false` — **we** drive `tick()` once per frame (1:1, PK22);
+- `enableStreamCapture: false` — an `OffscreenCanvas` has no `captureStream`.
+
+<Aside type="note" title="The DOM shim is smaller than p5's (PV70)">
+`hydra-synth` touches `window` at module-eval (`mouseListen`), so a 2-part shim
+(a `window = self` alias + a thin `document`) is installed *before* the import
+(`hostP5Worker.ts:405`, `installWorkerHydraShim`). That's far less than p5's
+6-condition shim — hydra needs `window`/`document` to exist, not a full
+canvas-element factory, because it renders into the canvas we hand it rather than
+creating its own.
+</Aside>
+
+## The audio feed — `s.a.fft[]` from the master analyser
+
+A hydra sketch reads audio via `a.fft[i]`. With `detectAudio:false` there's no
+analyser inside hydra, so the strategy's `draw()` fills `s.a.fft[]` itself each
+frame from the master analyser bytes (`hostP5Worker.ts:462`), mirroring the
+main-thread `pumpAudio`. The byte buffer is downsampled to
+`getVizConfig().hydraAudioBins` bins (`hostP5Worker.ts:470`), normalized to
+`0..1`, into a scratch buffer allocated once (`hostP5Worker.ts:453`). The bin
+count comes across the worker boundary in the marshalled config subset
+(`hydraAudioBins` is one of `WORKER_VIZ_CONFIG_KEYS`).
+
+The named-signal **bus** (the `u.*` signals + per-track access) is built into the
+hydra bag at mount (`hostP5Worker.ts:411`, `buildHydraStaveBag(feed.bus)`); the
+bus is ticked once per frame by `feed.applyFrame`, so `draw()` must **not** tick
+it again (`hostP5Worker.ts:478`).
+
+## Draw cadence — host-driven `tick()`
+
+`draw()` is one shader frame: fill `s.a.fft`, then `hydra.tick(performance.now())`
+(`hostP5Worker.ts:479`). There is no internal loop (`autoLoop:false`), so cadence
+is exactly the host's 1:1 contract.
+
+## The five strategy members for Hydra
+
+| Member | Hydra implementation | Where |
+| --- | --- | --- |
+| `setupDone()` | `true` immediately — the user pattern ran synchronously at mount | `hostP5Worker.ts:456` |
+| `draw()` | refill `s.a.fft`, `hydra.tick()` — one shader frame | `hostP5Worker.ts:462` |
+| `resizeKind(w,h)` | resize the transferred canvas + `hydra.setResolution(w,h)` | `hostP5Worker.ts:481` |
+| `teardown()` | `hydra.synth.hush()` | `hostP5Worker.ts:486` |
+| `gl?()` | re-get `webgl2`/`webgl` from the presenting canvas (regl owns it) | `hostP5Worker.ts:459` |
+
+<Aside type="caution" title="Built-in hydra sketches are NOT worker-routed (B-5 deferral)">
+The worker compiles a hydra *code string* (`compileHydraCode(msg.code)`,
+`hostP5Worker.ts:450`). Built-in hydra sketches that ship as **closures** can't be
+serialized across the worker boundary, so they're deferred to the main-thread
+path for now. A `.hydra` *file* (a string) routes through the worker fine.
+</Aside>
+
+## Gotcha 1 — hydra swallows user errors (#257 is p5-only for user code, P116)
+
+A p5 `draw()` typo surfaces in the Stave Console (#257). The hydra equivalent — a
+reactive arrow that throws, e.g. `.rotate(() => { throw … })` — **does not**.
+
+`hydra-synth` wraps every reactive-fn uniform evaluation in its own try/catch
+(`format-arguments.js:72`: `catch (e) { console.warn('ERROR', e); return
+input.default }`). The throw is caught *inside hydra*, logged to `console.warn`
+(not Stave's `engineLog`), and the uniform falls back to its default — so it never
+propagates out of `hydra.tick()`, never reaches the host's shared `s.draw()` catch
+(`hostP5Worker.ts:519`), never re-emits via `vizlog`. The host catch is correct
+but only fires for **engine-level** throws (regl / GL / context-lost), which a viz
+code string can't deterministically induce.
+
+<Aside type="caution" title="Before asserting 'X surfaces an error,' check who swallows it first">
+This was a doc-comment inference (the #257 comment implied parity across kinds).
+The detection rule: grep the runtime library's arg/uniform eval for a try/catch
+before claiming an error surfaces. Characterized in `hydra-path-coverage.spec.ts`
+(b) — a throwing hydra reactive fn yields `engineLog` errors === 0, no fallback,
+worker stays live. (A throw on **frame 1** never reaches `ready` → that's the
+#247 *fallback* path, different again.)
+</Aside>
+
+## Gotcha 2 — resolution doesn't move `viz.worker.draw` (P117)
+
+Dropping inline-viz resolution 1024→256 (16× fewer fragments) does **not** change
+a hydra viz's `viz.worker.draw` p95 — it stays ~0.06–0.13 ms at both.
+
+Because hydra is Tier-1, `hydra.tick()` only **dispatches** GPU work (issues draw
+calls and returns); the per-fragment fill runs **async on the GPU**. The
+profiler times the CPU wall-time of `s.draw()` — the dispatch — which is
+fragment-count-independent (PV83: the bridge measures dispatch, not fill).
+
+<Aside type="tip" title="Don't mirror the p5 density assertion onto hydra">
+Contrast p5's line meshes (#232), where the cost is CPU-side JS tessellation, so
+`density` *does* move `viz.worker.draw` (`viz-density-lod.spec.ts`). Hydra is the
+opposite class — GPU-fill-bound. To gauge hydra fill cost, measure the worker's
+actual frame **rate** under saturation, not the dispatch section. Verified flat
+across res in `hydra-path-coverage.spec.ts` (c).
+</Aside>
+
+**Verified by** `hydra-path-coverage.spec.ts` (the worker `gl()` accessor → #266,
+kind-agnostic `s.draw()` timing → #230, the P116 swallow, the P117 flat-cost) and
+`hydra-visual-gate.spec.ts` (the worker canvas actually paints, audio-reactive —
+PV86).

--- a/packages/docs/src/content/docs/architecture/p5.mdx
+++ b/packages/docs/src/content/docs/architecture/p5.mdx
@@ -1,0 +1,125 @@
+---
+title: 'Renderer: p5.js'
+description: How the p5.js renderer satisfies the viz contract — Tier-2 blit, the worker DOM shim, host-driven redraw(), the density LOD lever, and the double-swallowed-error gotcha.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+This is the **developer** chapter for the p5.js renderer. Read
+[The viz renderer contract](/architecture/renderer-contract/) first — this page
+covers only the kind-specific half. p5 is the **hardest** kind: it makes its own
+canvases, needs a DOM shim to run in a worker at all, and its `draw()` can throw
+user code. Every claim cites `file:line` in
+`packages/editor/src/visualizers/`.
+
+## Canvas tier — Tier-2 blit (PV73)
+
+Unlike hydra/GLSL, p5 does not render into the transferred canvas — it creates its
+**own** worker-local canvas and we **blit** its output onto the presenting canvas
+each frame. The presenting surface is sized to **device** pixels (`size × dpr`,
+`hostP5Worker.ts:340`) and gets a `bitmaprenderer` context
+(`hostP5Worker.ts:344`); `draw()` copies p5's render canvas across zero-copy with
+`transferFromImageBitmap(src.transferToImageBitmap())` (`hostP5Worker.ts:362`).
+
+The blit *is* what p5's `draw()` does — it's not a new seam, just this kind's
+implementation of the `draw()` contract.
+
+## The worker DOM shim (PV70, P105)
+
+p5 v2 **can** render WEBGL to an `OffscreenCanvas` in a worker — given a small,
+fixed DOM shim installed **before** the import (`hostP5Worker.ts:293`,
+`installWorkerDomShim`). The shim has six conditions; the load-bearing ones:
+
+1. **shim before import** — `installWorkerDomShim` runs before `await import('p5')`
+   (`hostP5Worker.ts:293`);
+3. **`disableFriendlyErrors = true`** — p5's FES reads `location`/`document.lang`
+   at import; disabling it sidesteps the i18n path (`hostP5Worker.ts:296`);
+5. **a fresh wrapped `OffscreenCanvas` per `createElement('canvas')`**
+   (`hostP5Worker.ts:293`, `makeCanvasEl`) — all worker-local, since we blit
+   rather than transfer.
+
+<Aside type="caution" title="A library's worker-DOM shim is BUILD-specific (P105)">
+The shim surface a prebuilt/minified POC needs can differ from the **bundled prod
+build** — the Next-bundled p5 re-runs i18next FES code that reads
+`location.search` / `documentElement.lang` at import. Harden the shim against the
+build that actually ships, not the POC min. The `@stave/editor/worker` subpath +
+DI + `app new Worker(new URL(...))` wiring exists for exactly this reason.
+</Aside>
+
+## The audio + signal feed
+
+The compiler reads `stave.analyser` / `stave.scheduler` off ref cells
+(`hostP5Worker.ts:304`) — the **same** contract `P5VizRenderer` uses on the main
+thread, so the sketch can't tell it's in a worker. The named-signal `u.*` bus is
+built with `buildStaveUniforms(feed.bus)` (`hostP5Worker.ts:300`); the bus is
+ticked once by `feed.applyFrame` (PK22), and `onTick`/`__tick` is a no-op so the
+sketch never double-ticks. Raw `hapStream` access isn't marshalled (no built-in
+needs it) → `null`.
+
+## Draw cadence — host-driven `redraw()`, p5 on `noLoop()`
+
+After the user's `setup()` runs, the host wraps it to call `p.noLoop()`
+(`hostP5Worker.ts:330`) so p5's auto-loop is off and **we** drive one
+`inst.redraw()` per frame (`hostP5Worker.ts:355`) — 1:1 with the host's signal
+frame (PK22). `setupDone()` flips `true` only after that wrapped setup runs
+(`hostP5Worker.ts:334`), so the contract gate holds frames until p5's async setup
+completes.
+
+## The density LOD lever (#232 / #269)
+
+For CPU-tessellated line meshes, frame cost is **linear in segment count** and
+almost nothing else — p5 builds quad geometry per thick-line segment on the CPU.
+That makes `u.density` the one effective quality lever (a sketch reads
+`u.density` to scale its segment/grid count). It crosses the worker boundary in
+the marshalled config subset (`density` ∈ `WORKER_VIZ_CONFIG_KEYS`,
+`vizConfig.ts:353`), applied with **merge** at mount and on every quality change
+— no remount.
+
+<Aside type="tip" title="Resolution doesn't help line meshes; density does">
+Lower resolution / smaller canvas has *no effect* on a CPU-tessellation-bound line
+mesh — that cost is CPU, not pixels (the inverse of hydra's GPU-fill case, P117).
+`density` does move `viz.worker.draw` because it changes how many segments p5
+tessellates (`viz-density-lod.spec.ts`). The user-facing version of this budget is
+[Writing fast viz sketches](/guides/viz-performance/).
+</Aside>
+
+## The five strategy members for p5
+
+| Member | p5 implementation | Where |
+| --- | --- | --- |
+| `setupDone()` | `true` after the wrapped `setup()` runs (async) | `hostP5Worker.ts:350` |
+| `draw()` | `inst.redraw()` then blit the render canvas → presenting canvas | `hostP5Worker.ts:354` |
+| `resizeKind(w,h,dpr)` | resize the presenting canvas (×dpr) + `inst.resizeCanvas(w,h)` | `hostP5Worker.ts:367` |
+| `teardown()` | neutralize p5's async `#_setup` chain so a destroy mid-flight can't paint | `hostP5Worker.ts:374` |
+| `gl?()` | `inst.drawingContext` — WEBGL context, or a 2D context whose `getExtension` yields null (not accounted) | `hostP5Worker.ts:353` |
+
+## Gotcha — a user `draw()` throw is double-swallowed (P114, #257)
+
+A `draw()` typo in the worker (e.g. `stave.fft.length` — wrong namespace) gives a
+silent blank canvas: no console error, no diag, only the first draw statement
+painted. The obvious hypothesis ("the host's `try { s.draw() } catch` reports it")
+is wrong **twice**:
+
+1. **Upstream catch beats the host catch.** `p5Compiler` wraps each user lifecycle
+   hook in its *own* try/catch that reports to `engineLog` and swallows the throw
+   — so it never reaches the host's `s.draw()` catch. (And p5's `redraw()` is
+   `async`, so even unwrapped the throw is a rejected promise the *synchronous*
+   host catch can't see.)
+2. **A module singleton doesn't cross the worker boundary.** That wrap reported to
+   `engineLog` — but `engineLog` is a module-level pub/sub, and the **worker
+   bundle has its own instance**, disconnected from the main `engineLog` that
+   feeds the Console. "It's reported" was true *in the worker*, invisible on main.
+
+<Aside type="caution" title="The fix: re-emit across the boundary, and split the channels (#257)">
+The worker subscribes to its local `engineLog` and posts each error across to the
+main `emitLog` (`vizlog`). Crucially the channels are separate: **fatal/mount**
+errors → `diag`→`onError`→fallback (tear the worker down); **runtime** draw/setup
+errors → `vizlog`→main `emitLog` (surface, do **not** fall back — a post-`ready`
+user typo must not kill the worker). Verified by `worker-draw-error.spec.ts` (one
+error surfaced, no fallback). This is the P105 family — a per-thread channel is
+invisible until explicitly bridged (PV83).
+</Aside>
+
+**Verified by** `worker-draw-error.spec.ts` (#257 user-throw surfacing),
+`viz-density-lod.spec.ts` (#232 density moves the cost curve, no remount), and the
+p5 worker-path coverage gates.

--- a/packages/docs/src/content/docs/architecture/renderer-contract.mdx
+++ b/packages/docs/src/content/docs/architecture/renderer-contract.mdx
@@ -401,14 +401,42 @@ Everything in [The kind-agnostic seams](#the-kind-agnostic-seams) — backpressu
 fallback, profiler bridge, config marshal, visibility, GL accounting — then
 applies automatically.
 
-<Aside type="tip" title="The GLSL renderer is the proof">
-The next renderer added against this contract is a single-pass GLSL/ShaderToy
-renderer (raw WebGL2, fullscreen quad + fragment shader, Tier-1 direct-to-canvas,
-zero library). It is deliberately the *simplest possible* instance — if it slots
-into the seams above with **no new seam**, the contract is genuinely
-engine-agnostic (proven, not just claimed). If it needs a new seam, that gap is a
-finding: it gets catalogued and this chapter is amended. Either way the docs and
-the code close the loop. The audio-feed seam (hydra downsamples the master
-analyser bytes; p5 reads the named-signal bus; GLSL will upload `u.fft` to a
-texture) is the most likely place the contract needs generalizing — watch it.
+The three kinds that exist each have their own developer chapter detailing how
+they fill in the contract:
+[GLSL](/architecture/glsl/) (the Tier-1 zero-library reference),
+[Hydra](/architecture/hydra/) (Tier-1, library), and
+[p5.js](/architecture/p5/) (Tier-2 blit, the hardest case).
+
+## Validated by the GLSL renderer
+
+This chapter was written **before** the GLSL renderer existed — as a spec, to be
+tested. The test: implement the *simplest possible* kind (single-pass GLSL/
+ShaderToy — raw WebGL2, fullscreen triangle + fragment shader, Tier-1
+direct-to-canvas, zero library) against the contract and see whether it slots in
+with **no new shared seam**, or exposes a gap. It slotted in. The result (PV87,
+PK31 OUTCOME):
+
+- **All five `RendererStrategy` members + all seven kind-agnostic seams were
+  satisfied with zero change to the shared host.** A new worker renderer really
+  is *just* a new strategy. GLSL's `gl()` is the most trivial of the three (the
+  raw context it created); `setupDone()` is synchronous; and because a GPU
+  `draw()` runs no per-frame user JS, the #257 draw-error seam is satisfied with
+  nothing to catch.
+- **The audio-feed seam — flagged above as the most likely place to need
+  generalizing — held.** `mountGLSL` reads the **same** already-refreshed
+  `rawAnalyser` hydra reads and uploads it to an `iChannel0` texture *internally*
+  (`hostP5Worker.ts:517`). The kind-agnostic `AudioByteSource` interface
+  (`glslCore.ts:32`) covered it; no host change.
+
+<Aside type="note" title="The one new thing was kind-specific, not shared (PV87 addendum)">
+The GLSL renderer also added **pattern-event uniforms** (`uKick`, `uSnare`, …,
+#284) — turning named-signal-bus values into shader uniforms. This is genuinely
+new work, but it lives **entirely inside the strategy's `draw()`**
+(`readGLSLEvents`, `glslEvents.ts:21`), exactly like p5's blit or hydra's
+`s.a.fft` fill. It is a *kind-specific marshal*, **not** a new shared-host seam —
+sourced from data the host already prepares (the ticked `feed.bus`). So the
+generalization the contract anticipated turned out to be the right shape: the
+shared seam is "the host hands you refreshed feeds and calls `draw()` once"; what
+each kind *does* with those feeds is its own business. Contract confirmed, not
+amended. See [Renderer: GLSL](/architecture/glsl/) for the detail.
 </Aside>

--- a/packages/docs/src/content/docs/guides/using-visualizers.md
+++ b/packages/docs/src/content/docs/guides/using-visualizers.md
@@ -1,0 +1,92 @@
+---
+title: Using visualizers
+description: Attach a visual to your music, tune its quality and resolution, let off-screen viz pause to save battery, and fix a blank or laggy canvas.
+---
+
+Stave can draw a live visual that reacts to your music — a spectrum, a shader, a
+piano roll, or your own sketch. This guide covers attaching one and tuning it. For
+writing a *fast* sketch, see [Writing fast viz sketches](/guides/viz-performance/).
+
+## Attach a visual with `.viz()`
+
+Add `.viz('name')` to any pattern. The visual appears inline, right under the
+pattern, and lights up as that pattern plays:
+
+```js
+sound("bd sd bd sd").viz('spectrum')   // a built-in spectrum
+sound("bd*4").viz('creation')          // a GPU shader
+note("c e g b").viz('pianoroll')       // a piano roll of the notes
+```
+
+The name matches a built-in visual or any of your own viz files
+(case-insensitive, ignoring spaces / dashes / underscores — so `Piano Roll.p5`
+matches `.viz('pianoroll')`). Each runtime has its own page:
+[p5.js](/runtimes/p5/), [Hydra](/runtimes/hydra/),
+[GLSL / ShaderToy](/runtimes/glsl/).
+
+Only the pattern you attach to drives the visual, so two patterns can carry two
+different visuals at once.
+
+## Quality and resolution
+
+Open **Settings** (the gear) → the viz rows. Two controls trade smoothness for
+detail:
+
+- **Viz quality** — **High**, **Balanced**, or **Performance**. This scales both
+  the render resolution *and*, for sketches that support it, their drawing density
+  (how much detail they draw). Drop to **Performance** if visuals stutter or the
+  fans spin up; it's the one knob that helps every viz type.
+- **Inline viz res** — the exact backing resolution for inline visuals
+  (256–1024 px, or a custom value). Higher is crisper but costs more **fill**.
+  This helps shader- and fill-heavy visuals; it makes little difference to
+  line-drawing sketches (those are limited by how many lines they draw, not
+  pixels — that's what *quality*'s density does).
+
+The resolution is independent of the on-screen size — a visual renders at the
+chosen resolution and stretches to fit its panel, keeping its shape.
+
+## Save battery: off-screen pause
+
+A visual you can't see isn't worth spending power on, so Stave **pauses** any
+visual that scrolls off-screen, sits in a collapsed panel, or is in a hidden
+browser tab — and resumes it the moment it's visible again. It comes back exactly
+where it left off; you don't need to do anything.
+
+For a visual left off-screen a long time, the **Off-screen viz teardown** setting
+(on by default) goes further and *frees its memory and GPU context* after ~60s,
+re-creating it when you scroll back. Turn it off if you'd rather visuals stay
+instantly resident at the cost of more memory.
+
+<aside>
+Audio keeps playing while a tab is in the background — but only while the tab is
+**making sound**. A long fully-silent stretch in a hidden tab can let the browser
+throttle timing; keep the tab audible (or foreground) across silent sections.
+</aside>
+
+## Troubleshooting
+
+**The canvas is blank.**
+- If it's a custom sketch, check the **Console** panel for an error — a typo in
+  `draw()` / `setup()` surfaces there (for p5). A shader that won't compile shows
+  its error and falls back to a safe path.
+- Make sure the pattern is actually playing — a visual attached to a stopped or
+  silent pattern has nothing to react to.
+- For a standalone preview (a viz file opened in its own tab, not attached via
+  `.viz()`), `stave.scheduler` / `stave.analyser` are empty by design — guard with
+  `if (stave.scheduler) { … }`.
+
+**It lags or stutters.**
+- Set **Viz quality** to **Performance**.
+- Lower **Inline viz res** if it's a shader or fill-heavy visual.
+- If it's a line-mesh sketch, the fix is drawing *fewer segments* — see
+  [Writing fast viz sketches](/guides/viz-performance/).
+- Watch the audio: if playback gets choppy when a visual is on screen, that visual
+  is too heavy for your machine — drop quality until audio is steady again.
+
+**It feels low-fps but audio is fine.** That's usually intended — an off-screen or
+background visual is paused, and on-screen ones are paced to their true draw rate.
+Open the **performance overlay** (`Alt+P`) to see real frame timing.
+
+**Check what's costing what.** `Alt+P` opens the performance overlay: frame p95,
+long-tasks, and the per-visual draw cost. It's the honest source of truth when a
+visual feels slow.

--- a/packages/docs/src/content/docs/runtimes/glsl.mdx
+++ b/packages/docs/src/content/docs/runtimes/glsl.mdx
@@ -1,0 +1,105 @@
+---
+title: GLSL / ShaderToy
+description: Run GPU fragment shaders as Stave visualizers — audio-reactive plasma, spectrum bars, and pattern-event shaders, attached to any pattern with .viz().
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+Stave runs **single-pass fragment shaders** as visualizers — the same kind of
+shader you'd write on [ShaderToy](https://www.shadertoy.com). They're the
+lightest, fastest visual option: pure GPU, no library. Four are built in, and
+each reacts to your music.
+
+## The built-in shaders
+
+Attach any of these to a pattern with `.viz('…')`:
+
+| `.viz('…')` | What you see | Reacts to |
+| --- | --- | --- |
+| `glsl` | audio-reactive plasma with a waveform line | the spectrum (bass warps + brightens, treble sparkles) |
+| `spectrum:glsl` | classic FFT spectrum bars | each column = one frequency bin |
+| `creation` | the iconic "Creation" shader, made audio-reactive | bass drives the zoom + glow, treble ripples |
+| `pulse` | a red flash on every kick, blue rings on snare | **pattern events**, not the raw spectrum |
+
+```js
+// Attach a shader to a pattern — it lights up as the pattern plays.
+sound("bd sd bd sd").viz('creation')
+
+// 'pulse' reacts to the individual drums, not just the mixed sound:
+sound("bd*4, ~ sd ~ sd, hh*8").viz('pulse')
+```
+
+<Aside type="tip">
+Shaders run on the GPU and barely touch your CPU, so they're a great choice when
+you want a rich full-screen backdrop without slowing the audio. See
+[Writing fast viz sketches](/guides/viz-performance/) for when each viz type costs
+what.
+</Aside>
+
+## What a shader can read
+
+The built-in shaders react to your music through a few inputs. If you're reading
+or learning from them, here's what each name means.
+
+### The audio texture — `iChannel0`
+
+The live audio is uploaded every frame to `iChannel0`, exactly as on ShaderToy:
+
+- **row 0** (`texture(iChannel0, vec2(x, 0.0)).x`) — the **FFT spectrum**
+  (`x` from 0 = low frequencies to 1 = high);
+- **row 1** (`texture(iChannel0, vec2(x, 1.0)).x`) — the **waveform**.
+
+```glsl
+float bass   = texture(iChannel0, vec2(0.03, 0.0)).x;  // low FFT bin
+float treble = texture(iChannel0, vec2(0.70, 0.0)).x;  // high FFT bin
+```
+
+### Pattern events — the `u*` uniforms
+
+Beyond the mixed spectrum, a shader can react to the **individual drums and
+dynamics** of the pattern through these `float` uniforms (all `0.0`–`1.0`):
+
+| Uniform | Fires on |
+| --- | --- |
+| `uKick` `uSnare` `uHat` `uOpenHat` `uClap` `uRim` `uTom` | that drum hitting (envelope level) |
+| `uVelocity` | the loudest current hit — a general "something just played" |
+| `uRms` | overall loudness |
+| `uBass` `uMid` `uTreble` | energy in each band |
+
+```glsl
+// A kick punches the screen red:
+col += vec3(1.0, 0.2, 0.15) * uKick;
+```
+
+This is why `pulse` reacts to each drum separately while `glsl` reacts to the
+overall sound — `pulse` reads `uKick`/`uSnare`/`uHat`, `glsl` reads `iChannel0`.
+
+### The standard uniforms
+
+`iResolution` (viewport size), `iTime` (seconds since the viz started), and
+`iMouse` — the usual ShaderToy set, so a shader animates on its own even in
+silence.
+
+## Two shader styles
+
+Stave accepts both conventions, and figures out which you wrote:
+
+- **ShaderToy style** — write `void mainImage(out vec4 fragColor, in vec2
+  fragCoord)`; Stave supplies the rest. Paste most single-pass ShaderToy shaders
+  as-is.
+- **Raw GLSL style** — write your own `void main()` and `out` color; Stave only
+  prepends the version, precision, and the uniforms above.
+
+<Aside type="caution">
+Don't write *both* a `mainImage` and a `main` (Stave will ask you to pick one),
+and don't redeclare the built-in uniforms — they're already provided, the same as
+on ShaderToy. v1 is **single-pass only**: no multi-buffer / feedback / cubemap /
+mic channels yet.
+</Aside>
+
+<Aside type="note" title="Custom shader files are coming">
+Today GLSL ships as the four built-in visuals above. A dedicated editor for your
+own `.glsl` shader files — with syntax highlighting and a live preview — is on the
+way. Until then, p5.js and Hydra are the runtimes for fully custom visuals (see
+[p5.js](/runtimes/p5/) and [Hydra](/runtimes/hydra/)).
+</Aside>

--- a/packages/docs/src/content/docs/runtimes/glsl.mdx
+++ b/packages/docs/src/content/docs/runtimes/glsl.mdx
@@ -97,9 +97,16 @@ on ShaderToy. v1 is **single-pass only**: no multi-buffer / feedback / cubemap /
 mic channels yet.
 </Aside>
 
-<Aside type="note" title="Custom shader files are coming">
-Today GLSL ships as the four built-in visuals above. A dedicated editor for your
-own `.glsl` shader files — with syntax highlighting and a live preview — is on the
-way. Until then, p5.js and Hydra are the runtimes for fully custom visuals (see
-[p5.js](/runtimes/p5/) and [Hydra](/runtimes/hydra/)).
-</Aside>
+## Write your own
+
+Beyond the built-ins, you can author your own shaders as `.glsl` files:
+
+1. In the file tree, **New file** → name it `something.glsl`.
+2. Paste a ShaderToy `mainImage` (or write a raw `void main()`). You get GLSL
+   syntax highlighting and a **live preview** that recompiles as you type.
+3. Attach it to a pattern with `.viz('something')`, exactly like the built-ins.
+
+A `.glsl` file reads the same uniforms documented above — `iChannel0` for the
+spectrum/waveform and `uKick`/`uSnare`/… for pattern events — so your shader is
+audio- and event-reactive with no extra wiring. New projects ship two examples to
+start from: **Prism** and **Pulse Grid**.


### PR DESCRIPTION
Continues the viz-performance docs arc (after #280 STEP 1 contract chapter and #282 STEP 2 GLSL renderer). Closes #285.

## What's here (STEP 3 + 4 + 5, one docs PR)

**STEP 3 — engine-specific developer chapters** (`architecture/`), every behavioral claim grounded `file:line` in `packages/editor/src/visualizers/`:
- **`architecture/glsl.mdx`** — the Tier-1, zero-library reference / perf floor. One shared `glslCore` driving both hosts (PV56); dual mode (ShaderToy `mainImage` + raw `void main`, #283); the `iChannel0` audio texture (row0 FFT / row1 wave); the `u*` pattern-event uniforms (#284); the five strategy members; why a GPU `draw()` satisfies #257 for free.
- **`architecture/hydra.mdx`** — Tier-1 direct (PV73), the `s.a.fft` bridge, host-driven `tick()`. Gotchas: **P116** (hydra swallows user reactive-fn throws → #257 is p5-only for user code) and **P117** (resolution-independent dispatch cost — don't mirror p5's density assertion).
- **`architecture/p5.mdx`** — Tier-2 blit, the 6-condition worker DOM shim (PV70 / **P105**), the `density` LOD lever (#232 / #269), and the double-swallowed user-throw (**P114** / #257).

**Contract amendment** — `renderer-contract.mdx` gains a **"Validated by the GLSL renderer"** section that turns the chapter's prediction into the proven result: all seven kind-agnostic seams satisfied with **zero new shared seam**; the event feed is a *kind-specific marshal*, not a shared-host change (PV87 + addendum, PK31 OUTCOME). Closes the deductive loop the contract promised on paper.

**STEP 4 — user docs**
- **`runtimes/glsl.mdx`** — the four built-in shaders via `.viz('glsl'|'spectrum:glsl'|'creation'|'pulse')`, what `iChannel0` and the `u*` uniforms react to, the two shader styles, and an honest note that custom `.glsl`-file authoring is upcoming (it's the deferred surface — verified not wired).
- **`guides/using-visualizers.md`** — attach with `.viz()`, quality/resolution settings, off-screen pause, troubleshooting (blank / lag / fps).

**STEP 5 — sidebar** — `astro.config.mjs`: Architecture gains the three chapters; Runtimes gains GLSL.

## Observation (Lokāyata)
`STAVE_DOCS_BASE=/ pnpm --filter @stave/docs build` → **20 pages built**, observed in the rendered HTML:
- all five new pages carry real content (asides, tables, `file:line` cites);
- the `#validated-by-the-glsl-renderer` anchor exists and the GLSL chapter's link to it resolves;
- the Architecture page links to all three engine chapters; sidebar lists every new entry;
- internal cross-links (`/architecture/glsl/`, `/runtimes/glsl/`, `/guides/viz-performance/`, `/guides/using-visualizers/`) point at real routes.

## Deferred (tracked, not in this PR)
- Per-track `u.track('drums')` → GLSL data-texture.
- `compiledVizProvider.tsx:116` renderer-union widen for a GLSL *backdrop* + the `.glsl`-file editing surface (Monaco language + preview provider + seeding).
- `packages/app/public/docs/` built output + Next `/docs` serving glue (deployment, later arc step).