### PR TITLE
✨ Song-view zoom + bars/beats ruler (#412)

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -23,16 +23,31 @@
 'use client'
 
 import * as React from 'react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import type { SongAnalysis } from '@stave/editor'
 import { paletteForTrack, trackIndexOf } from './musicalTimeline/colors'
-import { songCycleToX, xToSongCycle, wrapSongPosition } from './musicalTimeline/songAxis'
+import {
+  songCycleToX,
+  xToSongCycle,
+  wrapSongPosition,
+  clampZoom,
+  contentWidthFor,
+  scrollLeftForZoom,
+  rulerTicks,
+  MIN_ZOOM,
+  ZOOM_STEP,
+} from './musicalTimeline/songAxis'
 
 const TAB_ID = 'musical-timeline'
+const CONTROLS_HEIGHT = 26
 const TOPBAR_HEIGHT = 28
 const GUTTER_WIDTH = 90
 const ROW_HEIGHT = 22
 const FONT_MONO = '"JetBrains Mono", "Fira Code", ui-monospace, monospace'
+
+/** Ruler units (#412). CYCLES = Strudel's native numbering; BARS = DAW
+ *  convention (one cycle ≈ one bar) with quarter-cycle beat ticks. */
+type RulerUnits = 'cycles' | 'bars'
 
 export interface FullSongTimelineProps {
   /** Whole-song analysis, or null before the first analysis completes. */
@@ -75,6 +90,93 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     return () => ro.disconnect()
   }, [])
 
+  // ── Zoom + horizontal scroll + ruler units (#412) ────────────────────────
+  // zoom=1 fits the whole loop; >1 widens `contentWidth` past the viewport and
+  // the grid scrolls horizontally. The ruler tracks the grid's scrollLeft (one
+  // scrollbar, on the grid). Refs mirror state so the imperative wheel/button
+  // handlers and the seek math read live values without stale closures.
+  const [zoom, setZoom] = useState(MIN_ZOOM)
+  const [scrollLeft, setScrollLeft] = useState(0)
+  const [units, setUnits] = useState<RulerUnits>('cycles')
+  const zoomRef = useRef(zoom)
+  zoomRef.current = zoom
+  const scrollLeftRef = useRef(scrollLeft)
+  scrollLeftRef.current = scrollLeft
+  const areaWidthRef = useRef(areaWidth)
+  areaWidthRef.current = areaWidth
+
+  const contentWidth = contentWidthFor(areaWidth, zoom)
+  const pxPerCycle = displayCycles > 0 ? contentWidth / displayCycles : 0
+  const ticks = rulerTicks(displayCycles, pxPerCycle, units)
+
+  // Apply a new zoom, keeping the song point under `cursorX` (viewport-relative)
+  // pinned beneath the cursor. State drives the new content width; the layout
+  // effect below pushes the matching scrollLeft onto the DOM after it grows.
+  const applyZoom = React.useCallback((rawZoom: number, cursorX: number): void => {
+    const vw = areaWidthRef.current
+    const oldZoom = zoomRef.current
+    const newZoom = clampZoom(rawZoom)
+    if (newZoom === oldZoom) return
+    const next = Math.round(
+      scrollLeftForZoom({
+        oldZoom,
+        newZoom,
+        scrollLeft: scrollLeftRef.current,
+        cursorX,
+        viewportWidth: vw,
+      }),
+    )
+    zoomRef.current = newZoom
+    scrollLeftRef.current = next
+    setZoom(newZoom)
+    setScrollLeft(next)
+  }, [])
+
+  // Buttons zoom around the viewport centre; the gesture is identical to wheel
+  // zoom with the cursor parked mid-view.
+  const zoomBy = React.useCallback(
+    (factor: number) => applyZoom(zoomRef.current * factor, areaWidthRef.current / 2),
+    [applyZoom],
+  )
+  const fitZoom = React.useCallback(() => applyZoom(MIN_ZOOM, areaWidthRef.current / 2), [applyZoom])
+
+  // Ctrl/⌘ + wheel = cursor-centred zoom. A native non-passive listener is
+  // required: React's synthetic onWheel is passive, so preventDefault (which
+  // suppresses the browser's page-zoom) would be ignored.
+  useEffect(() => {
+    const el = areaRef.current
+    if (!el) return
+    const onWheel = (e: WheelEvent): void => {
+      if (!(e.ctrlKey || e.metaKey)) return // plain wheel → native horizontal scroll
+      e.preventDefault()
+      const rect = el.getBoundingClientRect()
+      const cursorX = e.clientX - rect.left
+      const factor = e.deltaY < 0 ? ZOOM_STEP : 1 / ZOOM_STEP
+      applyZoom(zoomRef.current * factor, cursorX)
+    }
+    el.addEventListener('wheel', onWheel, { passive: false })
+    return () => el.removeEventListener('wheel', onWheel)
+  }, [applyZoom])
+
+  // Push scrollLeft onto the DOM after a zoom/resize changes the content width,
+  // clamping into the (possibly shrunk) scrollable range. Keyed on zoom+width
+  // only, so user scrolling (which sets scrollLeft via onScroll) never refights.
+  useLayoutEffect(() => {
+    const el = areaRef.current
+    if (!el) return
+    const maxScroll = Math.max(0, contentWidthFor(areaWidth, zoom) - areaWidth)
+    const clamped = Math.max(0, Math.min(maxScroll, scrollLeftRef.current))
+    scrollLeftRef.current = clamped
+    if (el.scrollLeft !== clamped) el.scrollLeft = clamped
+    setScrollLeft((prev) => (prev === clamped ? prev : clamped))
+  }, [zoom, areaWidth])
+
+  const handleGridScroll = React.useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    const sl = e.currentTarget.scrollLeft
+    scrollLeftRef.current = sl
+    setScrollLeft((prev) => (prev === sl ? prev : sl))
+  }, [])
+
   // ── rAF playhead, gated on drawer-open + active-tab (DB-02 parity) ───────
   const accessorsRef = useRef(props)
   accessorsRef.current = props
