### PR TITLE
✨ feat(docs): #322 — serve /docs in prod via a route handler

### DIFF
--- a/packages/app/.gitignore
+++ b/packages/app/.gitignore
@@ -17,6 +17,11 @@
 /.next/
 /out/
 
+# Published by @stave/docs postbuild — generated, do not commit.
+# Served by the /docs/[[...slug]] route handler (kept out of /public so Next's
+# public-static handler doesn't shadow the nested clean-URLs — see #322).
+/docs-dist/
+
 # production
 /build
 

--- a/packages/app/next.config.ts
+++ b/packages/app/next.config.ts
@@ -8,6 +8,14 @@ const nextConfig: NextConfig = {
   // fail with "Module not found: Can't resolve <dynamic>".
   transpilePackages: ["@stave/editor"],
 
+  // #322 — the /docs/[[...slug]] route handler reads the published docs site
+  // (pages + assets) from ./docs-dist at runtime. On Vercel these files are not
+  // on the serverless function's filesystem by default, so trace the whole tree
+  // into the function bundle.
+  outputFileTracingIncludes: {
+    "/docs/[[...slug]]": ["./docs-dist/**/*"],
+  },
+
   // ── Phase B pre-flight Q2 (#237) — cross-origin isolation for SharedArrayBuffer.
   // SAB is the planned per-frame viz-signal transport between the main thread and
   // the OffscreenCanvas worker; it requires `crossOriginIsolated`, which needs
@@ -26,6 +34,23 @@ const nextConfig: NextConfig = {
         ],
       },
     ];
+  },
+
+  // ── #322 — serve the @stave/docs (Astro Starlight) site under /docs.
+  // DEV: the Astro dev server runs on :4321 with the same '/docs/' base — forward
+  // there so the MenuBar Docs button works against live docs without a build step.
+  // PROD: the src/app/docs/[[...slug]] route handler serves the whole site (pages
+  // and assets) from ./docs-dist, so no prod rewrite is needed. The output is kept
+  // out of public/ because Next's public-static handler shadows the nested
+  // directory clean-URLs (verified) — see the route handler for the full why.
+  async rewrites() {
+    if (process.env.NODE_ENV === "development") {
+      return [
+        { source: "/docs", destination: "http://localhost:4321/docs" },
+        { source: "/docs/:path*", destination: "http://localhost:4321/docs/:path*" },
+      ];
+    }
+    return [];
   },
 };
 

