### PR TITLE
🐛 Register .glsl files as named viz — fixes inline .viz() for GLSL

### DIFF
--- a/packages/app/src/components/StrudelEditorClient.tsx
+++ b/packages/app/src/components/StrudelEditorClient.tsx
@@ -247,7 +247,10 @@ export default function StrudelEditorClient({
     const viewing = isViewing();
     const allFiles = listWorkspaceFiles();
     const vizFiles = allFiles.filter(
-      (f) => f.language === "p5js" || f.language === "hydra",
+      (f) =>
+        f.language === "p5js" ||
+        f.language === "hydra" ||
+        f.language === "glsl",
     );
     // Basename (sans extension) of every p5 viz file. When a hydra file
     // shares a basename with a p5 file (e.g. scope.p5 + scope.hydra), the
@@ -289,9 +292,12 @@ export default function StrudelEditorClient({
         ? { ...effective0, nativeSize: bundledNative }
         : effective0;
       const base = baseOf(f.path);
+      // A non-p5 file sharing a basename with a p5 file registers under a
+      // renderer-qualified name (`<name>:hydra` / `<name>:glsl`) so bare
+      // `.viz("<name>")` deterministically resolves to the p5 preset (#181).
       const name =
-        f.language === "hydra" && p5Basenames.has(base)
-          ? `${base}:hydra`
+        f.language !== "p5js" && p5Basenames.has(base)
+          ? `${base}:${f.language === "hydra" ? "hydra" : "glsl"}`
           : preset.name;
       registerPresetAsNamedViz(effective, name);
     }


### PR DESCRIPTION
`registerAllVizFiles` (StrudelEditorClient) filtered viz files to `p5js|hydra` only, so a seeded/user `.glsl` was never registered as a named viz → inline `.viz("Prism")` resolved to nothing and mounted no renderer (the user-reported 'can't use glsl sketch as inline viz', after the importScripts/stale-chunk issue was cleared).

Fix: add `glsl` to the filter + extend the basename-collision disambiguation (`<name>:glsl`, mirroring `:hydra`).

**Observed** (headed, real GPU): `.viz("Prism")` mounts a worker GLSL viz — `viz.worker:1`, `viz.glsl:0` (no fallback), `viz.glctx:1`, **234 draw frames**, 0 console/network errors; screenshot shows the audio-reactive Prism painting. The last missed per-renderer site from the #287 authoring surface.