### PR TITLE
🧪 test(app): #368 — open viz tab via file tree in 2 stale-fixture e2e specs

### DIFF
--- a/packages/app/tests/screenshot-p5-backdrop.spec.ts
+++ b/packages/app/tests/screenshot-p5-backdrop.spec.ts
@@ -24,19 +24,33 @@ test('screenshot: p5 sketch as backdrop', async ({ page }) => {
   })
   await page.locator('.monaco-editor').waitFor({ timeout: 15000 })
 
-  // Step 1 — switch to p5 and overwrite the sketch with one that
+  // Step 1 — open a p5 viz tab and overwrite the sketch with one that
   // draws BIG visible shapes even without a playing pattern, since
   // headless chromium won't start audio without a trusted gesture.
   // This verifies the backdrop render pipeline independently of the
   // scheduler wiring (which has its own E2E coverage).
+  //
+  // #175 — the default workspace opens a single Strudel tab, so the p5
+  // preset must be OPENED via the file tree (its fileId
+  // `viz:__bundled_piano_roll_p5__` matches `*="p5"`), not found among
+  // already-open tabs. Mirrors backdrop-viz-chrome's clickHydraTab.
   const tabs = page.locator('[data-workspace-tab]')
   const count = await tabs.count()
+  let opened = false
   for (let i = 0; i < count; i++) {
     const t = await tabs.nth(i).textContent()
     if (t && /\.p5/.test(t)) {
       await tabs.nth(i).click()
+      opened = true
       break
     }
+  }
+  if (!opened) {
+    const p5Item = page.locator('[data-file-tree-item*="p5"]').first()
+    if ((await p5Item.count()) === 0) {
+      throw new Error('no p5 preset file in default project')
+    }
+    await p5Item.dblclick()
   }
   await page.waitForTimeout(400)
 

--- a/packages/app/tests/selection-backdrop.spec.ts
+++ b/packages/app/tests/selection-backdrop.spec.ts
@@ -6,22 +6,35 @@
  */
 import { test, expect } from '@playwright/test'
 
+// #175 — the default workspace opens a single Strudel tab, not the old
+// 11-tab wall, so a viz tab must be OPENED via the file tree rather than
+// found among already-open tabs. Mirrors backdrop-viz-chrome's clickHydraTab.
+async function openVizTab(page: import('@playwright/test').Page, ext: RegExp, fileTreeMatch: string) {
+  const tabs = page.locator('[data-workspace-tab]')
+  const count = await tabs.count()
+  for (let i = 0; i < count; i++) {
+    const t = await tabs.nth(i).textContent()
+    if (t && ext.test(t)) {
+      await tabs.nth(i).click()
+      await page.waitForTimeout(300)
+      return
+    }
+  }
+  const item = page.locator(`[data-file-tree-item*="${fileTreeMatch}"]`).first()
+  if ((await item.count()) === 0) {
+    throw new Error(`no ${fileTreeMatch} preset file in default project`)
+  }
+  await item.dblclick()
+  await page.waitForTimeout(500)
+}
+
 test('selection highlight visible with backdrop active', async ({ page }) => {
   await page.goto('/')
   await page.locator('[data-workspace-shell="root"]').waitFor({ timeout: 15000 })
   await page.locator('.monaco-editor').waitFor({ timeout: 15000 })
 
   // Pin a hydra file as backdrop.
-  const tabs = page.locator('[data-workspace-tab]')
-  const count = await tabs.count()
-  for (let i = 0; i < count; i++) {
-    const t = await tabs.nth(i).textContent()
-    if (t && /\.hydra/.test(t)) {
-      await tabs.nth(i).click()
-      break
-    }
-  }
-  await page.waitForTimeout(200)
+  await openVizTab(page, /\.hydra/, 'hydra')
   await page.locator('[data-testid="viz-chrome-bg-toggle"]').first().click()
   await page.locator('[data-workspace-background]').first().waitFor({ timeout: 5000 })
 


### PR DESCRIPTION
## Summary

Fixes the **contained stale-fixture sub-part** of #368: two e2e specs that broke when #175 made the default workspace open a single Strudel tab.

- `selection-backdrop.spec.ts` and `screenshot-p5-backdrop.spec.ts` located their viz tab by **looping already-open tabs** (`for tab: if /\.hydra/` / `/\.p5/`). Post-#175 nothing matches → no viz tab is activated → both time out waiting for `[data-testid="viz-chrome-bg-toggle"]` (only rendered on a viz tab). Confirmed failing identically on `main` — P153 class, not a regression.
- **Fix:** open the preset via the file tree when no matching tab is open — `[data-file-tree-item*="hydra"]` / `*="p5"` then `.dblclick()` — the same pattern `backdrop-viz-chrome`'s `clickHydraTab` already uses. (`data-file-tree-item` is the fileId; bundled preset ids are `viz:__bundled_piano_roll_{hydra,p5}__`, so the substring match resolves them.)

## Test plan
- `selection-backdrop` + `screenshot-p5-backdrop`: **2/2 green** (was 0/2, both timing out).
- Test-only change (two `.spec.ts` files) — no app/editor source touched, no dist rebuild.

## Scope note
This is **only** the helper-fix part of #368. The issue's main body — migrating the 14 stale `strudel-viz-methods` pixel tests off `getContext`-on-worker-canvas (PV90) — is a separate, larger task and is **not** addressed here. Leaving #368 open for it.

Part of #368.