@@ -115,16 +217,22 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
   }, [])
 
   const wrappedPos = wrapSongPosition(songPos, displayCycles)
-  const playheadX = songCycleToX(wrappedPos, displayCycles, areaWidth)
+  // Playhead lives in CONTENT space (inside the scrolled/translated inner div),
+  // so it maps against contentWidth, not the viewport width.
+  const playheadX = songCycleToX(wrappedPos, displayCycles, contentWidth)
   const playheadVisible = wrappedPos != null
 
   // ── Click → seek (relaxes DV-10) ─────────────────────────────────────────
+  // The ruler and grid share the grid's scrollLeft and the same left edge, so a
+  // click anywhere resolves through the grid's rect: viewport-x + scrollLeft is
+  // the content-x, inverted against contentWidth.
   const handleSeekAtClientX = React.useCallback(
     (clientX: number) => {
       const el = areaRef.current
       if (!el) return
       const rect = el.getBoundingClientRect()
-      const cycle = xToSongCycle(clientX - rect.left, displayCycles, rect.width)
+      const contentX = clientX - rect.left + scrollLeftRef.current
+      const cycle = xToSongCycle(contentX, displayCycles, contentWidthFor(rect.width, zoomRef.current))
       onSeek(cycle)
     },
     [displayCycles, onSeek],
@@ -150,14 +258,65 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
           ? `${analysis.horizonCycles}+ cycles`
           : `${analysis.horizonCycles} cycles`
 
+  const cellW = displayCycles > 0 ? contentWidth / displayCycles : 0
+  const zoomPercent = Math.round(zoom * 100)
+  const majorTicks = ticks.filter((t) => t.major)
+
   return (
     <div data-full-song="root" role="region" aria-label="Song" style={styles.root}>
       {/* Status lives in the parent's unified bar (with the view toggle); this
-          view renders the ruler + heatmap only. `periodLabel` is surfaced via
-          the data attribute below for Playwright observation. */}
+          view renders the controls + ruler + heatmap only. `periodLabel` is
+          surfaced via the data attribute below for Playwright observation. */}
       <div data-full-song-period={periodLabel} style={{ display: 'none' }} />
 
-      {/* Ruler: section chips + cycle ticks + clickable seek surface + playhead */}
+      {/* Controls: units toggle (left) + zoom (right). Discoverable buttons over
+          shortcuts; ⌘/Ctrl+wheel also zooms. */}
+      <div data-full-song="controls" style={styles.controls}>
+        <button
+          type="button"
+          data-full-song-units-toggle
+          data-units={units}
+          onClick={() => setUnits((u) => (u === 'cycles' ? 'bars' : 'cycles'))}
+          style={styles.unitsToggle}
+          title={units === 'cycles' ? 'Show bars & beats' : 'Show cycles'}
+        >
+          {units === 'cycles' ? 'CYCLES' : 'BARS'}
+        </button>
+        <div style={styles.zoomCluster} data-full-song-zoom={zoomPercent}>
+          <button
+            type="button"
+            data-full-song-zoom-fit
+            onClick={fitZoom}
+            disabled={zoom <= MIN_ZOOM}
+            style={styles.zoomButton}
+            title="Fit the whole song"
+          >
+            Fit
+          </button>
+          <button
+            type="button"
+            data-full-song-zoom-out
+            onClick={() => zoomBy(1 / ZOOM_STEP)}
+            disabled={zoom <= MIN_ZOOM}
+            style={styles.zoomButton}
+            title="Zoom out"
+          >
+            −
+          </button>
+          <span style={styles.zoomReadout}>{zoomPercent}%</span>
+          <button
+            type="button"
+            data-full-song-zoom-in
+            onClick={() => zoomBy(ZOOM_STEP)}
+            style={styles.zoomButton}
+            title="Zoom in"
+          >
+            +
+          </button>
+        </div>
+      </div>
+
+      {/* Ruler: section bands + cycle/bar ticks + clickable seek surface + playhead */}
       <div data-full-song="ruler" style={styles.topbar}>
         <div style={styles.gutter}>
           <span style={styles.caption}>SONG</span>
@@ -167,36 +326,55 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
           style={styles.rulerArea}
           onPointerDown={(e) => handleSeekAtClientX(e.clientX)}
         >
-          {areaWidth > 0 &&
-            sections.map((s, i) => {
-              const left = songCycleToX(s.startCycle, displayCycles, areaWidth)
-              const right = songCycleToX(s.endCycle, displayCycles, areaWidth)
-              return (
+          {/* Inner content tracks the grid's horizontal scroll via translateX */}
+          <div
+            data-full-song="ruler-content"
+            style={{ ...styles.scrollContent, width: contentWidth, transform: `translateX(${-scrollLeft}px)` }}
+          >
+            {areaWidth > 0 &&
+              sections.map((s, i) => {
+                const left = songCycleToX(s.startCycle, displayCycles, contentWidth)
+                const right = songCycleToX(s.endCycle, displayCycles, contentWidth)
+                return (
+                  <div
+                    key={`section-${s.startCycle}-${s.endCycle}`}
+                    data-full-song-section={i}
+                    title={`Section ${i + 1} · cycles ${s.startCycle}–${s.endCycle - 1}`}
+                    style={{
+                      ...styles.sectionChip,
+                      left,
+                      width: Math.max(0, right - left),
+                      // alternate tint so adjacent sections read as distinct
+                      background:
+                        i % 2 === 0
+                          ? 'var(--bg-input, rgba(255,255,255,0.04))'
+                          : 'var(--bg-panel, rgba(255,255,255,0.08))',
+                    }}
+                  >
+                    <span style={styles.sectionLabel}>{i + 1}</span>
+                  </div>
+                )
+              })}
+            {areaWidth > 0 &&
+              ticks.map((t) => (
                 <div
-                  key={`section-${s.startCycle}-${s.endCycle}`}
-                  data-full-song-section={i}
-                  title={`Section ${i + 1} · cycles ${s.startCycle}–${s.endCycle - 1}`}
+                  key={`tick-${t.cycle}`}
+                  data-full-song-tick={t.major ? 'major' : 'beat'}
                   style={{
-                    ...styles.sectionChip,
-                    left,
-                    width: Math.max(0, right - left),
-                    // alternate tint so adjacent sections read as distinct
-                    background:
-                      i % 2 === 0
-                        ? 'var(--bg-input, rgba(255,255,255,0.04))'
-                        : 'var(--bg-panel, rgba(255,255,255,0.08))',
+                    ...(t.major ? styles.tickMajor : styles.tickBeat),
+                    left: songCycleToX(t.cycle, displayCycles, contentWidth),
                   }}
                 >
-                  <span style={styles.sectionLabel}>{i + 1}</span>
+                  {t.label != null && <span style={styles.tickLabel}>{t.label}</span>}
                 </div>
-              )
-            })}
-          {playheadVisible && (
-            <div
-              data-full-song="ruler-playhead-arrow"
-              style={{ ...styles.playheadArrow, left: playheadX }}
-            />
-          )}
+              ))}
+            {playheadVisible && (
+              <div
+                data-full-song="ruler-playhead-arrow"
+                style={{ ...styles.playheadArrow, left: playheadX }}
+              />
+            )}
+          </div>
         </div>
       </div>
 
@@ -223,61 +401,75 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
           data-full-song="grid"
           ref={areaRef}
           style={styles.grid}
+          onScroll={handleGridScroll}
           onPointerDown={(e) => handleSeekAtClientX(e.clientX)}
         >
-          {/* Section bands (full height, behind cells) */}
-          {areaWidth > 0 &&
-            sections.map((s) => {
-              const left = songCycleToX(s.startCycle, displayCycles, areaWidth)
-              const right = songCycleToX(s.endCycle, displayCycles, areaWidth)
-              return (
+          {/* Inner content is contentWidth wide; the grid scrolls it horizontally */}
+          <div
+            data-full-song="grid-content"
+            style={{ ...styles.scrollContent, width: contentWidth }}
+          >
+            {/* Section bands (full height, behind cells) */}
+            {areaWidth > 0 &&
+              sections.map((s) => {
+                const left = songCycleToX(s.startCycle, displayCycles, contentWidth)
+                const right = songCycleToX(s.endCycle, displayCycles, contentWidth)
+                return (
+                  <div
+                    key={`band-${s.startCycle}`}
+                    style={{
+                      ...styles.sectionBand,
+                      left,
+                      width: Math.max(0, right - left),
+                    }}
+                  />
+                )
+              })}
+            {/* Bar/cycle gridlines (faint, behind cells) — orientation when zoomed */}
+            {areaWidth > 0 &&
+              majorTicks.map((t) => (
                 <div
-                  key={`band-${s.startCycle}`}
-                  style={{
-                    ...styles.sectionBand,
-                    left,
-                    width: Math.max(0, right - left),
-                  }}
+                  key={`gridline-${t.cycle}`}
+                  style={{ ...styles.gridline, left: songCycleToX(t.cycle, displayCycles, contentWidth) }}
                 />
-              )
-            })}
-          {/* Per-lane onset heatmap — sparse: a cell only where onsets > 0 */}
-          {areaWidth > 0 &&
-            lanes.map((lane, laneIdx) => {
-              const color = paletteForTrack(trackIndexOf(lane.laneKey), lane.laneKey)
-              const cellW = areaWidth / displayCycles
-              return (
-                <div
-                  key={lane.laneKey}
-                  data-full-song-lane={lane.laneKey}
-                  style={{ ...styles.laneRow, top: laneIdx * ROW_HEIGHT }}
-                >
-                  {lane.onsetsByCycle.map((count, cycle) =>
-                    // Guard: only render cells within the displayed span so a
-                    // wider analysis horizon can never pile cells onto the edge
-                    // (the period-trim in analyzeSong keeps these equal, but the
-                    // view must not depend on that holding).
-                    count > 0 && cycle < displayCycles ? (
-                      <div
-                        key={cycle}
-                        data-full-song-cell={`${lane.laneKey}:${cycle}`}
-                        title={`${lane.laneKey} · cycle ${cycle} · ${count} onset${count === 1 ? '' : 's'}`}
-                        style={{
-                          ...styles.cell,
-                          left: songCycleToX(cycle, displayCycles, areaWidth),
-                          width: Math.max(1, cellW - 1),
-                          background: color,
-                          opacity: 0.25 + 0.75 * (count / peak),
-                        }}
-                      />
-                    ) : null,
-                  )}
-                </div>
-              )
-            })}
-          {playheadVisible && (
-            <div data-full-song="playhead" style={{ ...styles.playhead, left: playheadX }} />
-          )}
+              ))}
+            {/* Per-lane onset heatmap — sparse: a cell only where onsets > 0 */}
+            {areaWidth > 0 &&
+              lanes.map((lane, laneIdx) => {
+                const color = paletteForTrack(trackIndexOf(lane.laneKey), lane.laneKey)
+                return (
+                  <div
+                    key={lane.laneKey}
+                    data-full-song-lane={lane.laneKey}
+                    style={{ ...styles.laneRow, top: laneIdx * ROW_HEIGHT }}
+                  >
+                    {lane.onsetsByCycle.map((count, cycle) =>
+                      // Guard: only render cells within the displayed span so a
+                      // wider analysis horizon can never pile cells onto the edge
+                      // (the period-trim in analyzeSong keeps these equal, but the
+                      // view must not depend on that holding).
+                      count > 0 && cycle < displayCycles ? (
+                        <div
+                          key={cycle}
+                          data-full-song-cell={`${lane.laneKey}:${cycle}`}
+                          title={`${lane.laneKey} · cycle ${cycle} · ${count} onset${count === 1 ? '' : 's'}`}
+                          style={{
+                            ...styles.cell,
+                            left: songCycleToX(cycle, displayCycles, contentWidth),
+                            width: Math.max(1, cellW - 1),
+                            background: color,
+                            opacity: 0.25 + 0.75 * (count / peak),
+                          }}
+                        />
+                      ) : null,
+                    )}
+                  </div>
+                )
+              })}
+            {playheadVisible && (
+              <div data-full-song="playhead" style={{ ...styles.playhead, left: playheadX }} />
+            )}
+          </div>
         </div>
       </div>
     </div>
@@ -295,6 +487,52 @@ const styles = {
     fontSize: 11,
     color: 'var(--text-body, #e2e8f0)',
     background: 'var(--bg-app, #090912)',
+  },
+  controls: {
+    height: CONTROLS_HEIGHT,
+    minHeight: CONTROLS_HEIGHT,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 8,
+    padding: '0 8px',
+    background: 'var(--bg-app, #090912)',
+    borderBottom: '1px solid var(--border-subtle, rgba(255,255,255,0.06))',
+  },
+  unitsToggle: {
+    fontFamily: FONT_MONO,
+    fontSize: 9,
+    letterSpacing: '0.08em',
+    padding: '2px 8px',
+    borderRadius: 3,
+    border: '1px solid var(--border-subtle, rgba(255,255,255,0.14))',
+    background: 'var(--bg-input, rgba(255,255,255,0.04))',
+    color: 'var(--text-tertiary, rgba(255,255,255,0.55))',
+    cursor: 'pointer' as const,
+  },
+  zoomCluster: { display: 'flex', alignItems: 'center', gap: 4 },
+  zoomButton: {
+    fontFamily: FONT_MONO,
+    fontSize: 11,
+    lineHeight: 1,
+    minWidth: 22,
+    padding: '3px 6px',
+    borderRadius: 3,
+    border: '1px solid var(--border-subtle, rgba(255,255,255,0.14))',
+    background: 'var(--bg-input, rgba(255,255,255,0.04))',
+    color: 'var(--text-tertiary, rgba(255,255,255,0.55))',
+    cursor: 'pointer' as const,
+  },
+  zoomReadout: {
+    fontSize: 9,
+    minWidth: 36,
+    textAlign: 'center' as const,
+    color: 'var(--text-tertiary, rgba(255,255,255,0.4))',
+  },
+  scrollContent: {
+    position: 'relative' as const,
+    height: '100%',
+    minHeight: '100%',
   },
   topbar: {
     height: TOPBAR_HEIGHT,
@@ -334,6 +572,31 @@ const styles = {
     pointerEvents: 'none' as const,
   },
   sectionLabel: { fontSize: 9, color: 'var(--text-tertiary, rgba(255,255,255,0.4))' },
+  tickMajor: {
+    position: 'absolute' as const,
+    bottom: 0,
+    top: 0,
+    width: 1,
+    borderLeft: '1px solid var(--border-subtle, rgba(255,255,255,0.18))',
+    pointerEvents: 'none' as const,
+    display: 'flex',
+    alignItems: 'flex-end',
+  },
+  tickBeat: {
+    position: 'absolute' as const,
+    bottom: 0,
+    height: 5,
+    width: 1,
+    borderLeft: '1px solid var(--border-subtle, rgba(255,255,255,0.1))',
+    pointerEvents: 'none' as const,
+  },
+  tickLabel: {
+    fontSize: 9,
+    lineHeight: 1,
+    paddingLeft: 3,
+    paddingBottom: 2,
+    color: 'var(--text-tertiary, rgba(255,255,255,0.5))',
+  },
   playheadArrow: {
     position: 'absolute' as const,
     top: 4,
@@ -386,7 +649,8 @@ const styles = {
     flex: 1,
     minWidth: 200,
     position: 'relative' as const,
-    overflow: 'hidden',
+    overflowX: 'auto' as const,
+    overflowY: 'hidden' as const,
     background: 'var(--bg-input, #0f0f1a)',
     cursor: 'pointer' as const,
   },
@@ -394,6 +658,14 @@ const styles = {
     position: 'absolute' as const,
     top: 0,
     bottom: 0,
+    borderLeft: '1px solid var(--border-subtle, rgba(255,255,255,0.05))',
+    pointerEvents: 'none' as const,
+  },
+  gridline: {
+    position: 'absolute' as const,
+    top: 0,
+    bottom: 0,
+    width: 1,
     borderLeft: '1px solid var(--border-subtle, rgba(255,255,255,0.05))',
     pointerEvents: 'none' as const,
   },

--- a/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
+++ b/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
@@ -122,4 +122,51 @@ describe('FullSongTimeline', () => {
     const meta = container.querySelector('[data-full-song-period]')
     expect(meta?.getAttribute('data-full-song-period')).toBe('loop 4')
   })
+
+  // ── Zoom + ruler controls (#412) ───────────────────────────────────────────
+
+  it('renders zoom controls at 100% with Fit/zoom-out disabled', async () => {
+    const { container } = renderFull()
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const cluster = container.querySelector('[data-full-song-zoom]') as HTMLElement
+    expect(cluster.getAttribute('data-full-song-zoom')).toBe('100')
+    expect((container.querySelector('[data-full-song-zoom-fit]') as HTMLButtonElement).disabled).toBe(true)
+    expect((container.querySelector('[data-full-song-zoom-out]') as HTMLButtonElement).disabled).toBe(true)
+    expect((container.querySelector('[data-full-song-zoom-in]') as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('zooms in on the + button (enables Fit/zoom-out)', async () => {
+    const { container } = renderFull()
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const zoomIn = container.querySelector('[data-full-song-zoom-in]') as HTMLButtonElement
+    await act(async () => {
+      zoomIn.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    // default ZOOM_STEP is 1.5 → 150%
+    expect(container.querySelector('[data-full-song-zoom]')?.getAttribute('data-full-song-zoom')).toBe('150')
+    expect((container.querySelector('[data-full-song-zoom-fit]') as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('toggles CYCLES ↔ BARS and adds beat ticks in bars mode', async () => {
+    const { container } = renderFull()
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const toggle = container.querySelector('[data-full-song-units-toggle]') as HTMLButtonElement
+    expect(toggle.textContent).toBe('CYCLES')
+    // CYCLES: 4 major ticks (period 4 across 800px → 200px/cycle), no beats.
+    expect(container.querySelectorAll('[data-full-song-tick="major"]').length).toBe(4)
+    expect(container.querySelectorAll('[data-full-song-tick="beat"]').length).toBe(0)
+    await act(async () => {
+      toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(toggle.textContent).toBe('BARS')
+    // BARS: 4 majors + 4×3 interior beat ticks (200/4 = 50px/beat ≥ 14).
+    expect(container.querySelectorAll('[data-full-song-tick="major"]').length).toBe(4)
+    expect(container.querySelectorAll('[data-full-song-tick="beat"]').length).toBe(12)
+  })
 })

--- a/packages/app/src/components/musicalTimeline/__tests__/songAxis.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/songAxis.test.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect } from 'vitest'
-import { songCycleToX, xToSongCycle, wrapSongPosition } from '../songAxis'
+import {
+  songCycleToX,
+  xToSongCycle,
+  wrapSongPosition,
+  clampZoom,
+  contentWidthFor,
+  scrollLeftForZoom,
+  rulerTicks,
+  MIN_ZOOM,
+  MAX_ZOOM,
+  BEATS_PER_BAR,
+} from '../songAxis'
 
 describe('songCycleToX', () => {
   it('maps a cycle linearly across the width', () => {
@@ -61,5 +72,95 @@ describe('wrapSongPosition', () => {
     expect(wrapSongPosition(null, 8)).toBeNull()
     expect(wrapSongPosition(Number.NaN, 8)).toBeNull()
     expect(wrapSongPosition(4, 0)).toBeNull()
+  })
+})
+
+describe('clampZoom', () => {
+  it('clamps to [MIN_ZOOM, MAX_ZOOM]', () => {
+    expect(clampZoom(0.2)).toBe(MIN_ZOOM)
+    expect(clampZoom(1000)).toBe(MAX_ZOOM)
+    expect(clampZoom(4)).toBe(4)
+  })
+  it('falls back to MIN_ZOOM for non-finite (incl. infinity)', () => {
+    expect(clampZoom(Number.NaN)).toBe(MIN_ZOOM)
+    expect(clampZoom(Number.POSITIVE_INFINITY)).toBe(MIN_ZOOM)
+  })
+})
+
+describe('contentWidthFor', () => {
+  it('returns the viewport width at zoom 1 and widens proportionally', () => {
+    expect(contentWidthFor(800, 1)).toBe(800)
+    expect(contentWidthFor(800, 2)).toBe(1600)
+  })
+  it('never shrinks below the viewport, and degenerates to 0', () => {
+    expect(contentWidthFor(800, 0.5)).toBe(800)
+    expect(contentWidthFor(0, 4)).toBe(0)
+  })
+})
+
+describe('scrollLeftForZoom (cursor-centered)', () => {
+  it('keeps the content point under the cursor pinned when zooming in', () => {
+    // viewport 800, at zoom 1 the cursor at x=400 sits over content x=400.
+    // Zoom to 2 → that content point is now at 800; to keep it under x=400 we
+    // scroll to 800 - 400 = 400.
+    const next = scrollLeftForZoom({
+      oldZoom: 1,
+      newZoom: 2,
+      scrollLeft: 0,
+      cursorX: 400,
+      viewportWidth: 800,
+    })
+    expect(next).toBe(400)
+  })
+  it('clamps to the scrollable range', () => {
+    // far-right cursor zooming in would push past max scroll → clamp.
+    const next = scrollLeftForZoom({
+      oldZoom: 1,
+      newZoom: 2,
+      scrollLeft: 0,
+      cursorX: 800,
+      viewportWidth: 800,
+    })
+    expect(next).toBe(800) // maxScroll = 800*2 - 800
+  })
+  it('never goes negative and handles degenerate inputs', () => {
+    expect(
+      scrollLeftForZoom({ oldZoom: 2, newZoom: 1, scrollLeft: 0, cursorX: 0, viewportWidth: 800 }),
+    ).toBe(0)
+    expect(
+      scrollLeftForZoom({ oldZoom: 1, newZoom: 2, scrollLeft: 0, cursorX: 400, viewportWidth: 0 }),
+    ).toBe(0)
+  })
+})
+
+describe('rulerTicks', () => {
+  it('emits a 0-indexed major per cycle when there is room (CYCLES)', () => {
+    const ticks = rulerTicks(4, 200, 'cycles')
+    expect(ticks.map((t) => t.label)).toEqual(['0', '1', '2', '3'])
+    expect(ticks.every((t) => t.major)).toBe(true)
+  })
+  it('uses 1-indexed bar labels and adds beat ticks when zoomed in (BARS)', () => {
+    const ticks = rulerTicks(2, 200, 'bars') // 200px/cycle → 50px/beat ≥ 14
+    const majors = ticks.filter((t) => t.major)
+    expect(majors.map((t) => t.label)).toEqual(['1', '2'])
+    const beats = ticks.filter((t) => !t.major)
+    // 2 bars × (BEATS_PER_BAR - 1) interior beat ticks
+    expect(beats.length).toBe(2 * (BEATS_PER_BAR - 1))
+    expect(beats.map((t) => t.cycle)).toContain(0.25)
+    expect(beats.every((t) => t.label === null)).toBe(true)
+  })
+  it('drops beat ticks when each beat is too narrow', () => {
+    const ticks = rulerTicks(2, 40, 'bars') // 40/4 = 10px/beat < 14 → no beats
+    expect(ticks.every((t) => t.major)).toBe(true)
+  })
+  it('thins majors by powers of two when zoomed out', () => {
+    // 64 cycles across 800px → 12.5px/cycle; step doubles until ≥40 → step 4.
+    const ticks = rulerTicks(64, 12.5, 'cycles')
+    expect(ticks.map((t) => t.cycle)).toEqual([0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60])
+  })
+  it('returns [] for degenerate inputs', () => {
+    expect(rulerTicks(0, 100, 'cycles')).toEqual([])
+    expect(rulerTicks(4, 0, 'cycles')).toEqual([])
+    expect(rulerTicks(4, Number.NaN, 'cycles')).toEqual([])
   })
 })

--- a/packages/app/src/components/musicalTimeline/songAxis.ts
+++ b/packages/app/src/components/musicalTimeline/songAxis.ts
@@ -58,3 +58,99 @@ export function wrapSongPosition(
   const wrapped = songPosition % displayCycles
   return wrapped < 0 ? wrapped + displayCycles : wrapped
 }
+
+// ── Zoom (#412) ────────────────────────────────────────────────────────────
+//
+// zoom = 1 fits the whole loop to the viewport (the existing fit-to-width
+// default). zoom > 1 widens the content (`contentWidth = viewportWidth * zoom`)
+// past the viewport, revealing a horizontal scrollbar. All the cycle↔pixel
+// helpers above are width-agnostic, so the view simply passes `contentWidth`
+// where it used to pass the raw viewport width.
+
+/** Minimum zoom — fit the whole song to the viewport. */
+export const MIN_ZOOM = 1
+/** Maximum zoom — far enough to inspect individual cycles on a long song. */
+export const MAX_ZOOM = 64
+/** Multiplier per zoom-button press / wheel notch. */
+export const ZOOM_STEP = 1.5
+
+/** Clamp a zoom factor to `[MIN_ZOOM, MAX_ZOOM]`; non-finite → MIN_ZOOM. */
+export function clampZoom(zoom: number): number {
+  if (!Number.isFinite(zoom)) return MIN_ZOOM
+  return Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom))
+}
+
+/** Content width at a given zoom (`viewportWidth * zoom`, never below the viewport). */
+export function contentWidthFor(viewportWidth: number, zoom: number): number {
+  if (viewportWidth <= 0) return 0
+  return viewportWidth * Math.max(MIN_ZOOM, zoom)
+}
+
+/**
+ * The new horizontal scroll offset after a zoom change that keeps the song
+ * point currently under `cursorX` pinned beneath the cursor (cursor-centered
+ * zoom). `cursorX` is viewport-relative (0 = left edge of the scroll area).
+ * Result is clamped to the scrollable range `[0, contentWidth - viewportWidth]`.
+ */
+export function scrollLeftForZoom(params: {
+  oldZoom: number
+  newZoom: number
+  scrollLeft: number
+  cursorX: number
+  viewportWidth: number
+}): number {
+  const { oldZoom, newZoom, scrollLeft, cursorX, viewportWidth } = params
+  if (viewportWidth <= 0 || oldZoom <= 0 || newZoom <= 0) return 0
+  const contentX = scrollLeft + cursorX // content-space x under the cursor pre-zoom
+  const next = contentX * (newZoom / oldZoom) - cursorX
+  const maxScroll = Math.max(0, viewportWidth * newZoom - viewportWidth)
+  return Math.max(0, Math.min(maxScroll, next))
+}
+
+// ── Ruler ticks (#412) ───────────────────────────────────────────────────────
+
+/** Beats per bar for the BARS ruler. Strudel has no fixed meter (one cycle is
+ *  one bar), so beats are a display subdivision; 4 is the universal DAW default. */
+export const BEATS_PER_BAR = 4
+
+export interface RulerTick {
+  /** Song cycle position (fractional for beat ticks). */
+  readonly cycle: number
+  /** Label text, or null for an unlabeled minor (beat) tick. */
+  readonly label: string | null
+  /** Major ticks sit on cycle/bar boundaries, draw taller, and carry a label. */
+  readonly major: boolean
+}
+
+/**
+ * Tick marks for the song ruler. `pxPerCycle` (= contentWidth / displayCycles)
+ * drives density: majors stay ≥ ~40px apart by stepping in powers of two when
+ * zoomed out, and beat subdivisions only appear once each beat clears ~14px.
+ *
+ * CYCLES mode → 0-indexed labels (matches Strudel cycle numbering and the cell
+ *   tooltips); no beats. BARS mode → 1-indexed labels (DAW convention: bar 1 is
+ *   the first bar) with beat ticks at multiples of 1/BEATS_PER_BAR.
+ */
+export function rulerTicks(
+  displayCycles: number,
+  pxPerCycle: number,
+  mode: 'cycles' | 'bars',
+): RulerTick[] {
+  if (displayCycles <= 0 || !Number.isFinite(pxPerCycle) || pxPerCycle <= 0) return []
+  const MIN_MAJOR_PX = 40
+  const BEAT_MIN_PX = 14
+  let step = 1
+  while (step * pxPerCycle < MIN_MAJOR_PX) step *= 2
+  const showBeats =
+    mode === 'bars' && step === 1 && pxPerCycle / BEATS_PER_BAR >= BEAT_MIN_PX
+  const ticks: RulerTick[] = []
+  for (let c = 0; c < displayCycles; c += step) {
+    ticks.push({ cycle: c, label: mode === 'bars' ? String(c + 1) : String(c), major: true })
+    if (showBeats) {
+      for (let b = 1; b < BEATS_PER_BAR; b++) {
+        ticks.push({ cycle: c + b / BEATS_PER_BAR, label: null, major: false })
+      }
+    }
+  }
+  return ticks
+}

--- a/packages/app/tests/full-song-zoom-ruler.spec.ts
+++ b/packages/app/tests/full-song-zoom-ruler.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * Full-song zoom + bars/beats ruler (#412) — Playwright observation spec.
+ *
+ * AnviDev observe gate: songAxis.test.ts covers the zoom/tick math and
+ * FullSongTimeline.test.tsx covers the controls in jsdom; this drives the REAL
+ * app to confirm the end-to-end behaviour against a real evaluated song —
+ *   1. Zoom controls render (Fit / − / readout / +) in the song view.
+ *   2. The + button widens the heatmap past the viewport (a horizontal
+ *      scrollbar appears: scrollWidth > clientWidth) and the readout grows.
+ *   3. Scrolling the grid drives the ruler content (shared scrollLeft).
+ *   4. Fit returns to 100% and refits to the viewport.
+ *   5. The CYCLES↔BARS toggle adds beat ticks (bars mode).
+ *   6. No console / page errors throughout.
+ *
+ * ⌘/Ctrl+wheel zoom shares the same `applyZoom` path as the buttons (unit-
+ * tested via scrollLeftForZoom); the buttons exercise it deterministically here.
+ *
+ * INPUT NOTE (same as full-song-timeline.spec.ts): the eval reads the file
+ * store, so the analyzed song is the starter example — assertions are generic.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+const STORAGE_KEYS = {
+  height: 'stave:bottomPanel.height',
+  open: 'stave:bottomPanel.open',
+  activeTabId: 'stave:bottomPanel.activeTabId',
+} as const
+
+async function preOpenDrawer(page: Page): Promise<void> {
+  await page.addInitScript(
+    ([heightKey, openKey, activeKey]: readonly string[]) => {
+      try {
+        window.localStorage.setItem(heightKey, '320')
+        window.localStorage.setItem(openKey, 'true')
+        window.localStorage.setItem(activeKey, 'musical-timeline')
+      } catch {
+        /* ignore */
+      }
+    },
+    [STORAGE_KEYS.height, STORAGE_KEYS.open, STORAGE_KEYS.activeTabId],
+  )
+}
+
+async function bootShell(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => {
+      const m = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+      return (m?.editor?.getEditors?.()?.length ?? 0) > 0
+    },
+    { timeout: 20_000 },
+  )
+}
+
+async function evalStrudel(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+    const editors = (monaco?.editor?.getEditors?.() ?? []) as Array<{
+      getModel: () => { getLanguageId?: () => string } | null
+      focus: () => void
+    }>
+    const target = editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
+    target?.focus()
+  })
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1800)
+}
+
+test('full-song view: zoom widens + scrolls, Fit refits, bars toggle adds beat ticks', async ({
+  page,
+}) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await preOpenDrawer(page)
+  await bootShell(page)
+  await evalStrudel(page)
+
+  // Enter the full-song view.
+  const toggle = page.locator('[data-musical-timeline="view-toggle"]')
+  await toggle.waitFor({ timeout: 10_000 })
+  await toggle.click()
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+
+  const grid = page.locator('[data-full-song="grid"]')
+  const zoomCluster = page.locator('[data-full-song-zoom]')
+
+  // (1) Controls present at 100%, fit at the viewport (no horizontal overflow).
+  expect(await zoomCluster.getAttribute('data-full-song-zoom')).toBe('100')
+  const fitMetrics = await grid.evaluate((el) => ({
+    scrollWidth: el.scrollWidth,
+    clientWidth: el.clientWidth,
+  }))
+  // At zoom 1 the content fits within ~1px of the viewport.
+  expect(fitMetrics.scrollWidth).toBeLessThanOrEqual(fitMetrics.clientWidth + 1)
+
+  // (2) Zoom in twice → readout grows and the content overflows the viewport.
+  await page.locator('[data-full-song-zoom-in]').click()
+  await page.locator('[data-full-song-zoom-in]').click()
+  const zoomed = await zoomCluster.getAttribute('data-full-song-zoom')
+  expect(Number(zoomed)).toBeGreaterThan(100) // 1.5×1.5 = 225
+  const zoomedMetrics = await grid.evaluate((el) => ({
+    scrollWidth: el.scrollWidth,
+    clientWidth: el.clientWidth,
+  }))
+  expect(zoomedMetrics.scrollWidth).toBeGreaterThan(zoomedMetrics.clientWidth + 10)
+
+  // (3) Scrolling the grid drives the ruler content (shared scrollLeft).
+  await grid.evaluate((el) => {
+    el.scrollLeft = 80
+    el.dispatchEvent(new Event('scroll', { bubbles: true }))
+  })
+  await page.waitForTimeout(120)
+  const rulerTransform = await page
+    .locator('[data-full-song="ruler-content"]')
+    .evaluate((el) => (el as HTMLElement).style.transform)
+  expect(rulerTransform).toContain('translateX(-80px)')
+
+  // (4) Fit returns to 100% and refits to the viewport.
+  await page.locator('[data-full-song-zoom-fit]').click()
+  expect(await zoomCluster.getAttribute('data-full-song-zoom')).toBe('100')
+  const refit = await grid.evaluate((el) => ({
+    scrollWidth: el.scrollWidth,
+    clientWidth: el.clientWidth,
+    scrollLeft: el.scrollLeft,
+  }))
+  expect(refit.scrollWidth).toBeLessThanOrEqual(refit.clientWidth + 1)
+  expect(refit.scrollLeft).toBe(0)
+
+  // (5) Bars toggle adds beat ticks (zoom in first so beats clear the px floor).
+  await page.locator('[data-full-song-zoom-in]').click()
+  await page.locator('[data-full-song-zoom-in]').click()
+  const unitsToggle = page.locator('[data-full-song-units-toggle]')
+  expect(await unitsToggle.textContent()).toBe('CYCLES')
+  await unitsToggle.click()
+  expect(await unitsToggle.textContent()).toBe('BARS')
+  expect(await page.locator('[data-full-song-tick="beat"]').count()).toBeGreaterThan(0)
+
+  // Visual evidence (observe, don't infer).
+  await page.screenshot({ path: 'test-results/full-song-zoom-bars.png' })
+
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})

--- a/packages/app/tests/full-song-zoom-ruler.spec.ts
+++ b/packages/app/tests/full-song-zoom-ruler.spec.ts
@@ -133,6 +133,19 @@ test('full-song view: zoom widens + scrolls, Fit refits, bars toggle adds beat t
   expect(refit.scrollWidth).toBeLessThanOrEqual(refit.clientWidth + 1)
   expect(refit.scrollLeft).toBe(0)
 
+  // (4b) ⌘/Ctrl + wheel zooms via the native non-passive listener (the unique
+  //      glue the buttons don't exercise: preventDefault + cursor-x).
+  const box = await grid.boundingBox()
+  if (box) {
+    await page.keyboard.down(MOD)
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2)
+    await page.mouse.wheel(0, -120) // wheel up → zoom in
+    await page.keyboard.up(MOD)
+    await page.waitForTimeout(120)
+    expect(Number(await zoomCluster.getAttribute('data-full-song-zoom'))).toBeGreaterThan(100)
+    await page.locator('[data-full-song-zoom-fit]').click() // reset for the bars step
+  }
+
   // (5) Bars toggle adds beat ticks (zoom in first so beats clear the px floor).
   await page.locator('[data-full-song-zoom-in]').click()
   await page.locator('[data-full-song-zoom-in]').click()


### PR DESCRIPTION
## Summary
Closes the near-term **#412** gaps on the full-song timeline (#385): horizontal **zoom**, horizontal **scroll**, and an optional **bars/beats ruler** — the closeable divergences a grounded UI audit found vs a standard DAW arrangement view. Editable clips/regions stay **Phase-19-gated** (structural Stack/cat/arrange mutations, not text-subset edits).

App-only change (no editor `dist`). Base = `studio_v0.2.0`.

## What changed
- **`songAxis.ts`** — pure, unit-tested helpers: `clampZoom` / `contentWidthFor` / `scrollLeftForZoom` (cursor-centred) and `rulerTicks`. Cycles labels are 0-indexed (Strudel + cell-tooltip convention); bars are 1-indexed (DAW convention) with 1/4-cycle beat ticks at the default **4 beats/bar**. One cycle ≈ one bar in Strudel (no fixed meter), so BARS is a relabel + beat subdivisions, not a re-timing.
- **`FullSongTimeline.tsx`** — content renders at `viewportWidth * zoom`: **zoom=1 fits the whole loop** (unchanged default), >1 widens past the viewport and the grid scrolls horizontally; the ruler tracks the grid's `scrollLeft` via `translateX` (one scrollbar). Zoom via **`[Fit] [−] [+]`** buttons **and ⌘/Ctrl+wheel** (cursor-centred — a native non-passive listener so `preventDefault` suppresses browser page-zoom; macOS trackpad pinch zooms the view too). A **CYCLES↔BARS** units toggle, numeric ruler ticks, and faint bar/cycle gridlines. Seek math maps `viewport-x + scrollLeft` against `contentWidth`, so clicks resolve at any zoom/scroll.

## Grounding
DAW-standard zoom (fit default + zoom-in + horizontal scroll) and the 4-beats-per-bar ruler default match common arrangement-view conventions; Strudel's cycle/cps model means BARS is a 1:1 relabel of cycles with beat subdivisions.

## Test plan
- **Unit** (`songAxis.test.ts`): zoom clamp, content width, cursor-centred scroll, tick generation (cycles/bars/beats/thinning/degenerate). 
- **Component** (`FullSongTimeline.test.tsx`): controls render at 100% with Fit/− disabled; + zooms to 150% and enables them; CYCLES↔BARS toggle adds beat ticks. Existing coverage (lanes/cells/sections/empty/seek/period) unchanged.
- **App unit suite: 485 green** (was 470 baseline).
- **e2e** (`full-song-zoom-ruler.spec.ts`): real app — + overflows the viewport (scrollWidth > clientWidth) and grows the readout; scrolling drives the ruler (`translateX(-80px)`); Fit refits to 100%/scrollLeft 0; BARS adds beat ticks; no console/page errors. Existing `full-song-timeline` + `full-song-cold-eval` specs still green.
- **Observed in-app** (screenshots): `100%/CYCLES` fits with `0 1 2 3` labels + playhead; `225%/BARS` widens, scrolls to bar 3, shows beat ticks.

## Out of scope (tracked / gated)
- Editable clips/regions → Phase-19 arrangement engine (#386 retargeted).
- The live 2-cycle window stays a read-only livecoding monitor (intentional).

closes #412