### PR TITLE
docs(viz): update the error-surfacing chapters end-to-end — the p5/hydra/glsl triad

### DIFF
--- a/packages/docs/src/content/docs/architecture/glsl.mdx
+++ b/packages/docs/src/content/docs/architecture/glsl.mdx
@@ -162,15 +162,24 @@ rendering.
 | `teardown()` | `program.dispose()` — delete program, VAO, texture | `hostP5Worker.ts:535` → `glslCore.ts:240` |
 | `gl?()` | re-get the WebGL2 context — **the easiest of all three kinds** (the context we created; no search) | `hostP5Worker.ts:515` |
 
-<Aside type="tip" title="GLSL satisfies #257 for free">
+<Aside type="tip" title="GLSL's draw can't throw — but its compile error is the user error, and it surfaces (#331)">
 Two seams are trivially satisfied by GLSL's nature. (1) `setupDone()` is
 synchronous because compile/link runs at mount — so there's no async-readiness
 dance. (2) `draw()` runs a GPU shader with **no per-frame user JavaScript**, so it
-cannot throw post-mount — the #257 draw-error surfacing seam has nothing to catch
-(`glslCore.ts:18`). The only failure point is shader compile/link, which throws
-at mount (`glslCore.ts:85`, `glslCore.ts:155`) → caught by the host → `onError` →
-`FallbackVizRenderer` degrades to main (#247). Contrast p5 (async setup, `draw()`
-can throw a user typo — P114) and hydra (library swallows user throws — P116).
+cannot throw post-mount — the *runtime* draw-error seam (#257) has nothing to
+catch (`glslCore.ts:18`).
+
+But that doesn't make GLSL error-free — it moves the user error to **mount time**:
+a shader that won't compile/link throws (`glslCore.ts:85`, `glslCore.ts:155`) →
+caught by the host → `onError` → `FallbackVizRenderer` degrades to main (#247),
+where the same shader throws again. That terminal catch in `GLSLVizRenderer` is
+where #331 surfaces it: `emitLog({ runtime: 'glsl', … })` to the main Console,
+and — because a GLSL info log carries a `0:N` line — it maps that line back through
+the wrapper preamble (`glslFragmentErrorUserLine`) to the user's **editor line**.
+So GLSL is the *only* runtime whose surfaced error lights an editor squiggle (p5
+has lines too; hydra can't — no line for a code-string reactive fn). The error-
+surfacing triad: p5 (`draw()` typo, #257), hydra (library-swallowed, re-surfaced
+#275), GLSL (mount-time compile, #331) — each swallows differently, each surfaces.
 </Aside>
 
 ## GL-context release (#266 hygiene)

--- a/packages/docs/src/content/docs/architecture/hydra.mdx
+++ b/packages/docs/src/content/docs/architecture/hydra.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Renderer: Hydra'
-description: How the Hydra renderer satisfies the viz contract — Tier-1 direct-to-canvas, the s.a.fft audio bridge, host-driven tick(), and the library-swallowed-error and GPU-async-dispatch gotchas.
+description: How the Hydra renderer satisfies the viz contract — Tier-1 direct-to-canvas, the s.a.fft audio bridge, host-driven tick(), and the library-swallowed-error (re-surfaced) and GPU-async-dispatch gotchas.
 ---
 
 import { Aside } from '@astrojs/starlight/components';
@@ -76,27 +76,38 @@ serialized across the worker boundary, so they're deferred to the main-thread
 path for now. A `.hydra` *file* (a string) routes through the worker fine.
 </Aside>
 
-## Gotcha 1 — hydra swallows user errors (#257 is p5-only for user code, P116)
+## Gotcha 1 — hydra swallows user errors *inside the library* — Stave re-surfaces them (#275)
 
 A p5 `draw()` typo surfaces in the Stave Console (#257). The hydra equivalent — a
-reactive arrow that throws, e.g. `.rotate(() => { throw … })` — **does not**.
+reactive arrow that throws, e.g. `.rotate(() => { throw … })` — does **not** reach
+the host's draw catch on its own, because `hydra-synth` wraps every reactive-fn
+uniform evaluation in its own try/catch (`format-arguments.js:82`:
+`catch (e) { console.warn('ERROR', e); return input.default }`). The throw is
+caught *inside hydra*, logged to `console.warn`, and the uniform falls back to its
+default — so it never propagates out of `hydra.tick()`, never reaches the host's
+shared `s.draw()` catch (`hostP5Worker.ts`), never re-emits via `vizlog`. The host
+catch only fires for **engine-level** throws (regl / GL / context-lost), which a
+viz code string can't deterministically induce.
 
-`hydra-synth` wraps every reactive-fn uniform evaluation in its own try/catch
-(`format-arguments.js:72`: `catch (e) { console.warn('ERROR', e); return
-input.default }`). The throw is caught *inside hydra*, logged to `console.warn`
-(not Stave's `engineLog`), and the uniform falls back to its default — so it never
-propagates out of `hydra.tick()`, never reaches the host's shared `s.draw()` catch
-(`hostP5Worker.ts:519`), never re-emits via `vizlog`. The host catch is correct
-but only fires for **engine-level** throws (regl / GL / context-lost), which a viz
-code string can't deterministically induce.
+**The fix (#275):** rather than fight the library, Stave patches the worker's
+`console.warn` once — while a hydra sketch is live (`currentRuntimeRef.kind ===
+'hydra'`), it recognises hydra's two user-error markers (`'ERROR'` → error,
+`'function does not return a number'` → warn), re-emits them through the same
+deduped `postVizLog` → `vizlog` → main `emitLog` path a p5 typo uses, then always
+delegates to the real `console.warn` so devtools keeps the original. Gated on
+kind + the exact marker, so p5/other warns and hydra/regl internals pass through
+untouched. A hydra typo now appears in the Console just like a p5 one — the only
+difference is no source line (hydra gives no line for a code-string reactive fn;
+GLSL does — see [the GLSL chapter](/architecture/glsl/)).
 
 <Aside type="caution" title="Before asserting 'X surfaces an error,' check who swallows it first">
-This was a doc-comment inference (the #257 comment implied parity across kinds).
-The detection rule: grep the runtime library's arg/uniform eval for a try/catch
-before claiming an error surfaces. Characterized in `hydra-path-coverage.spec.ts`
-(b) — a throwing hydra reactive fn yields `engineLog` errors === 0, no fallback,
-worker stays live. (A throw on **frame 1** never reaches `ready` → that's the
-#247 *fallback* path, different again.)
+The original #257 comment *implied* parity across kinds — an inference that
+observation disproved (a probe showed hydra's `engineLog` errors === 0). The
+detection rule that found the real gap: grep the runtime library's arg/uniform
+eval for a try/catch before claiming an error surfaces. `hydra-path-coverage.spec.ts`
+(b) now **asserts the fix**: a clean sketch surfaces 0 (no over-capture), a throwing
+reactive fn surfaces ≥1 carrying its thrown text end-to-end. (A throw on **frame 1**
+never reaches `ready` → that's the #247 *fallback* path, different again.)
 </Aside>
 
 ## Gotcha 2 — resolution doesn't move `viz.worker.draw` (P117)
@@ -118,6 +129,6 @@ across res in `hydra-path-coverage.spec.ts` (c).
 </Aside>
 
 **Verified by** `hydra-path-coverage.spec.ts` (the worker `gl()` accessor → #266,
-kind-agnostic `s.draw()` timing → #230, the P116 swallow, the P117 flat-cost) and
+kind-agnostic `s.draw()` timing → #230, the #275 error re-surfacing, the P117 flat-cost) and
 `hydra-visual-gate.spec.ts` (the worker canvas actually paints, audio-reactive —
 PV86).

--- a/packages/docs/src/content/docs/architecture/p5.mdx
+++ b/packages/docs/src/content/docs/architecture/p5.mdx
@@ -150,6 +150,15 @@ error surfaced, no fallback). This is the P105 family — a per-thread channel i
 invisible until explicitly bridged (PV83).
 </Aside>
 
+<Aside type="note" title="p5 was the first leg of the error-surfacing triad">
+This `vizlog` re-emit is the *original* of a pattern every runtime now follows:
+each one swallows user errors differently, so each gets its own surfacing hook to
+the same Console. The siblings caught up — hydra ([#275](/architecture/hydra/),
+its library swallows reactive-fn throws) and GLSL ([#331](/architecture/glsl/), a
+mount-time compile error, surfaced *with* an editor line). The cross-runtime
+invariant is in the [renderer contract](/architecture/renderer-contract/).
+</Aside>
+
 **Verified by** `worker-draw-error.spec.ts` (#257 user-throw surfacing),
 `viz-density-lod.spec.ts` (#232 density moves the cost curve, no remount), and the
 p5 worker-path coverage gates.

--- a/packages/docs/src/content/docs/architecture/renderer-contract.mdx
+++ b/packages/docs/src/content/docs/architecture/renderer-contract.mdx
@@ -462,7 +462,8 @@ This is the spec. To add a renderer kind to the worker host, provide a
 2. **`draw()`** — render **exactly one** frame from the already-refreshed shims.
    Read audio from `rawAnalyser` / the named-signal bus; do **not** tick the bus
    (PK22). May throw — the host catches, re-emits to the main log (#257,
-   `hostP5Worker.ts:519`), and suppresses `ready`.
+   `hostP5Worker.ts`), and suppresses `ready`. This host catch is necessary but
+   **not sufficient** — see [the error-surfacing obligation](#error-surfacing-is-a-per-runtime-obligation).
 3. **`resizeKind(w, h, dpr)`** — apply a new size to the renderer and the
    presenting canvas. Tier-1 sizes the transferred canvas directly; Tier-2 sizes
    its blit target.
@@ -481,6 +482,33 @@ they fill in the contract:
 [GLSL](/architecture/glsl/) (the Tier-1 zero-library reference),
 [Hydra](/architecture/hydra/) (Tier-1, library), and
 [p5.js](/architecture/p5/) (Tier-2 blit, the hardest case).
+
+### Error-surfacing is a per-runtime obligation
+
+A user-authored sketch error — a typo, an undeclared symbol, a wrong API — **must**
+reach the main Console (a `runtime`-tagged `emitLog` entry → Console panel + a
+squiggle where a line is available), not only the devtools console. A blank viz
+with no in-app feedback is the worst authoring experience, and it's the reason the
+host wraps `draw()` at all.
+
+But the host's `draw()` catch is **necessary, not sufficient** — because each
+runtime *swallows* user errors by a different mechanism, at a different point.
+A single shared hook can't cover them; each kind needs its own, verified by
+observation (don't infer "it surfaces" — a probe across all three found the gaps):
+
+| Runtime | What the user error is | How it's swallowed | Where Stave surfaces it |
+| --- | --- | --- | --- |
+| **p5** | a `draw()` / `setup()` throw (runtime) | p5Compiler's lifecycle try/catch → worker-local `engineLog` | `subscribeLog` → `vizlog` → main `emitLog` (#257) |
+| **hydra** | a reactive-fn throw (runtime) | hydra-synth's per-uniform try/catch → `console.warn` + default | patch the worker `console.warn`, re-emit via `vizlog` (#275) |
+| **GLSL** | a shader compile/link failure (**mount-time**) | throws → fallback → main `GLSLVizRenderer` `console.error` | `emitLog` at the terminal compile catch, **with the editor line** (#331) |
+
+GLSL is the only one whose surfaced error carries a source line (its info log has
+`0:N`, mapped back through the wrapper preamble); p5 has lines too; hydra can't
+(no line for a code-string reactive fn). When you add a fourth kind, ask **how does
+*this* runtime hide a user mistake**, and surface it at that point — a clean sketch
+must surface nothing (no over-capture) and a broken one must surface its own error
+end-to-end. Gates: `worker-draw-error.spec.ts` (p5), `hydra-path-coverage.spec.ts`
+(b), `glsl-path-coverage.spec.ts` (c).
 
 ## Validated by the GLSL renderer
 

--- a/packages/docs/src/content/docs/guides/using-visualizers.md
+++ b/packages/docs/src/content/docs/guides/using-visualizers.md
@@ -66,9 +66,13 @@ throttle timing; keep the tab audible (or foreground) across silent sections.
 ## Troubleshooting
 
 **The canvas is blank.**
-- If it's a custom sketch, check the **Console** panel for an error — a typo in
-  `draw()` / `setup()` surfaces there (for p5). A shader that won't compile shows
-  its error and falls back to a safe path.
+- If it's a custom sketch, check the **Console** panel — Stave surfaces sketch
+  errors there for every visual type:
+  - **p5** — a typo in `draw()` / `setup()` shows up (with the line).
+  - **Hydra** — if a reactive function (`() => …`) throws, the message appears and
+    that value defaults so the rest keeps running (no source line — check the text).
+  - **GLSL** — a shader that won't compile shows its error **with the line number**
+    and falls back to a safe path; jump to that line, fix it, re-evaluate.
 - Make sure the pattern is actually playing — a visual attached to a stopped or
   silent pattern has nothing to react to.
 - For a standalone preview (a viz file opened in its own tab, not attached via

--- a/packages/docs/src/content/docs/runtimes/glsl.mdx
+++ b/packages/docs/src/content/docs/runtimes/glsl.mdx
@@ -140,3 +140,11 @@ A `.glsl` file reads the same uniforms documented above — `iChannel0` for the
 spectrum/waveform and `uKick`/`uSnare`/… for pattern events — so your shader is
 audio- and event-reactive with no extra wiring. New projects ship two examples to
 start from: **Prism** and **Pulse Grid**.
+
+## When a shader won't compile
+
+A typo or undeclared variable means the shader can't compile. When that happens the
+GLSL compiler's error shows up in the **Console** panel — **with the line number**,
+so you can jump straight to the offending line in your `.glsl` source (the canvas
+falls back to a safe path meanwhile). Fix it and re-evaluate; the live preview
+recompiles as you type.

--- a/packages/docs/src/content/docs/runtimes/hydra.mdx
+++ b/packages/docs/src/content/docs/runtimes/hydra.mdx
@@ -41,3 +41,11 @@ s.osc(() => 20 + s.a.fft[0] * 80, 0.1, 0)
 ## Full function reference
 
 [Hydra reference](/reference/hydra/) — 65 entries derived from `hydra-synth/src/glsl/glsl-functions.js`.
+
+## When your sketch errors
+
+If a reactive function throws — a typo, a bad property access inside `() => …` — the
+sketch doesn't go black: hydra defaults that value and keeps running, and Stave
+surfaces the error in the **Console** panel so you can see *what* broke. (There's no
+source line for it — hydra evaluates these functions without one — so check the
+Console message rather than looking for an editor squiggle.)


### PR DESCRIPTION
> **Stacked on #332** (GLSL surfacing), which is stacked on #329 (hydra). Merge order: **#329 → #332 → this**. Verify each PR's base retargets to the prior (then to `main`) before merging (stacked base-retarget gotcha).

Documents the behavior shipped in #257 (p5, merged), #275 (hydra, #329) and #331 (GLSL, #332). The renderer docs predated the hydra/GLSL surfacing work, so two chapters described the **old swallowed behavior as a standing limitation**. One coherent pass so the triad reads true end-to-end.

## Files (7)

**Dev / architecture**
- `architecture/hydra.mdx` — flip **Gotcha 1**: a hydra reactive-fn throw used to say "**does not** surface"; now it surfaces via the worker `console.warn` patch (#275). Kept the "check who swallows it first" caution (it's how the gap was found), updated so the (b) gate *asserts* the fix.
- `architecture/glsl.mdx` — amend the "#257 for free" aside: the *runtime* draw still can't throw, but the user error moved to **mount-time compile** — now surfaced to the Console **with the editor line** (#331), the only runtime whose surfaced error carries a line.
- `architecture/p5.mdx` — note p5 was the first leg of the triad; the siblings caught up.
- `architecture/renderer-contract.mdx` — new **"Error-surfacing is a per-runtime obligation"** section: the host `draw()` catch is necessary-but-not-sufficient (each runtime swallows differently), a table of how each hides a user error + where Stave surfaces it, and the rule for a future 4th kind.

**User-facing**
- `runtimes/hydra.mdx` — "When your sketch errors" (defaults + Console, no line).
- `runtimes/glsl.mdx` — "When a shader won't compile" (Console + line + fallback).
- `guides/using-visualizers.md` — troubleshooting "blank canvas" now covers all three runtimes.

## Observed (the end-to-end gate)
`STAVE_DOCS_BASE=/ pnpm --filter @stave/docs build` → **20 pages built**; verified in the rendered HTML: the hydra flip (`re-surfaces them`/`#275`), the glsl `#331` aside (`editor line`), the contract section + its `#error-surfacing-is-a-per-runtime-obligation` anchor, the user notes, and **every added cross-link resolves** (no broken internal links).

_Built `dist`/`public/docs` are artifacts (dist is gitignored; `/docs` serving is the separate #234/#322 thread) — this PR is content sources only._
