### PR TITLE
✨ Song view: follow playhead (auto-scroll) + ruler tick-density cap (#415)

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -33,12 +33,16 @@ import {
   clampZoom,
   contentWidthFor,
   scrollLeftForZoom,
+  followScrollLeft,
   rulerTicks,
   MIN_ZOOM,
   ZOOM_STEP,
 } from './musicalTimeline/songAxis'
 
 const TAB_ID = 'musical-timeline'
+/** How long a manual scroll/seek suspends follow (#415), so auto-scroll never
+ *  fights the user mid-gesture, then resumes once they've settled. */
+const USER_SCROLL_GUARD_MS = 1200
 const CONTROLS_HEIGHT = 26
 const TOPBAR_HEIGHT = 28
 const GUTTER_WIDTH = 90
@@ -105,6 +109,23 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
   const areaWidthRef = useRef(areaWidth)
   areaWidthRef.current = areaWidth
 
+  // ── Follow / auto-scroll (#415) ──────────────────────────────────────────
+  // When zoomed, the playhead can advance off the right edge. Follow nudges
+  // scrollLeft to keep it in a centered dead-zone band (followScrollLeft). It
+  // pauses briefly while the user manually scrolls/seeks so it never fights
+  // their navigation. displayCyclesRef lets the rAF loop read the live span
+  // without re-creating the loop per analysis change.
+  const [follow, setFollow] = useState(true)
+  const followRef = useRef(follow)
+  followRef.current = follow
+  const displayCyclesRef = useRef(displayCycles)
+  displayCyclesRef.current = displayCycles
+  // Suspends follow until this timestamp (set on user scroll/seek).
+  const userScrollUntilRef = useRef(0)
+  // The last scrollLeft *we* wrote to the DOM — lets the scroll handler tell a
+  // follow/zoom-driven scroll (don't suspend) from a user drag/wheel (suspend).
+  const programmaticScrollRef = useRef(-1)
+
   const contentWidth = contentWidthFor(areaWidth, zoom)
   const pxPerCycle = displayCycles > 0 ? contentWidth / displayCycles : 0
   const ticks = rulerTicks(displayCycles, pxPerCycle, units)
@@ -167,6 +188,9 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     const maxScroll = Math.max(0, contentWidthFor(areaWidth, zoom) - areaWidth)
     const clamped = Math.max(0, Math.min(maxScroll, scrollLeftRef.current))
     scrollLeftRef.current = clamped
+    // This is a programmatic (zoom/resize-driven) scroll, not a user drag —
+    // mark it so the scroll handler doesn't suspend follow.
+    programmaticScrollRef.current = clamped
     if (el.scrollLeft !== clamped) el.scrollLeft = clamped
     setScrollLeft((prev) => (prev === clamped ? prev : clamped))
   }, [zoom, areaWidth])
@@ -175,6 +199,11 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     const sl = e.currentTarget.scrollLeft
     scrollLeftRef.current = sl
     setScrollLeft((prev) => (prev === sl ? prev : sl))
+    // A scroll we didn't write (> 1px from our last programmatic value) is a
+    // user drag/wheel-pan → suspend follow briefly so it doesn't fight them.
+    if (Math.abs(sl - programmaticScrollRef.current) > 1) {
+      userScrollUntilRef.current = Date.now() + USER_SCROLL_GUARD_MS
+    }
   }, [])
 
   // ── rAF playhead, gated on drawer-open + active-tab (DB-02 parity) ───────
