### PR TITLE
🐛 fix(docs): navigable /docs — base-prefix content links (#355) + emit favicon (#336)

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from 'astro/config'
 import starlight from '@astrojs/starlight'
+import rehypeBaseInternalLinks from './rehype-base-internal-links.mjs'
 
 // Deployed at stave.live/docs/ — Astro's `base` makes every generated
 // URL (asset + internal link) include that prefix, so the Next app can
@@ -11,6 +12,13 @@ const BASE = process.env.STAVE_DOCS_BASE ?? '/docs/'
 export default defineConfig({
   site: 'https://stave.live',
   base: BASE,
+  // Author-written content links (markdown bodies) are emitted verbatim by
+  // Astro/Starlight — they don't get the `base` prefix that framework URLs do.
+  // This plugin prefixes root-absolute internal links in content with BASE so
+  // they resolve under `/docs/`. Base-agnostic: a no-op when BASE is `/`. (#355)
+  markdown: {
+    rehypePlugins: [[rehypeBaseInternalLinks, { base: BASE }]],
+  },
   integrations: [
     starlight({
       title: 'Stave Code',

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -25,6 +25,11 @@ export default defineConfig({
       description:
         'Browser-native live-coding editor for music (Strudel, Sonic Pi) and visuals (p5.js, Hydra).',
       logo: { src: './src/assets/stave.svg' },
+      // Override Hero to base-prefix splash action links — Starlight renders
+      // them verbatim, and the rehype plugin can't reach frontmatter. (#355)
+      components: {
+        Hero: './src/components/Hero.astro',
+      },
       social: {
         github: 'https://github.com/MrityunjayBhardwaj/stave-code',
       },

--- a/packages/docs/public/favicon.svg
+++ b/packages/docs/public/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect x="0" y="0" width="64" height="64" rx="12" fill="#0f0f1e"/>
+  <g stroke="#c4b5fd" stroke-width="2.5" fill="none" stroke-linecap="round">
+    <line x1="10" y1="18" x2="54" y2="18"/>
+    <line x1="10" y1="28" x2="54" y2="28"/>
+    <line x1="10" y1="38" x2="54" y2="38"/>
+    <line x1="10" y1="48" x2="54" y2="48"/>
+  </g>
+  <circle cx="22" cy="23" r="3.5" fill="#8b5cf6"/>
+  <circle cx="36" cy="33" r="3.5" fill="#8b5cf6"/>
+  <circle cx="44" cy="43" r="3.5" fill="#8b5cf6"/>
+</svg>

--- a/packages/docs/rehype-base-internal-links.mjs
+++ b/packages/docs/rehype-base-internal-links.mjs
@@ -21,6 +21,12 @@
  * blanket over every `<a href>`/`<img src>` without risk of double-prefixing.
  *
  * Dependency-free walker (unist-util-visit is not resolvable at the docs root).
+ *
+ * Assumption: every root-absolute (`/…`) link in docs content is docs-INTERNAL.
+ * This holds for a docs site — authors link within the docs. If you ever need to
+ * link to a host-app route OUTSIDE the docs (e.g. the Stave editor at `/`), this
+ * plugin would wrongly prefix it to `/docs/…`. Escape hatch: write a full origin
+ * URL (`https://stave.live/`) or a protocol-relative `//…` — both are skipped.
  */
 
 const ATTR_FOR = { a: 'href', area: 'href', img: 'src', source: 'src' }

--- a/packages/docs/rehype-base-internal-links.mjs
+++ b/packages/docs/rehype-base-internal-links.mjs
@@ -1,0 +1,53 @@
+/**
+ * rehype-base-internal-links
+ *
+ * Prefixes root-absolute internal links in docs CONTENT with the configured
+ * Astro `base`, so author-written links work when the site is served under a
+ * subpath (`base: '/docs/'`).
+ *
+ * Why this is needed: Astro/Starlight only base-prefixes framework-generated
+ * URLs (favicon, sitemap, sidebar config links via `pathWithBase`). Links an
+ * author writes in markdown bodies (`[x](/architecture/...)`) and HTML pass
+ * through verbatim — so under `base: '/docs/'` they resolve to `/architecture/...`
+ * (the host app's catch-all) instead of `/docs/architecture/...`. See issue #355.
+ *
+ * Base-agnostic: it receives the resolved base and skips anything already
+ * carrying it, so `STAVE_DOCS_BASE=/` (standalone preview) is a clean no-op.
+ *
+ * Scope note: `markdown.rehypePlugins` runs over the per-page markdown/MDX
+ * content tree ONLY — not the surrounding Starlight chrome (nav, sidebar are
+ * `.astro` components). So this can only touch author content links, never the
+ * already-correct framework links. That's the safety property that lets it run
+ * blanket over every `<a href>`/`<img src>` without risk of double-prefixing.
+ *
+ * Dependency-free walker (unist-util-visit is not resolvable at the docs root).
+ */
+
+const ATTR_FOR = { a: 'href', area: 'href', img: 'src', source: 'src' }
+
+export default function rehypeBaseInternalLinks({ base = '/' } = {}) {
+  // Normalise to a leading+trailing-slash form, e.g. '/docs/'.
+  const b = ('/' + base + '/').replace(/\/{2,}/g, '/')
+  // No subpath → nothing to prefix (e.g. STAVE_DOCS_BASE=/).
+  if (b === '/') return () => {}
+  const prefix = b.slice(0, -1) // '/docs'
+
+  const walk = (node) => {
+    if (node.type === 'element') {
+      const attr = ATTR_FOR[node.tagName]
+      const val = attr && node.properties ? node.properties[attr] : undefined
+      if (
+        typeof val === 'string' &&
+        val.startsWith('/') && // root-absolute only…
+        !val.startsWith('//') && // …but not protocol-relative
+        val !== prefix && // not already exactly the base root
+        !val.startsWith(b) // not already base-prefixed
+      ) {
+        node.properties[attr] = prefix + val
+      }
+    }
+    if (node.children) for (const child of node.children) walk(child)
+  }
+
+  return (tree) => walk(tree)
+}

--- a/packages/docs/src/components/Hero.astro
+++ b/packages/docs/src/components/Hero.astro
@@ -1,0 +1,46 @@
+---
+// Override of Starlight's Hero component.
+//
+// Starlight renders splash-page hero action links verbatim (Hero.astro:54 —
+// `<LinkButton href={action.link}>`), with NO `base` prefix — so a hero
+// `link: /getting-started/` ships as `/getting-started/` and, under
+// `base: /docs/`, leaves the docs entirely. The rehype plugin can't reach it
+// (frontmatter isn't in the markdown AST). (#355)
+//
+// This thin wrapper base-prefixes root-absolute action links via
+// `import.meta.env.BASE_URL`, then delegates to the default Hero. Base-agnostic
+// (no-op when the base is `/`), and emits an ABSOLUTE href — which, unlike a
+// relative link, survives Next's trailing-slash stripping in the prod route
+// handler that serves the site (a relative `getting-started/` resolved against
+// the slash-stripped `/docs` → `/getting-started` → 404).
+import Default from '@astrojs/starlight/components/Hero.astro'
+
+const base = import.meta.env.BASE_URL // '/docs/' (or '/' under STAVE_DOCS_BASE=/)
+const b = ('/' + base + '/').replace(/\/{2,}/g, '/') // normalised, e.g. '/docs/'
+
+function withBase(link) {
+  if (typeof link !== 'string') return link
+  if (!link.startsWith('/') || link.startsWith('//')) return link // relative / protocol-relative / external
+  if (b === '/' || link === b.slice(0, -1) || link.startsWith(b)) return link // base is root, or already prefixed
+  return b.slice(0, -1) + link
+}
+
+// Clone props with prefixed action links; leave everything else untouched.
+const entry = Astro.props.entry
+const hero = entry?.data?.hero
+const props =
+  hero?.actions?.length > 0
+    ? {
+        ...Astro.props,
+        entry: {
+          ...entry,
+          data: {
+            ...entry.data,
+            hero: { ...hero, actions: hero.actions.map((a) => ({ ...a, link: withBase(a.link) })) },
+          },
+        },
+      }
+    : Astro.props
+---
+
+<Default {...props} />

--- a/packages/docs/src/content/docs/getting-started.mdx
+++ b/packages/docs/src/content/docs/getting-started.mdx
@@ -72,4 +72,4 @@ Stave is local-first. Projects are stored in IndexedDB, synced across tabs via C
 
 - Language-specific tutorials: [Strudel](/runtimes/strudel/), [Sonic Pi](/runtimes/sonicpi/), [p5.js](/runtimes/p5/), [Hydra](/runtimes/hydra/)
 - Concepts: [Projects](/concepts/projects/), [Tabs and groups](/concepts/tabs-and-groups/), [Inline viz](/concepts/viz/)
-- [API reference](/reference/strudel/) — every symbol, with upstream links
+- API reference — every symbol Stave recognises: [p5.js](/reference/p5/), [Hydra](/reference/hydra/), [Sonic Pi](/reference/sonicpi/)

--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -6,10 +6,10 @@ hero:
   tagline: Live-code music and visuals side-by-side. No install, no toolchain — it's a URL.
   actions:
     - text: Get started
-      # Relative (not /getting-started/) so it resolves against the splash page's
-      # own URL under `base` — Starlight renders hero action links verbatim, with
-      # no base prefix, and frontmatter isn't reachable by the rehype plugin. (#355)
-      link: getting-started/
+      # Absolute — the Hero override (src/components/Hero.astro) base-prefixes
+      # this to /docs/getting-started/. Kept absolute (not relative) so the
+      # emitted href survives Next's trailing-slash stripping in prod. (#355)
+      link: /getting-started/
       icon: right-arrow
       variant: primary
     - text: View on GitHub

--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -45,4 +45,4 @@ Everything runs locally. Projects are stored in your browser (IndexedDB + CRDT),
 
 - **[Getting started](/getting-started/)** — five minutes, from URL to sound.
 - **[Runtimes](/runtimes/strudel/)** — tutorials per language.
-- **[API reference](/reference/strudel/)** — every symbol Stave recognises.
+- **API reference** — every symbol Stave recognises: [p5.js](/reference/p5/) · [Hydra](/reference/hydra/) · [Sonic Pi](/reference/sonicpi/).

--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -6,7 +6,10 @@ hero:
   tagline: Live-code music and visuals side-by-side. No install, no toolchain — it's a URL.
   actions:
     - text: Get started
-      link: /getting-started/
+      # Relative (not /getting-started/) so it resolves against the splash page's
+      # own URL under `base` — Starlight renders hero action links verbatim, with
+      # no base prefix, and frontmatter isn't reachable by the rehype plugin. (#355)
+      link: getting-started/
       icon: right-arrow
       variant: primary
     - text: View on GitHub

--- a/packages/docs/src/content/docs/runtimes/strudel.mdx
+++ b/packages/docs/src/content/docs/runtimes/strudel.mdx
@@ -59,7 +59,7 @@ setcps(130/240)  // 130 BPM assuming 4 beats per cycle
 
 ## Full function reference
 
-Every Strudel symbol Stave recognises appears in the [Strudel reference](/reference/strudel/). Signatures, descriptions, examples, and a link to upstream `strudel.cc`.
+The full Strudel function list lives in the upstream docs at [strudel.cc/learn](https://strudel.cc/learn/) — signatures, descriptions, and runnable examples. (A Stave-local Strudel reference will follow once the symbol index is vendored.)
 
 <Aside title="Upstream project">
 Strudel lives at [codeberg.org/uzu/strudel](https://codeberg.org/uzu/strudel). When the upstream surface grows, Stave's reference can be re-synced.


### PR DESCRIPTION
Two independent pre-public-release docs bugs, both **observed live** on the running docs server (reproduced on `:4321/docs/` direct *and* the `:3000/docs` proxy, so Astro-side, not the proxy).

## #355 — author-written content links drop the `/docs` base
Astro/Starlight only base-prefixes its *own* URLs (favicon, sitemap, sidebar config via `pathWithBase`). Links written in **content** — markdown bodies (`[x](/architecture/…)`) and the hero frontmatter — pass through verbatim. Under `base: /docs/`, all ~38 of them resolved to `/<path>` — the Stave **app's catch-all (the editor)** — instead of `/docs/<path>`. Clicking "Get started" left the docs entirely. Grounded in Starlight `Hero.astro:54-55` (renders `href={action.link}` raw).

**Fix (base-agnostic — `STAVE_DOCS_BASE` is overridable, so no hardcoded `/docs/`):**
- `rehype-base-internal-links.mjs`, wired into `astro.config` `markdown.rehypePlugins` with the resolved `BASE`. Prefixes root-absolute internal `<a href>`/`<img src>` in the **per-page content tree only** — Starlight chrome is `.astro`, not markdown rehype, so the already-correct sidebar can't be double-prefixed. Dependency-free walker; clean no-op when `BASE` is `/`.
- Hero CTA → relative `getting-started/` (frontmatter isn't in the markdown AST; relative resolves against the splash `/docs/`).

## #336 — `/docs/favicon.svg` 404
Starlight links the favicon but no `favicon.svg` was ever emitted. Added `packages/docs/public/favicon.svg` (the 64×64 stave logo) → served at `/docs/favicon.svg`.

## Test plan (all observed, not inferred)
- ✅ Default build → **every** author link carries `/docs/`; comprehensive dist leak scan for any non-`/docs/` internal href/src → **empty**.
- ✅ `STAVE_DOCS_BASE=/` build → links become bare `/…` with **zero `/docs/` leak** (proves base-agnostic).
- ✅ Real-browser click-through (`astro preview`): hero "Get started" → `/docs/getting-started/` (was `/getting-started/`); a body link → `/docs/architecture/glsl/`, both HTTP 200; **zero console errors**.
- ✅ `/docs/favicon.svg` → HTTP 200; emitted in dist.

Independent of #335 (that PR is the serving infrastructure; this is content correctness — different packages). Verified standalone via `astro build`/`preview`; end-to-end through the route handler will confirm once #335 lands.

Closes #355
Closes #336