### PR TITLE
🐛 fix(test): bump defaultDescriptors count 11→15 + assert GLSL ids

### DIFF
--- a/packages/editor/src/__tests__/defaultDescriptors.test.ts
+++ b/packages/editor/src/__tests__/defaultDescriptors.test.ts
@@ -6,8 +6,8 @@ vi.mock('p5', () => ({ default: vi.fn() }))
 import { DEFAULT_VIZ_DESCRIPTORS } from '../visualizers/defaultDescriptors'
 
 describe('DEFAULT_VIZ_DESCRIPTORS', () => {
-  it('has exactly 11 entries', () => {
-    expect(DEFAULT_VIZ_DESCRIPTORS).toHaveLength(11)
+  it('has exactly 15 entries', () => {
+    expect(DEFAULT_VIZ_DESCRIPTORS).toHaveLength(15)
   })
 
   it('each entry has id, label, and factory', () => {
@@ -35,6 +35,11 @@ describe('DEFAULT_VIZ_DESCRIPTORS', () => {
     expect(ids).toContain('pianoroll:hydra')
     expect(ids).toContain('scope:hydra')
     expect(ids).toContain('kaleidoscope:hydra')
+    // glsl renderers (#281/#287)
+    expect(ids).toContain('glsl')
+    expect(ids).toContain('spectrum:glsl')
+    expect(ids).toContain('creation')
+    expect(ids).toContain('pulse')
   })
 
   it('factory returns a VizRenderer with all 5 methods', () => {


### PR DESCRIPTION
## Problem

`packages/editor/src/__tests__/defaultDescriptors.test.ts` asserted `DEFAULT_VIZ_DESCRIPTORS` `.toHaveLength(11)`, but the list grew to **15** when the GLSL arc (#281/#287) added `glsl`, `spectrum:glsl`, `creation`, and `pulse`. The test was **failing on `performance` already**, independent of #293/#294 (the descriptor source wasn't touched by the consolidation).

The `contains the expected ids` check uses `toContain` (subset), so it stayed green — meaning the 4 GLSL ids went **unverified by id**.

## Fix

- Bump the length assertion `11 → 15`.
- Add the 4 GLSL ids to the `contains the expected ids` test, so the count and the named-id list stay in sync — a future descriptor add/remove now trips a named assertion, not just a bare count.

Test-only change; descriptor source untouched.

## Test plan

- `defaultDescriptors.test.ts`: 10/10 green (was 9/10).
- Full editor suite: **1962/1962** across 120 files.

closes #295

🤖 Generated with [Claude Code](https://claude.com/claude-code)