@@ -184,6 +213,28 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
   useEffect(() => {
     let cancelled = false
     let raf: number | null = null
+    // Auto-scroll the grid so the playhead stays in a centered band, unless
+    // follow is off or the user just scrolled/seeked. The DOM write is tagged
+    // programmatic (via programmaticScrollRef) so the scroll handler doesn't
+    // mistake it for a user drag and suspend follow. Reads live state through
+    // refs; the playhead element itself stays put in content space, so the grid
+    // scroll is the only motion. No-op when not zoomed (followScrollLeft → cur).
+    const applyFollow = (pos: number | null): void => {
+      if (!followRef.current || pos == null) return
+      if (Date.now() < userScrollUntilRef.current) return
+      const dc = displayCyclesRef.current
+      const vw = areaWidthRef.current
+      const cw = contentWidthFor(vw, zoomRef.current)
+      const ph = songCycleToX(wrapSongPosition(pos, dc), dc, cw)
+      const target = followScrollLeft(ph, vw, cw, scrollLeftRef.current)
+      if (Math.abs(target - scrollLeftRef.current) < 1) return
+      const el = areaRef.current
+      if (!el) return
+      programmaticScrollRef.current = target
+      scrollLeftRef.current = target
+      el.scrollLeft = target
+      setScrollLeft((prev) => (prev === target ? prev : target))
+    }
     const tick = (): void => {
       if (cancelled) return
       const a = accessorsRef.current
@@ -193,6 +244,7 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
       }
       const pos = a.getSongPosition()
       setSongPos((prev) => (prev === pos ? prev : pos))
+      applyFollow(pos)
       raf = requestAnimationFrame(tick)
     }
     if (props.getDrawerOpen() && props.getActiveTabId() === TAB_ID) {
@@ -233,6 +285,9 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
       const rect = el.getBoundingClientRect()
       const contentX = clientX - rect.left + scrollLeftRef.current
       const cycle = xToSongCycle(contentX, displayCycles, contentWidthFor(rect.width, zoomRef.current))
+      // A manual seek is user navigation — suspend follow briefly so it doesn't
+      // immediately yank the view back as the sought playhead resumes.
+      userScrollUntilRef.current = Date.now() + USER_SCROLL_GUARD_MS
       onSeek(cycle)
     },
     [displayCycles, onSeek],
@@ -283,6 +338,20 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
           {units === 'cycles' ? 'CYCLES' : 'BARS'}
         </button>
         <div style={styles.zoomCluster} data-full-song-zoom={zoomPercent}>
+          <button
+            type="button"
+            data-full-song-follow-toggle
+            data-follow={follow ? 'on' : 'off'}
+            aria-pressed={follow}
+            onClick={() => setFollow((f) => !f)}
+            style={{
+              ...styles.unitsToggle,
+              ...(follow ? styles.followOn : null),
+            }}
+            title={follow ? 'Following the playhead — click to stop' : 'Follow the playhead while playing'}
+          >
+            FOLLOW
+          </button>
           <button
             type="button"
             data-full-song-zoom-fit
@@ -509,6 +578,13 @@ const styles = {
     background: 'var(--bg-input, rgba(255,255,255,0.04))',
     color: 'var(--text-tertiary, rgba(255,255,255,0.55))',
     cursor: 'pointer' as const,
+  },
+  followOn: {
+    // Use the `border` shorthand (the base unitsToggle also sets `border`) —
+    // mixing it with the `borderColor` longhand warns on rerender in React.
+    border: '1px solid var(--accent, #6ea8fe)',
+    color: 'var(--accent, #6ea8fe)',
+    background: 'var(--accent-faint, rgba(110,168,254,0.12))',
   },
   zoomCluster: { display: 'flex', alignItems: 'center', gap: 4 },
   zoomButton: {

--- a/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
+++ b/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
@@ -151,6 +151,32 @@ describe('FullSongTimeline', () => {
     expect((container.querySelector('[data-full-song-zoom-fit]') as HTMLButtonElement).disabled).toBe(false)
   })
 
+  // ── Follow toggle (#415) ───────────────────────────────────────────────────
+
+  it('renders the Follow toggle defaulting to on', async () => {
+    const { container } = renderFull()
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const toggle = container.querySelector('[data-full-song-follow-toggle]') as HTMLButtonElement
+    expect(toggle).not.toBeNull()
+    expect(toggle.getAttribute('data-follow')).toBe('on')
+    expect(toggle.getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('flips Follow off on click', async () => {
+    const { container } = renderFull()
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const toggle = container.querySelector('[data-full-song-follow-toggle]') as HTMLButtonElement
+    await act(async () => {
+      toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(toggle.getAttribute('data-follow')).toBe('off')
+    expect(toggle.getAttribute('aria-pressed')).toBe('false')
+  })
+
   it('toggles CYCLES ↔ BARS and adds beat ticks in bars mode', async () => {
     const { container } = renderFull()
     await act(async () => {

--- a/packages/app/src/components/musicalTimeline/__tests__/songAxis.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/songAxis.test.ts
@@ -6,10 +6,12 @@ import {
   clampZoom,
   contentWidthFor,
   scrollLeftForZoom,
+  followScrollLeft,
   rulerTicks,
   MIN_ZOOM,
   MAX_ZOOM,
   BEATS_PER_BAR,
+  MAX_TICKS,
 } from '../songAxis'
 
 describe('songCycleToX', () => {
@@ -133,6 +135,53 @@ describe('scrollLeftForZoom (cursor-centered)', () => {
   })
 })
 
+describe('followScrollLeft', () => {
+  // viewport 800, content 1600 (zoom 2) → maxScroll 800. Default band = middle
+  // 60% → in-band span of viewport-x is [160, 640].
+  it('returns the current offset unchanged when the playhead is in-band (no churn)', () => {
+    // playhead content-x 800, scrollLeft 400 → viewport-x 400 (dead centre).
+    expect(followScrollLeft(800, 800, 1600, 400)).toBe(400)
+    // viewport-x 640 (right band edge) is still in-band.
+    expect(followScrollLeft(1040, 800, 1600, 400)).toBe(400)
+  })
+
+  it('recenters the playhead when it exits the band to the right', () => {
+    // playhead content-x 1200, scrollLeft 0 → viewport-x 1200 > 640 → out of band.
+    // target = 1200 - 400 = 800 (clamped to maxScroll 800).
+    expect(followScrollLeft(1200, 800, 1600, 0)).toBe(800)
+  })
+
+  it('recenters when the playhead exits the band to the left', () => {
+    // playhead content-x 600, scrollLeft 700 → viewport-x -100 < 160 → out of band.
+    // target = 600 - 400 = 200.
+    expect(followScrollLeft(600, 800, 1600, 700)).toBe(200)
+  })
+
+  it('clamps (pins) at the song ends without oscillating', () => {
+    // near the end: playhead 1550, already scrolled to max 800 → viewport-x 750
+    // (out of band) but recenter target 1150 clamps back to 800 == current → no churn.
+    expect(followScrollLeft(1550, 800, 1600, 800)).toBe(800)
+    // near the start: playhead 40, scrollLeft 0 → target -360 clamps to 0.
+    expect(followScrollLeft(40, 800, 1600, 0)).toBe(0)
+  })
+
+  it('no-ops when there is nothing to scroll (not zoomed) or on degenerate input', () => {
+    // content == viewport → maxScroll 0 → returns the clamped current offset.
+    expect(followScrollLeft(400, 800, 800, 0)).toBe(0)
+    expect(followScrollLeft(400, 0, 1600, 123)).toBe(123) // viewportWidth 0
+    expect(followScrollLeft(Number.NaN, 800, 1600, 400)).toBe(400) // non-finite playhead
+    // an out-of-range current offset is clamped into the scrollable range: with
+    // current clamped to 800, a playhead at 1200 is dead-centre → in-band → 800.
+    expect(followScrollLeft(1200, 800, 1600, 5000)).toBe(800)
+  })
+
+  it('recenters on every step when deadZone is 0', () => {
+    // band 0 → in-band span collapses to the exact centre; any drift recenters.
+    // playhead 820, scrollLeft 400 → viewport-x 420 ≠ 400 → target 820 - 400 = 420.
+    expect(followScrollLeft(820, 800, 1600, 400, { deadZone: 0 })).toBe(420)
+  })
+})
+
 describe('rulerTicks', () => {
   it('emits a 0-indexed major per cycle when there is room (CYCLES)', () => {
     const ticks = rulerTicks(4, 200, 'cycles')
@@ -158,6 +207,23 @@ describe('rulerTicks', () => {
     const ticks = rulerTicks(64, 12.5, 'cycles')
     expect(ticks.map((t) => t.cycle)).toEqual([0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60])
   })
+  it('caps the total tick count on a long song at high zoom (#415)', () => {
+    // 4000 cycles × 1000px/cycle would emit 4000 majors uncapped → thin by
+    // powers of two until majors fit the budget.
+    const ticks = rulerTicks(4000, 1000, 'cycles')
+    expect(ticks.length).toBeLessThanOrEqual(MAX_TICKS)
+    // step doubled to 8 (4000/8 = 500 ≤ 600) → first majors are 0, 8, 16…
+    expect(ticks.slice(0, 3).map((t) => t.cycle)).toEqual([0, 8, 16])
+  })
+
+  it('drops beats when they would blow the budget, keeping only majors', () => {
+    // 256 bars at step 1 with wide beats: 256×4 = 1024 > MAX_TICKS → beats off.
+    const ticks = rulerTicks(256, 250, 'bars')
+    expect(ticks.every((t) => t.major)).toBe(true)
+    expect(ticks.length).toBe(256)
+    expect(ticks.length).toBeLessThanOrEqual(MAX_TICKS)
+  })
+
   it('returns [] for degenerate inputs', () => {
     expect(rulerTicks(0, 100, 'cycles')).toEqual([])
     expect(rulerTicks(4, 0, 'cycles')).toEqual([])

--- a/packages/app/src/components/musicalTimeline/songAxis.ts
+++ b/packages/app/src/components/musicalTimeline/songAxis.ts
@@ -107,11 +107,67 @@ export function scrollLeftForZoom(params: {
   return Math.max(0, Math.min(maxScroll, next))
 }
 
+// ── Follow / auto-scroll (#415) ──────────────────────────────────────────────
+//
+// When zoomed in, the playhead can advance past the right edge of the viewport
+// while playing. "Follow" mode auto-scrolls to keep it in view. This helper is
+// renderer-agnostic — it only computes a target `scrollLeft` from the playhead's
+// CONTENT-space x (already produced by `songCycleToX` against `contentWidth`),
+// so it carries straight into the canvas view (the timeline never re-derives it).
+//
+// A centered dead-zone band avoids churn: while the playhead drifts within the
+// band the current offset is returned unchanged (so the caller's `prev === next`
+// guard short-circuits). Once it exits the band the playhead is recentered,
+// clamped to the scrollable range — at the song's ends it simply pins to the
+// edge (no oscillation, because the clamped target equals the clamped current).
+
+export interface FollowOptions {
+  /** Width of the centered no-scroll band as a fraction of the viewport. The
+   *  playhead may drift within this band without triggering an auto-scroll.
+   *  0 = recenter on every step; 1 = only scroll once it leaves the viewport.
+   *  Clamped to [0, 1]. Default 0.6 (the middle 60%). */
+  readonly deadZone?: number
+}
+
+const DEFAULT_DEAD_ZONE = 0.6
+
+/**
+ * Target horizontal scroll offset that keeps the playhead within a centered
+ * dead-zone band. `playheadX` is the playhead's content-space x (e.g. from
+ * `songCycleToX(pos, displayCycles, contentWidth)`). Returns the (clamped)
+ * current offset when the playhead is already in-band or there is nothing to
+ * scroll (`contentWidth ≤ viewportWidth`), so callers can no-op on no change.
+ */
+export function followScrollLeft(
+  playheadX: number,
+  viewportWidth: number,
+  contentWidth: number,
+  currentScrollLeft: number,
+  opts: FollowOptions = {},
+): number {
+  const maxScroll = Math.max(0, contentWidth - viewportWidth)
+  const clampedCurrent = Math.max(0, Math.min(maxScroll, Number.isFinite(currentScrollLeft) ? currentScrollLeft : 0))
+  // Nothing to scroll (not zoomed) or degenerate input → pin to a valid offset.
+  if (viewportWidth <= 0 || maxScroll <= 0 || !Number.isFinite(playheadX)) return clampedCurrent
+  const band = Math.max(0, Math.min(1, opts.deadZone ?? DEFAULT_DEAD_ZONE))
+  const playheadViewportX = playheadX - clampedCurrent
+  const lowEdge = viewportWidth * (0.5 - band / 2)
+  const highEdge = viewportWidth * (0.5 + band / 2)
+  // In-band → no churn (return the clamped current offset unchanged).
+  if (playheadViewportX >= lowEdge && playheadViewportX <= highEdge) return clampedCurrent
+  // Out of band → recenter the playhead, clamped to the scrollable range.
+  return Math.max(0, Math.min(maxScroll, playheadX - viewportWidth / 2))
+}
+
 // ── Ruler ticks (#412) ───────────────────────────────────────────────────────
 
 /** Beats per bar for the BARS ruler. Strudel has no fixed meter (one cycle is
  *  one bar), so beats are a display subdivision; 4 is the universal DAW default. */
 export const BEATS_PER_BAR = 4
+
+/** Upper bound on the total number of ruler ticks (majors + beats) at any zoom,
+ *  so a long-horizon song can't flood the DOM with ~1k+ tick divs (#415). */
+export const MAX_TICKS = 600
 
 export interface RulerTick {
   /** Song cycle position (fractional for beat ticks). */
@@ -141,8 +197,17 @@ export function rulerTicks(
   const BEAT_MIN_PX = 14
   let step = 1
   while (step * pxPerCycle < MIN_MAJOR_PX) step *= 2
+  // Density cap (#415): a long song at high zoom can otherwise emit ~1k+ divs
+  // (e.g. 256 cycles × 4 beats). Thin majors by powers of two until the major
+  // count fits the budget, and only show beats if they fit too — so the total
+  // tick count never exceeds MAX_TICKS regardless of zoom/horizon.
+  while (displayCycles / step > MAX_TICKS) step *= 2
+  const majorCount = Math.ceil(displayCycles / step)
   const showBeats =
-    mode === 'bars' && step === 1 && pxPerCycle / BEATS_PER_BAR >= BEAT_MIN_PX
+    mode === 'bars' &&
+    step === 1 &&
+    pxPerCycle / BEATS_PER_BAR >= BEAT_MIN_PX &&
+    majorCount * BEATS_PER_BAR <= MAX_TICKS
   const ticks: RulerTick[] = []
   for (let c = 0; c < displayCycles; c += step) {
     ticks.push({ cycle: c, label: mode === 'bars' ? String(c + 1) : String(c), major: true })

--- a/packages/app/tests/full-song-follow.spec.ts
+++ b/packages/app/tests/full-song-follow.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Full-song view: follow playhead (auto-scroll) — Playwright observation spec (#415).
+ *
+ * AnviDev observe gate: songAxis.test.ts covers the followScrollLeft math and
+ * FullSongTimeline.test.tsx covers the toggle in jsdom (which has no real
+ * layout/scroll); this drives the REAL app to confirm the end-to-end behaviour
+ * against a real playing song —
+ *   1. With the song zoomed in and Follow ON (default), the grid auto-scrolls
+ *      to keep the moving playhead within the viewport (scrollLeft tracks it).
+ *   2. With Follow OFF, the view stays where the user left it (no auto-scroll)
+ *      even as the playhead drifts past the edge.
+ *   3. No console / page errors throughout.
+ *
+ * INPUT NOTE (same as the sibling specs): the eval reads the FILE STORE, so the
+ * analyzed song is the starter example — assertions are generic (the playhead
+ * moves, the view follows / stops following), never a fixed scroll value.
+ *
+ * AUDIO NOTE: playback is real but not audibly observed here; this spec watches
+ * the scroll geometry only.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+const STORAGE_KEYS = {
+  height: 'stave:bottomPanel.height',
+  open: 'stave:bottomPanel.open',
+  activeTabId: 'stave:bottomPanel.activeTabId',
+} as const
+
+async function preOpenDrawer(page: Page): Promise<void> {
+  await page.addInitScript(
+    ([heightKey, openKey, activeKey]: readonly string[]) => {
+      try {
+        window.localStorage.setItem(heightKey, '320')
+        window.localStorage.setItem(openKey, 'true')
+        window.localStorage.setItem(activeKey, 'musical-timeline')
+      } catch {
+        /* ignore */
+      }
+    },
+    [STORAGE_KEYS.height, STORAGE_KEYS.open, STORAGE_KEYS.activeTabId],
+  )
+}
+
+async function bootShell(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => {
+      const m = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+      return (m?.editor?.getEditors?.()?.length ?? 0) > 0
+    },
+    { timeout: 20_000 },
+  )
+}
+
+async function evalStrudel(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+    const editors = (monaco?.editor?.getEditors?.() ?? []) as Array<{
+      getModel: () => { getLanguageId?: () => string } | null
+      focus: () => void
+    }>
+    const target = editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
+    target?.focus()
+  })
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1800)
+}
+
+/** Sample the grid's scrollLeft, the playhead's content-x, and the viewport
+ *  width over `n` ticks spaced `gapMs` apart. */
+async function sampleScroll(
+  page: Page,
+  n: number,
+  gapMs: number,
+): Promise<Array<{ scrollLeft: number; playheadX: number; clientWidth: number }>> {
+  const out: Array<{ scrollLeft: number; playheadX: number; clientWidth: number }> = []
+  for (let i = 0; i < n; i++) {
+    const s = await page.locator('[data-full-song="grid"]').evaluate((el) => {
+      const playhead = el.querySelector('[data-full-song="playhead"]') as HTMLElement | null
+      return {
+        scrollLeft: el.scrollLeft,
+        // offsetLeft is content-space x (grid-content is not translated; the
+        // grid scrolls natively), so playheadX - scrollLeft is the on-screen x.
+        playheadX: playhead ? playhead.offsetLeft : Number.NaN,
+        clientWidth: el.clientWidth,
+      }
+    })
+    out.push(s)
+    if (i < n - 1) await page.waitForTimeout(gapMs)
+  }
+  return out
+}
+
+test('full-song view: Follow auto-scrolls to keep the playhead in view; off freezes it', async ({
+  page,
+}) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await preOpenDrawer(page)
+  await bootShell(page)
+  await evalStrudel(page)
+
+  // Enter the full-song view and wait for analysis + a live playhead.
+  const toggle = page.locator('[data-musical-timeline="view-toggle"]')
+  await toggle.waitFor({ timeout: 10_000 })
+  await toggle.click()
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+  await page.locator('[data-full-song="playhead"]').waitFor({ timeout: 8_000 })
+
+  // Follow defaults ON.
+  const followToggle = page.locator('[data-full-song-follow-toggle]')
+  expect(await followToggle.getAttribute('data-follow')).toBe('on')
+
+  // Zoom in hard so the content is many viewports wide — the playhead then
+  // sweeps well past the dead-zone band each cycle, forcing follow to scroll.
+  for (let i = 0; i < 6; i++) await page.locator('[data-full-song-zoom-in]').click()
+  const grid = page.locator('[data-full-song="grid"]')
+  const overflow = await grid.evaluate((el) => ({ sw: el.scrollWidth, cw: el.clientWidth }))
+  expect(overflow.sw).toBeGreaterThan(overflow.cw + 50)
+
+  // (1) Follow ON → over ~3s the view auto-scrolls (scrollLeft changes) and the
+  //     playhead never leaves the viewport.
+  const onSamples = await sampleScroll(page, 7, 450)
+  const onScrolls = onSamples.map((s) => s.scrollLeft)
+  const scrollRange = Math.max(...onScrolls) - Math.min(...onScrolls)
+  expect(scrollRange, `follow ON should auto-scroll; samples=${onScrolls.join(',')}`).toBeGreaterThan(5)
+  for (const s of onSamples) {
+    if (Number.isNaN(s.playheadX)) continue // playhead briefly absent between wraps
+    const viewportX = s.playheadX - s.scrollLeft
+    expect(viewportX).toBeGreaterThanOrEqual(-24)
+    expect(viewportX).toBeLessThanOrEqual(s.clientWidth + 24)
+  }
+
+  // (2) Follow OFF → the view stays put. Turn it off, park the scroll, wait past
+  //     the manual-scroll guard, then confirm scrollLeft no longer tracks.
+  await followToggle.click()
+  expect(await followToggle.getAttribute('data-follow')).toBe('off')
+  await grid.evaluate((el) => {
+    el.scrollLeft = 40
+    el.dispatchEvent(new Event('scroll', { bubbles: true }))
+  })
+  await page.waitForTimeout(1400) // > USER_SCROLL_GUARD_MS so any guard has lapsed
+  const offSamples = await sampleScroll(page, 4, 450)
+  const offScrolls = offSamples.map((s) => s.scrollLeft)
+  const offRange = Math.max(...offScrolls) - Math.min(...offScrolls)
+  expect(offRange, `follow OFF should freeze the view; samples=${offScrolls.join(',')}`).toBeLessThanOrEqual(2)
+
+  // Visual evidence (observe, don't infer).
+  await page.screenshot({ path: 'test-results/full-song-follow.png' })
+
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})


### PR DESCRIPTION
Closes #415. Stacked on #414 (Song-view zoom + ruler) — **base = `feat/song-view-zoom-ruler`**. Retarget to `studio_v0.2.0` once #414 merges.

## Problem
With Song-view horizontal zoom (#412) landed, a zoomed-in song lets the playhead scroll **out of the visible viewport** while playing — no auto-scroll kept it in view. Separately, a long-horizon song at extreme zoom could make `rulerTicks` emit ~1k+ tick/beat divs (e.g. 256 cycles × 4 beats).

## What changed
- **`followScrollLeft` helper** (`songAxis.ts`) — renderer-agnostic: returns a target `scrollLeft` that keeps the playhead within a centered **dead-zone band**. In-band → returns the clamped current offset (callers no-op on no change); out-of-band → recenter; at the song's ends → pins to the edge with no oscillation. Operates on the playhead's *content-space x*, so it carries straight into the planned canvas view.
- **`FOLLOW` toggle** in the Song-view controls (default **ON**). In the rAF playhead loop, follow applies `followScrollLeft` unless it's off or the user just scrolled/seeked. A short guard suspends follow during manual navigation; programmatic (follow/zoom-driven) scrolls are tagged so they don't self-suspend. No-op until zoomed.
- **Ruler tick-density cap** (`MAX_TICKS = 600`) — thin majors by powers of two until the count fits the budget, and only show beats if they fit too. Total tick count bounded at any zoom/horizon.

## Test plan
- **Unit** (`songAxis.test.ts`): `followScrollLeft` — in-band no-op, past-edge recenter (both directions), clamp/pin at ends, degenerate inputs, `deadZone: 0`; ruler cap — long-song majors capped, beats dropped when over budget.
- **Component** (`FullSongTimeline.test.tsx`): toggle renders default-on, flips off.
- **e2e** (`full-song-follow.spec.ts`): drives the real playing song — Follow **ON** auto-scrolls and keeps the playhead in view; Follow **OFF** freezes the view as the playhead drifts; no console/page errors; **screenshot observe**.
- Full app unit suite green (495); sibling `full-song-zoom-ruler` + `full-song-timeline` e2e still pass (no regression).

App-only — **no editor `dist`** touched. First phase of the canvas-timeline ladder (#416); the follow helper is reused by the later canvas view, not thrown away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)