--- a/packages/app/next.config.ts
+++ b/packages/app/next.config.ts
@@ -46,7 +46,9 @@ const nextConfig: NextConfig = {
   async rewrites() {
     if (process.env.NODE_ENV === "development") {
       return [
-        { source: "/docs", destination: "http://localhost:4321/docs" },
+        // The Astro dev server (base '/docs/') serves the home page only at the
+        // trailing-slash URL — forward the bare /docs to /docs/ so it resolves.
+        { source: "/docs", destination: "http://localhost:4321/docs/" },
         { source: "/docs/:path*", destination: "http://localhost:4321/docs/:path*" },
       ];
     }

--- a/packages/app/next.config.ts
+++ b/packages/app/next.config.ts
@@ -48,6 +48,12 @@ const nextConfig: NextConfig = {
       return [
         // The Astro dev server (base '/docs/') serves the home page only at the
         // trailing-slash URL — forward the bare /docs to /docs/ so it resolves.
+        // NOTE: this proxies the docs PAGES so the in-app Docs button lands
+        // somewhere in dev, but Astro/Vite serve their dev stylesheets + client
+        // from root-level virtual paths (/@fs, /src, /node_modules/.vite, the HMR
+        // socket) that we deliberately do NOT proxy — chasing them all is fragile.
+        // For fully-styled docs while authoring, open http://localhost:4321/docs/
+        // directly. PROD (the route handler) serves everything correctly.
         { source: "/docs", destination: "http://localhost:4321/docs/" },
         { source: "/docs/:path*", destination: "http://localhost:4321/docs/:path*" },
       ];

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "pnpm --filter @stave/docs build && next build",
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",

--- a/packages/app/src/app/docs/[[...slug]]/__tests__/resolveDocsFile.test.ts
+++ b/packages/app/src/app/docs/[[...slug]]/__tests__/resolveDocsFile.test.ts
@@ -9,7 +9,11 @@ const j = (...p: string[]) => path.join(ROOT, ...p);
 describe("resolveDocsFile (#322 /docs serving)", () => {
   it("maps the root (empty slug) to the index page", () => {
     const r = resolveDocsFile([], ROOT);
-    expect(r).toEqual({ filePath: j("index.html"), contentType: DOCS_MIME[".html"] });
+    expect(r).toEqual({
+      filePath: j("index.html"),
+      contentType: DOCS_MIME[".html"],
+      cacheControl: "public, max-age=0, must-revalidate",
+    });
   });
 
   it("maps an extensionless single-segment slug to <slug>/index.html", () => {
@@ -28,6 +32,7 @@ describe("resolveDocsFile (#322 /docs serving)", () => {
     expect(resolveDocsFile(["_astro", "index.abc.css"], ROOT)).toEqual({
       filePath: j("_astro", "index.abc.css"),
       contentType: DOCS_MIME[".css"],
+      cacheControl: "public, max-age=31536000, immutable",
     });
     expect(resolveDocsFile(["_astro", "page.abc.js"], ROOT)?.contentType).toBe(
       DOCS_MIME[".js"],
@@ -47,6 +52,18 @@ describe("resolveDocsFile (#322 /docs serving)", () => {
     );
     expect(resolveDocsFile(["pagefind", "fragment", "x.pf_fragment"], ROOT)?.contentType).toBe(
       "application/octet-stream",
+    );
+  });
+
+  it("caches content-hashed _astro assets immutably, revalidates everything else", () => {
+    expect(resolveDocsFile(["_astro", "page.abc.js"], ROOT)?.cacheControl).toBe(
+      "public, max-age=31536000, immutable",
+    );
+    expect(resolveDocsFile(["getting-started"], ROOT)?.cacheControl).toBe(
+      "public, max-age=0, must-revalidate",
+    );
+    expect(resolveDocsFile(["pagefind", "pagefind-entry.json"], ROOT)?.cacheControl).toBe(
+      "public, max-age=0, must-revalidate",
     );
   });
 

--- a/packages/app/src/app/docs/[[...slug]]/__tests__/resolveDocsFile.test.ts
+++ b/packages/app/src/app/docs/[[...slug]]/__tests__/resolveDocsFile.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import path from "node:path";
+import { resolveDocsFile, DOCS_MIME } from "../route";
+
+// A fixed absolute root keeps assertions platform-stable.
+const ROOT = path.resolve("/srv/docs-dist");
+const j = (...p: string[]) => path.join(ROOT, ...p);
+
+describe("resolveDocsFile (#322 /docs serving)", () => {
+  it("maps the root (empty slug) to the index page", () => {
+    const r = resolveDocsFile([], ROOT);
+    expect(r).toEqual({ filePath: j("index.html"), contentType: DOCS_MIME[".html"] });
+  });
+
+  it("maps an extensionless single-segment slug to <slug>/index.html", () => {
+    const r = resolveDocsFile(["getting-started"], ROOT);
+    expect(r?.filePath).toBe(j("getting-started", "index.html"));
+    expect(r?.contentType).toBe(DOCS_MIME[".html"]);
+  });
+
+  it("maps a nested page slug to the directory index.html", () => {
+    const r = resolveDocsFile(["architecture", "glsl"], ROOT);
+    expect(r?.filePath).toBe(j("architecture", "glsl", "index.html"));
+    expect(r?.contentType).toBe(DOCS_MIME[".html"]);
+  });
+
+  it("serves an asset (path with extension) verbatim with its mime", () => {
+    expect(resolveDocsFile(["_astro", "index.abc.css"], ROOT)).toEqual({
+      filePath: j("_astro", "index.abc.css"),
+      contentType: DOCS_MIME[".css"],
+    });
+    expect(resolveDocsFile(["_astro", "page.abc.js"], ROOT)?.contentType).toBe(
+      DOCS_MIME[".js"],
+    );
+    expect(resolveDocsFile(["docs-search.json"], ROOT)?.contentType).toBe(
+      DOCS_MIME[".json"],
+    );
+    expect(resolveDocsFile(["sitemap-index.xml"], ROOT)?.contentType).toBe(
+      DOCS_MIME[".xml"],
+    );
+  });
+
+  it("falls back to octet-stream for pagefind binary chunks", () => {
+    // .pagefind (wasm) and .pf_* fragments are not in the mime map.
+    expect(resolveDocsFile(["pagefind", "wasm.unknown.pagefind"], ROOT)?.contentType).toBe(
+      "application/octet-stream",
+    );
+    expect(resolveDocsFile(["pagefind", "fragment", "x.pf_fragment"], ROOT)?.contentType).toBe(
+      "application/octet-stream",
+    );
+  });
+
+  it("rejects `..` traversal out of the docs root", () => {
+    expect(resolveDocsFile(["..", "..", "etc", "passwd"], ROOT)).toBeNull();
+    expect(resolveDocsFile(["..", "next.config.ts"], ROOT)).toBeNull();
+    // a sibling dir that shares the root's prefix must NOT pass the guard
+    expect(resolveDocsFile(["..", "docs-dist-secrets", "x"], ROOT)).toBeNull();
+  });
+});

--- a/packages/app/src/app/docs/[[...slug]]/route.ts
+++ b/packages/app/src/app/docs/[[...slug]]/route.ts
@@ -1,0 +1,95 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+// #322 — serve the @stave/docs (Astro Starlight) static site under /docs.
+//
+// The docs build publishes its output (directory format, base '/docs/') into
+// packages/app/docs-dist — deliberately NOT public/, because Next 16's
+// public-static handler claims the nested directory clean-URLs (each
+// `<page>/index.html` exists) and 404s them before any route or rewrite can
+// serve them (verified against `next build && next start`). Keeping the tree
+// out of public/ lets this handler own all of /docs/*.
+//
+// In dev a next.config rewrite forwards /docs/* to the Astro dev server (:4321)
+// before this handler runs, so the handler is the production path only.
+//
+// docs-dist is traced into this function's bundle via next.config
+// `outputFileTracingIncludes` so readFile resolves on Vercel (where the files
+// are otherwise not on the function filesystem).
+
+const DOCS_ROOT = path.join(process.cwd(), "docs-dist");
+
+// Astro emits a small, fixed set of extensions. Anything not listed (pagefind's
+// .pf_fragment/.pf_index/.pf_meta/.pagefind binary chunks) falls back to
+// octet-stream, which is correct — pagefind fetches those as array buffers.
+export const DOCS_MIME: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".xml": "application/xml; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".txt": "text/plain; charset=utf-8",
+  ".woff2": "font/woff2",
+  ".woff": "font/woff",
+  ".wasm": "application/wasm",
+  ".png": "image/png",
+  ".webp": "image/webp",
+  ".ico": "image/x-icon",
+};
+
+/**
+ * Map a /docs/* request (the catch-all slug segments) to a file under `root`.
+ *
+ * - A slug with a file extension is an asset, served verbatim.
+ * - An extensionless slug is a page; Astro's directory build emits
+ *   `<route>/index.html`, and the root (`/docs`, slug `[]`) is the index.
+ * - Returns null if the resolved path escapes `root` (`..` traversal).
+ *
+ * Pure (no IO) so the traversal guard and page/asset disambiguation are unit
+ * tested without a filesystem.
+ */
+export function resolveDocsFile(
+  slug: string[],
+  root: string,
+): { filePath: string; contentType: string } | null {
+  const rel = slug.join("/");
+  const isAsset = path.extname(rel) !== "";
+  const filePath = isAsset
+    ? path.resolve(root, rel)
+    : path.resolve(root, rel, "index.html");
+
+  // Contain to `root`. The root page resolves to `<root>/index.html`, which
+  // satisfies the prefix guard.
+  if (!filePath.startsWith(root + path.sep)) return null;
+
+  return {
+    filePath,
+    contentType: DOCS_MIME[path.extname(filePath)] ?? "application/octet-stream",
+  };
+}
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ slug?: string[] }> },
+) {
+  const { slug = [] } = await ctx.params;
+  const resolved = resolveDocsFile(slug, DOCS_ROOT);
+  if (!resolved) return new Response("Not found", { status: 404 });
+
+  try {
+    const body = await readFile(resolved.filePath);
+    return new Response(body, {
+      status: 200,
+      headers: {
+        "content-type": resolved.contentType,
+        // Docs are rebuilt and republished on every deploy; revalidate rather
+        // than cache hard so a new deploy is picked up immediately.
+        "cache-control": "public, max-age=0, must-revalidate",
+      },
+    });
+  } catch {
+    return new Response("Not found", { status: 404 });
+  }
+}

--- a/packages/app/src/app/docs/[[...slug]]/route.ts
+++ b/packages/app/src/app/docs/[[...slug]]/route.ts
@@ -53,7 +53,7 @@ export const DOCS_MIME: Record<string, string> = {
 export function resolveDocsFile(
   slug: string[],
   root: string,
-): { filePath: string; contentType: string } | null {
+): { filePath: string; contentType: string; cacheControl: string } | null {
   const rel = slug.join("/");
   const isAsset = path.extname(rel) !== "";
   const filePath = isAsset
@@ -64,9 +64,17 @@ export function resolveDocsFile(
   // satisfies the prefix guard.
   if (!filePath.startsWith(root + path.sep)) return null;
 
+  // `_astro/*` filenames are content-hashed by Astro → cache them immutably.
+  // Everything else (HTML pages, pagefind index/entry, sitemaps) is revalidated
+  // so a new deploy is picked up immediately.
+  const cacheControl = rel.startsWith("_astro/")
+    ? "public, max-age=31536000, immutable"
+    : "public, max-age=0, must-revalidate";
+
   return {
     filePath,
     contentType: DOCS_MIME[path.extname(filePath)] ?? "application/octet-stream",
+    cacheControl,
   };
 }
 
@@ -84,9 +92,7 @@ export async function GET(
       status: 200,
       headers: {
         "content-type": resolved.contentType,
-        // Docs are rebuilt and republished on every deploy; revalidate rather
-        // than cache hard so a new deploy is picked up immediately.
-        "cache-control": "public, max-age=0, must-revalidate",
+        "cache-control": resolved.cacheControl,
       },
     });
   } catch {

--- a/packages/app/src/components/MenuBar.tsx
+++ b/packages/app/src/components/MenuBar.tsx
@@ -220,7 +220,7 @@ export function MenuBar({
           variant="text"
           title="Documentation"
           ariaLabel="Open documentation"
-          onClick={() => { window.location.href = "/docs/"; }}
+          onClick={() => { window.open("/docs/", "_blank", "noopener,noreferrer"); }}
         >
           Docs
         </CornerButton>

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -3,9 +3,10 @@ import starlight from '@astrojs/starlight'
 
 // Deployed at stave.live/docs/ — Astro's `base` makes every generated
 // URL (asset + internal link) include that prefix, so the Next app can
-// serve the built output from `public/docs/` and the dev rewrite can
-// forward `/docs/:path*` to the Astro dev server running with the same
-// base. Override via `STAVE_DOCS_BASE=/` for standalone preview.
+// serve the built output (published to app/docs-dist, served by the
+// /docs/[[...slug]] route handler) and the dev rewrite can forward
+// `/docs/:path*` to the Astro dev server running with the same base.
+// Override via `STAVE_DOCS_BASE=/` for standalone preview.
 const BASE = process.env.STAVE_DOCS_BASE ?? '/docs/'
 
 export default defineConfig({

--- a/packages/docs/scripts/publish-to-app.mjs
+++ b/packages/docs/scripts/publish-to-app.mjs
@@ -1,8 +1,13 @@
 /**
- * Copy the built Astro output into `packages/app/public/docs/` so the
- * Next app serves `/docs/*` statically. Runs as postbuild. In dev a
- * Next rewrite forwards to the Astro dev server instead — this step is
- * only relevant for production builds.
+ * Copy the built Astro output into `packages/app/docs-dist/` so the Next app's
+ * /docs/[[...slug]] route handler serves it. Runs as postbuild. In dev a Next
+ * rewrite forwards to the Astro dev server instead — this step is only relevant
+ * for production builds.
+ *
+ * NOT `public/docs`: Next 16's public-static handler claims the docs' nested
+ * directory clean-URLs (because each `<page>/index.html` exists) and 404s them
+ * before the route handler runs (#322). Keeping the output out of `public/`
+ * lets the route handler own all of `/docs/*`.
  */
 
 import fs from 'node:fs/promises'
@@ -11,7 +16,7 @@ import { fileURLToPath } from 'node:url'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const DIST = path.resolve(__dirname, '../dist')
-const TARGET = path.resolve(__dirname, '../../app/public/docs')
+const TARGET = path.resolve(__dirname, '../../app/docs-dist')
 
 async function rmrf(p) {
   await fs.rm(p, { recursive: true, force: true })


### PR DESCRIPTION
Closes #322. Largely addresses #234 (the docs site now builds in the app pipeline and serves; the viz-performance guide is live at `/docs/guides/viz-performance/`).

## The bug (root cause, all observed via `next build && next start`)
The docs *content* was on `main` but `/docs` 404'd. The stranded serving glue (on `editor-features-and-fixes`) published to `public/docs` and relied on Next's static handler — which **does not work on Next 16**:

- Next's public-static handler claims the docs' nested directory clean-URLs (each `<page>/index.html` exists), 308-redirects `/docs/foo/` → `/docs/foo`, then **404s the bare path** — *before* any rewrite or catch-all route can serve it.
- Only the top-level `/docs` index served; every subpage 404'd.
- A rewrite to a nested `public/.../index.html` resolves against app routes (prerendered `_not-found`), never the file.
- And Vercel never built the docs at all: `vercel.json`'s `--filter=@stave/app` excludes `@stave/docs`, so `public/docs` was never produced in prod.

## The fix — serve the site from a route handler, out of `public/`
- **Build coupling**: app `build` runs `@stave/docs build` first (explicit, ordered, local == Vercel); its postbuild publishes the Astro output.
- **Publish target** `public/docs` → **`docs-dist`** (out of `public/`, so Next can't shadow the clean-URLs); gitignored.
- **`src/app/docs/[[...slug]]/route.ts`** serves pages *and* assets from `docs-dist`: extensionless slug → `<route>/index.html`, asset → verbatim with a small mime map (pagefind binaries → `octet-stream`), `..` traversal → 404. The path resolver is a pure, unit-tested helper.
- **`outputFileTracingIncludes`** traces `docs-dist` into the function bundle so `readFile` resolves on Vercel.
- **Dev unchanged**: next.config rewrites `/docs/*` → the Astro dev server (`:4321`).
- **MenuBar** Docs button opens `/docs/` in a new tab (preserves editor state).

## Test plan (observed)
- `next start` (prod): all 20 pages 200 with real content + correct content-types; no broken asset refs; pagefind payloads load; a subpage renders fully styled (screenshot); traversal/missing → 404; app root intact.
- Vercel parity: `turbo run build --filter=@stave/app` builds docs→app in order; **68 `docs-dist` files traced into the route's `.nft.json`** (the lambda inclusion).
- **454** app unit tests green (incl. **6** new resolver tests covering page/asset disambiguation, mime, and the traversal guard). Lint clean.

## Follow-ups (filed separately, out of scope)
- Starlight references `/docs/favicon.svg` but never emits it → cosmetic 404 under any serving mechanism.
- In-editor Cmd+K D docs search (the other half still on `editor-features-and-fixes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)