### PR TITLE
✨ Song timeline: canvas display rewrite (per-track lanes + mini-note previews) (#419)

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -23,9 +23,12 @@
 'use client'
 
 import * as React from 'react'
-import { useEffect, useLayoutEffect, useRef, useState } from 'react'
-import type { SongAnalysis } from '@stave/editor'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import type { SongAnalysis, PatternIR } from '@stave/editor'
 import { paletteForTrack, trackIndexOf } from './musicalTimeline/colors'
+import { buildTimelineScene } from './musicalTimeline/timelineScene'
+import { collectNoteMarks } from './musicalTimeline/timelineMarks'
+import { SongTimelineCanvas } from './SongTimelineCanvas'
 import {
   songCycleToX,
   xToSongCycle,
@@ -56,6 +59,9 @@ type RulerUnits = 'cycles' | 'bars'
 export interface FullSongTimelineProps {
   /** Whole-song analysis, or null before the first analysis completes. */
   readonly analysis: SongAnalysis | null
+  /** The evaluated IR snapshot — source of the mini-note marks the canvas draws
+   *  (collected app-side over the display span). Null before the first eval. */
+  readonly ir?: PatternIR | null
   /** Transport-offset-aware song position (cycles), or null when stopped. */
   readonly getSongPosition: () => number | null
   /** Seek the transport to an absolute song cycle. */
@@ -296,13 +302,12 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
   const lanes = analysis?.lanes ?? []
   const sections = analysis?.sections ?? []
 
-  // Peak onset count across all lanes — normalises heatmap intensity so the
-  // busiest cell is full-opacity and quieter cells fade proportionally.
-  const peak = (() => {
-    let m = 1
-    for (const l of lanes) for (const c of l.onsetsByCycle) if (c > m) m = c
-    return m
-  })()
+  // Canvas scene: per-lane density (from analysis) + capped mini-note marks
+  // (collected app-side from the IR over the display span). Memoised so the
+  // collect + build run only when the analysis or IR changes — NOT on scroll or
+  // zoom (those only move the shared transform the canvas already redraws against).
+  const marks = useMemo(() => collectNoteMarks(props.ir ?? null, displayCycles), [props.ir, displayCycles])
+  const scene = useMemo(() => buildTimelineScene(analysis, marks), [analysis, marks])
 
   const periodLabel =
     analysis == null
@@ -313,9 +318,7 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
           ? `${analysis.horizonCycles}+ cycles`
           : `${analysis.horizonCycles} cycles`
 
-  const cellW = displayCycles > 0 ? contentWidth / displayCycles : 0
   const zoomPercent = Math.round(zoom * 100)
-  const majorTicks = ticks.filter((t) => t.major)
 
   return (
     <div data-full-song="root" role="region" aria-label="Song" style={styles.root}>
@@ -454,7 +457,12 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
             <div style={styles.emptyLabel}>No song to map yet — press play.</div>
           ) : (
             lanes.map((lane) => (
-              <div key={lane.laneKey} style={styles.laneLabel} title={lane.laneKey}>
+              <div
+                key={lane.laneKey}
+                data-full-song-lane={lane.laneKey}
+                style={styles.laneLabel}
+                title={lane.laneKey}
+              >
                 <span
                   style={{
                     ...styles.laneDot,
@@ -473,68 +481,24 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
           onScroll={handleGridScroll}
           onPointerDown={(e) => handleSeekAtClientX(e.clientX)}
         >
-          {/* Inner content is contentWidth wide; the grid scrolls it horizontally */}
+          {/* Inner content is contentWidth wide (the scroll spacer for the native
+              scrollbar); the canvas sits sticky inside and redraws the visible
+              slice, while the playhead stays a DOM element in content space. */}
           <div
             data-full-song="grid-content"
             style={{ ...styles.scrollContent, width: contentWidth }}
           >
-            {/* Section bands (full height, behind cells) */}
-            {areaWidth > 0 &&
-              sections.map((s) => {
-                const left = songCycleToX(s.startCycle, displayCycles, contentWidth)
-                const right = songCycleToX(s.endCycle, displayCycles, contentWidth)
-                return (
-                  <div
-                    key={`band-${s.startCycle}`}
-                    style={{
-                      ...styles.sectionBand,
-                      left,
-                      width: Math.max(0, right - left),
-                    }}
-                  />
-                )
-              })}
-            {/* Bar/cycle gridlines (faint, behind cells) — orientation when zoomed */}
-            {areaWidth > 0 &&
-              majorTicks.map((t) => (
-                <div
-                  key={`gridline-${t.cycle}`}
-                  style={{ ...styles.gridline, left: songCycleToX(t.cycle, displayCycles, contentWidth) }}
-                />
-              ))}
-            {/* Per-lane onset heatmap — sparse: a cell only where onsets > 0 */}
-            {areaWidth > 0 &&
-              lanes.map((lane, laneIdx) => {
-                const color = paletteForTrack(trackIndexOf(lane.laneKey), lane.laneKey)
-                return (
-                  <div
-                    key={lane.laneKey}
-                    data-full-song-lane={lane.laneKey}
-                    style={{ ...styles.laneRow, top: laneIdx * ROW_HEIGHT }}
-                  >
-                    {lane.onsetsByCycle.map((count, cycle) =>
-                      // Guard: only render cells within the displayed span so a
-                      // wider analysis horizon can never pile cells onto the edge
-                      // (the period-trim in analyzeSong keeps these equal, but the
-                      // view must not depend on that holding).
-                      count > 0 && cycle < displayCycles ? (
-                        <div
-                          key={cycle}
-                          data-full-song-cell={`${lane.laneKey}:${cycle}`}
-                          title={`${lane.laneKey} · cycle ${cycle} · ${count} onset${count === 1 ? '' : 's'}`}
-                          style={{
-                            ...styles.cell,
-                            left: songCycleToX(cycle, displayCycles, contentWidth),
-                            width: Math.max(1, cellW - 1),
-                            background: color,
-                            opacity: 0.25 + 0.75 * (count / peak),
-                          }}
-                        />
-                      ) : null,
-                    )}
-                  </div>
-                )
-              })}
+            {/* Canvas draws lanes (density + mini-note marks), sections, gridlines
+                — all the high-volume mass — over the shared transform (PV116). */}
+            {areaWidth > 0 && (
+              <SongTimelineCanvas
+                scene={scene}
+                scrollLeft={scrollLeft}
+                contentWidth={contentWidth}
+                viewportWidth={areaWidth}
+                rowHeight={ROW_HEIGHT}
+              />
+            )}
             {playheadVisible && (
               <div data-full-song="playhead" style={{ ...styles.playhead, left: playheadX }} />
             )}
@@ -729,35 +693,6 @@ const styles = {
     overflowY: 'hidden' as const,
     background: 'var(--bg-input, #0f0f1a)',
     cursor: 'pointer' as const,
-  },
-  sectionBand: {
-    position: 'absolute' as const,
-    top: 0,
-    bottom: 0,
-    borderLeft: '1px solid var(--border-subtle, rgba(255,255,255,0.05))',
-    pointerEvents: 'none' as const,
-  },
-  gridline: {
-    position: 'absolute' as const,
-    top: 0,
-    bottom: 0,
-    width: 1,
-    borderLeft: '1px solid var(--border-subtle, rgba(255,255,255,0.05))',
-    pointerEvents: 'none' as const,
-  },
-  laneRow: {
-    position: 'absolute' as const,
-    left: 0,
-    right: 0,
-    height: ROW_HEIGHT,
-    borderBottom: '1px solid var(--border-subtle, rgba(255,255,255,0.06))',
-  },
-  cell: {
-    position: 'absolute' as const,
-    top: 4,
-    height: ROW_HEIGHT - 8,
-    borderRadius: 2,
-    pointerEvents: 'none' as const,
   },
   playhead: {
     position: 'absolute' as const,

--- a/packages/app/src/components/MusicalTimeline.tsx
+++ b/packages/app/src/components/MusicalTimeline.tsx
@@ -1076,6 +1076,7 @@ export function MusicalTimeline(
       {viewMode === 'song' ? (
         <FullSongTimeline
           analysis={analysis}
+          ir={snapshot?.ir ?? null}
           getSongPosition={props.getSongPosition ?? (() => null)}
           onSeek={props.onSeek ?? (() => {})}
           getDrawerOpen={props.getDrawerOpen}

--- a/packages/app/src/components/SongTimelineCanvas.tsx
+++ b/packages/app/src/components/SongTimelineCanvas.tsx
@@ -1,0 +1,101 @@
+/**
+ * SongTimelineCanvas — the canvas surface for the Song timeline (#419).
+ *
+ * Owns a single `<canvas>` and redraws the `TimelineScene` via the pure
+ * `drawTimeline`. It sits **sticky** at the left edge inside the grid's scroll
+ * container (which provides the native scrollbar via a `contentWidth`-wide
+ * spacer), so it stays pinned to the viewport while the content scrolls and
+ * redraws the visible slice for the current `scrollLeft` (PV116 — canvas over
+ * the shared content-space transform; the DOM playhead + overlay position
+ * against the same transform).
+ *
+ * DIRTY-FLAGGED: it redraws only when the scene / transform / size changes
+ * (a rAF coalesces bursts), never on a free-running loop — the timeline is
+ * event-driven, not continuously animated (design §4.6). The playhead's
+ * continuous motion lives in the DOM overlay, so it never forces a canvas redraw.
+ *
+ * Main-thread first (design §4.7): the same `drawTimeline` moves into the
+ * OffscreenCanvas worker in Phase 4 only if profiling shows jank.
+ */
+'use client'
+
+import * as React from 'react'
+import { useEffect, useRef } from 'react'
+import type { TimelineScene } from './musicalTimeline/timelineScene'
+import { drawTimeline, type DrawTheme } from './musicalTimeline/drawTimeline'
+
+export interface SongTimelineCanvasProps {
+  readonly scene: TimelineScene
+  /** Horizontal scroll offset (content px hidden left) — from FullSongTimeline. */
+  readonly scrollLeft: number
+  /** Full content width = `contentWidthFor(viewportWidth, zoom)`. */
+  readonly contentWidth: number
+  /** Visible width (the grid's clientWidth). */
+  readonly viewportWidth: number
+  /** Per-lane row height (CSS px). */
+  readonly rowHeight: number
+}
+
+/** Literal dark-theme colors (canvas can't read CSS custom properties); these
+ *  mirror the DOM `FullSongTimeline` style fallbacks so the views match. */
+const DEFAULT_THEME: DrawTheme = {
+  background: '#0f0f1a',
+  rowAlt: 'rgba(255,255,255,0.02)',
+  section: 'rgba(255,255,255,0.04)',
+  sectionAlt: 'rgba(255,255,255,0.07)',
+  gridline: 'rgba(255,255,255,0.06)',
+}
+
+/** Cap the backing-store DPR — 2D fills are cheap, but matching the viz
+ *  `maxDpr` discipline keeps memory bounded on Retina. */
+const MAX_DPR = 2
+
+export function SongTimelineCanvas(props: SongTimelineCanvasProps): React.ReactElement {
+  const { scene, scrollLeft, contentWidth, viewportWidth, rowHeight } = props
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const height = Math.max(rowHeight, scene.lanes.length * rowHeight)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    // Coalesce bursts (a scroll + a resize in the same frame) into one draw.
+    const raf = requestAnimationFrame(() => {
+      const dpr = Math.min(MAX_DPR, typeof window !== 'undefined' ? window.devicePixelRatio || 1 : 1)
+      const cssW = Math.max(0, viewportWidth)
+      const cssH = Math.max(0, height)
+      const bw = Math.round(cssW * dpr)
+      const bh = Math.round(cssH * dpr)
+      if (canvas.width !== bw) canvas.width = bw
+      if (canvas.height !== bh) canvas.height = bh
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0) // draw in CSS px
+      drawTimeline(
+        ctx,
+        scene,
+        { scrollLeft, contentWidth, viewportWidth: cssW, rowHeight, height: cssH },
+        DEFAULT_THEME,
+      )
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [scene, scrollLeft, contentWidth, viewportWidth, rowHeight, height])
+
+  return (
+    <canvas
+      ref={canvasRef}
+      data-full-song-canvas
+      // Decorative: canvas is opaque to screen readers, so the accessible
+      // surface is the DOM overlay (lane labels, period, ruler) — design §4.3.
+      aria-hidden="true"
+      style={{
+        position: 'sticky',
+        left: 0,
+        top: 0,
+        display: 'block',
+        width: viewportWidth,
+        height,
+        pointerEvents: 'none', // seek/scroll are handled by the grid container
+      }}
+    />
+  )
+}

--- a/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
+++ b/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
@@ -13,6 +13,17 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import * as React from 'react'
 import { act, render, cleanup } from '@testing-library/react'
 import type { SongAnalysis } from '@stave/editor'
+
+// FullSongTimeline now pulls the editor runtime (collectCycles/laneKeyOf, via
+// timelineMarks) into its import graph; the real module drags in a CJS dep
+// (gifenc) that breaks vitest's loader. These props never pass a real `ir`, so
+// the stubs are loaded but never called — the mini-note collection path is
+// covered by the Playwright spec against a real song.
+vi.mock('@stave/editor', () => ({
+  collectCycles: () => [],
+  laneKeyOf: (ev: { trackId?: string; s?: string }) => ev?.trackId ?? ev?.s ?? '$default',
+}))
+
 import { FullSongTimeline } from '../FullSongTimeline'
 
 let mockGridWidth = 800
@@ -79,14 +90,18 @@ describe('FullSongTimeline', () => {
     expect(container.querySelector('[data-full-song-lane="hh"]')).not.toBeNull()
   })
 
-  it('renders section chips and onset cells once a width is known', async () => {
+  it('renders section chips on the ruler and mounts the canvas body', async () => {
     const { container } = renderFull()
     await act(async () => {
       await Promise.resolve()
     })
+    // Section chips live on the (DOM) ruler overlay.
     expect(container.querySelectorAll('[data-full-song-section]').length).toBe(2)
-    // bd has onsets in cycles 0 and 2 → 2 cells; hh in all 4 → 4 cells.
-    expect(container.querySelectorAll('[data-full-song-cell]').length).toBe(6)
+    // The onset heatmap is now drawn on the canvas (the per-cell DOM nodes are
+    // gone). Assert the canvas surface mounted; pixel output is covered by the
+    // drawTimeline unit tests + the Playwright screenshot.
+    expect(container.querySelector('[data-full-song-canvas]')).not.toBeNull()
+    expect(container.querySelectorAll('[data-full-song-cell]').length).toBe(0)
   })
 
   it('shows an empty state when there is no analysis', async () => {

--- a/packages/app/src/components/musicalTimeline/__tests__/drawTimeline.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/drawTimeline.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { drawTimeline, laneRenderMode, COARSEN_PX, type DrawTransform, type DrawTheme } from '../drawTimeline'
+import type { TimelineScene } from '../timelineScene'
+
+const theme: DrawTheme = {
+  background: '#000',
+  rowAlt: '#111',
+  section: '#222',
+  sectionAlt: '#333',
+  gridline: '#444',
+}
+
+interface Rect { x: number; y: number; w: number; h: number }
+
+/** Recording mock 2D context — captures every fillRect (the only primitive the
+ *  renderer uses) so tests can assert positions/counts without a real canvas. */
+function mockCtx() {
+  const rects: Rect[] = []
+  const ctx = {
+    fillStyle: '' as string,
+    globalAlpha: 1,
+    clearRect() {},
+    fillRect(x: number, y: number, w: number, h: number) {
+      rects.push({ x, y, w, h })
+    },
+  }
+  return { ctx: ctx as unknown as CanvasRenderingContext2D, rects }
+}
+
+const scene: TimelineScene = {
+  displayCycles: 4,
+  period: 4,
+  peakDensity: 2,
+  notesCapped: false,
+  sections: [{ startCycle: 0, endCycle: 4, laneKeys: ['lead'] }],
+  lanes: [
+    {
+      laneKey: 'lead',
+      color: '#0af',
+      density: [1, 0, 2, 0], // onsets at integer cycles 0 and 2
+      notes: [
+        { cycle: 0, pitch: 60, gain: 1 },
+        { cycle: 2, pitch: 72, gain: 0.5 },
+        { cycle: 2.5, pitch: 64, gain: 0.8 }, // fractional → only marks render here
+      ],
+      pitchMin: 60,
+      pitchMax: 72,
+    },
+  ],
+}
+
+describe('laneRenderMode', () => {
+  it('shows marks when a cycle is wide enough, density when narrow', () => {
+    expect(laneRenderMode(COARSEN_PX + 1, true)).toBe('marks')
+    expect(laneRenderMode(COARSEN_PX - 1, true)).toBe('density')
+  })
+  it('always uses density when the lane has no marks', () => {
+    expect(laneRenderMode(1000, false)).toBe('density')
+  })
+  it('degenerate pxPerCycle → density', () => {
+    expect(laneRenderMode(Number.NaN, true)).toBe('density')
+  })
+})
+
+describe('drawTimeline', () => {
+  const vw = 400
+
+  it('draws mini-note marks when zoomed in (a mark lands at the fractional cycle 2.5)', () => {
+    // contentWidth 4000 over 4 cycles = 1000px/cycle ≫ COARSEN_PX → marks mode.
+    const transform: DrawTransform = { scrollLeft: 0, contentWidth: 4000, viewportWidth: vw, rowHeight: 22, height: 22 }
+    const { ctx, rects } = mockCtx()
+    drawTimeline(ctx, scene, transform, theme)
+    // cycle 2.5 → contentX = (2.5/4)*4000 = 2500; with scrollLeft 0 it's off-screen
+    // (vw=400). Scroll so it's visible and re-check instead:
+    const { ctx: ctx2, rects: rects2 } = mockCtx()
+    drawTimeline(ctx2, scene, { ...transform, scrollLeft: 2400 }, theme)
+    const screenXof = (cycle: number) => (cycle / 4) * 4000 - 2400
+    const markAt25 = rects2.some((r) => Math.abs(r.x - screenXof(2.5)) < 1 && r.h === 3)
+    expect(markAt25).toBe(true)
+    // sanity: marks are short (h=3), unlike full-height bands/gridlines.
+    expect(rects2.some((r) => r.h === 3)).toBe(true)
+    expect(rects.length).toBeGreaterThan(0)
+  })
+
+  it('draws coarse density when zoomed out (no fractional-cycle rect)', () => {
+    // contentWidth 40 over 4 cycles = 10px/cycle < COARSEN_PX → density mode.
+    const transform: DrawTransform = { scrollLeft: 0, contentWidth: 40, viewportWidth: vw, rowHeight: 22, height: 22 }
+    const { ctx, rects } = mockCtx()
+    drawTimeline(ctx, scene, transform, theme)
+    const screenXof = (cycle: number) => (cycle / 4) * 40
+    // density only draws at integer cycles 0 and 2 — never at 2.5.
+    expect(rects.some((r) => Math.abs(r.x - screenXof(2.5)) < 0.5 && r.h !== 22)).toBe(false)
+    // and there IS a density cell at integer cycle 2 (padded height, not full).
+    expect(rects.some((r) => Math.abs(r.x - screenXof(2)) < 0.5)).toBe(true)
+  })
+
+  it('no-ops cleanly on a degenerate transform', () => {
+    const { ctx, rects } = mockCtx()
+    drawTimeline(ctx, scene, { scrollLeft: 0, contentWidth: 0, viewportWidth: 0, rowHeight: 22, height: 22 }, theme)
+    expect(rects.length).toBe(0)
+  })
+})

--- a/packages/app/src/components/musicalTimeline/__tests__/timelineScene.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/timelineScene.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import type { SongAnalysis } from '@stave/editor'
+import { buildTimelineScene, type SceneNote, type CollectedMarks } from '../timelineScene'
+
+const analysisFixture: SongAnalysis = {
+  periodCycles: 4,
+  horizonCycles: 8,
+  reachedCap: false,
+  lanes: [
+    { laneKey: 'bd', onsetsByCycle: [2, 0, 3, 0] },
+    { laneKey: 'lead', onsetsByCycle: [1, 1, 1, 1] },
+  ],
+  sections: [
+    { startCycle: 0, endCycle: 1, laneKeys: ['bd', 'lead'] },
+    { startCycle: 1, endCycle: 4, laneKeys: ['lead'] },
+  ],
+}
+
+function marks(entries: Record<string, SceneNote[]>, capped = false): CollectedMarks {
+  return { marksByLane: new Map(Object.entries(entries)), capped }
+}
+
+describe('buildTimelineScene', () => {
+  it('returns an empty scene for null analysis', () => {
+    const scene = buildTimelineScene(null)
+    expect(scene.lanes).toEqual([])
+    expect(scene.displayCycles).toBe(1)
+    expect(scene.period).toBeNull()
+    expect(scene.peakDensity).toBe(1)
+    expect(scene.notesCapped).toBe(false)
+  })
+
+  it('spans one loop period and carries density + peak', () => {
+    const scene = buildTimelineScene(analysisFixture)
+    expect(scene.displayCycles).toBe(4) // periodCycles wins over horizon
+    expect(scene.period).toBe(4)
+    expect(scene.lanes.map((l) => l.laneKey)).toEqual(['bd', 'lead']) // first-seen order
+    expect(scene.peakDensity).toBe(3) // busiest cell across lanes
+    expect(scene.lanes[0].density).toEqual([2, 0, 3, 0])
+    expect(scene.sections.length).toBe(2)
+  })
+
+  it('falls back to the horizon when no period was found', () => {
+    const noPeriod: SongAnalysis = { ...analysisFixture, periodCycles: null, horizonCycles: 8 }
+    const scene = buildTimelineScene(noPeriod)
+    expect(scene.displayCycles).toBe(8)
+    expect(scene.period).toBeNull()
+  })
+
+  it('merges note marks and computes per-lane pitch range', () => {
+    const scene = buildTimelineScene(
+      analysisFixture,
+      marks({
+        bd: [{ cycle: 0, pitch: null, gain: 1 }], // percussive → no pitch range
+        lead: [
+          { cycle: 0, pitch: 60, gain: 0.5 },
+          { cycle: 1, pitch: 72, gain: 1 },
+          { cycle: 2, pitch: 64, gain: 0.8 },
+        ],
+      }),
+    )
+    const bd = scene.lanes.find((l) => l.laneKey === 'bd')!
+    const lead = scene.lanes.find((l) => l.laneKey === 'lead')!
+    expect(bd.notes.length).toBe(1)
+    expect(bd.pitchMin).toBeNull()
+    expect(bd.pitchMax).toBeNull()
+    expect(lead.notes.length).toBe(3)
+    expect(lead.pitchMin).toBe(60)
+    expect(lead.pitchMax).toBe(72)
+  })
+
+  it('assigns a stable color per lane and leaves note-less lanes empty', () => {
+    const scene = buildTimelineScene(analysisFixture, marks({ bd: [{ cycle: 0, pitch: null, gain: 1 }] }))
+    expect(typeof scene.lanes[0].color).toBe('string')
+    expect(scene.lanes[0].color.length).toBeGreaterThan(0)
+    const lead = scene.lanes.find((l) => l.laneKey === 'lead')!
+    expect(lead.notes).toEqual([]) // no marks supplied for this lane
+  })
+
+  it('propagates the capped flag', () => {
+    const scene = buildTimelineScene(analysisFixture, marks({ bd: [] }, true))
+    expect(scene.notesCapped).toBe(true)
+  })
+})
+
+// `collectNoteMarks` (timelineMarks.ts) needs the runtime `collectCycles` from
+// `@stave/editor`, whose CJS `gifenc` dep breaks vitest's loader — so it isn't
+// unit-tested here (importing it would pull the editor bundle into this suite).
+// Its null-IR guard is trivial; the real collection path is covered by the
+// Playwright spec against a real evaluated song.

--- a/packages/app/src/components/musicalTimeline/drawTimeline.ts
+++ b/packages/app/src/components/musicalTimeline/drawTimeline.ts
@@ -1,0 +1,173 @@
+/**
+ * drawTimeline — pure canvas renderer for the Song timeline scene (#419).
+ *
+ * Draws a `TimelineScene` against the shared content-space transform (PV116):
+ * section bands, cycle gridlines, then per lane either the coarse onset DENSITY
+ * (when a cycle is narrow — marks would smear sub-pixel) or readable MINI-NOTE
+ * MARKS (when zoomed in). It draws in CSS pixels into the VISIBLE window only
+ * (the host translates by `scrollLeft`), so the work is O(visible), not
+ * O(whole song). DPR is the host's job: it scales the context before calling,
+ * so this function never touches `devicePixelRatio` — which also keeps it pure
+ * and testable against a recording mock context.
+ *
+ * No React, no DOM, no canvas creation — just draw calls. The host
+ * (`SongTimelineCanvas`) owns the surface, sizing, and dirty-flagged scheduling.
+ */
+
+import type { TimelineScene } from './timelineScene'
+
+/** The view transform + geometry the draw needs, all in CSS pixels. */
+export interface DrawTransform {
+  /** Horizontal scroll offset (content px hidden to the left). */
+  readonly scrollLeft: number
+  /** Full content width = `viewportWidth * zoom`. */
+  readonly contentWidth: number
+  /** Visible canvas width (CSS px). */
+  readonly viewportWidth: number
+  /** Per-lane row height (CSS px). */
+  readonly rowHeight: number
+  /** Total canvas height (CSS px) = `lanes.length * rowHeight`. */
+  readonly height: number
+}
+
+/** Resolved literal colors (canvas can't read CSS custom properties). */
+export interface DrawTheme {
+  readonly background: string
+  readonly rowAlt: string
+  readonly section: string
+  readonly sectionAlt: string
+  readonly gridline: string
+}
+
+/** Below this per-cycle width, individual note marks would smear sub-pixel, so
+ *  the lane falls back to coarse density blocks (design §4.2 readability). */
+export const COARSEN_PX = 28
+
+/**
+ * Which rendering a lane uses at a given zoom. Pure + exported so the readability
+ * switchover is unit-tested directly. A lane with no marks always draws density.
+ */
+export function laneRenderMode(pxPerCycle: number, hasNotes: boolean): 'density' | 'marks' {
+  if (!hasNotes || !Number.isFinite(pxPerCycle)) return 'density'
+  return pxPerCycle >= COARSEN_PX ? 'marks' : 'density'
+}
+
+/** Draw the whole scene into `ctx` (already DPR-scaled, in CSS px). */
+export function drawTimeline(
+  ctx: CanvasRenderingContext2D,
+  scene: TimelineScene,
+  transform: DrawTransform,
+  theme: DrawTheme,
+): void {
+  const { scrollLeft, contentWidth, viewportWidth, rowHeight, height } = transform
+  ctx.clearRect(0, 0, viewportWidth, height)
+  const dc = scene.displayCycles
+  if (dc <= 0 || contentWidth <= 0 || viewportWidth <= 0) return
+
+  const pxPerCycle = contentWidth / dc
+  const toScreenX = (cycle: number): number => (cycle / dc) * contentWidth - scrollLeft
+  // Visible cycle window — clamp the per-lane loops to what's on screen.
+  const firstCycle = Math.max(0, Math.floor(scrollLeft / pxPerCycle))
+  const lastCycle = Math.min(dc, Math.ceil((scrollLeft + viewportWidth) / pxPerCycle))
+
+  ctx.fillStyle = theme.background
+  ctx.fillRect(0, 0, viewportWidth, height)
+
+  // Section bands (full height, behind lanes).
+  scene.sections.forEach((s, i) => {
+    const x0 = toScreenX(s.startCycle)
+    const x1 = toScreenX(s.endCycle)
+    if (x1 <= 0 || x0 >= viewportWidth) return
+    const left = Math.max(0, x0)
+    const width = Math.min(viewportWidth, x1) - left
+    if (width <= 0) return
+    ctx.fillStyle = i % 2 === 0 ? theme.section : theme.sectionAlt
+    ctx.fillRect(left, 0, width, height)
+  })
+
+  // Cycle gridlines, coarsened so they never crowd below ~6px apart.
+  let gridStep = 1
+  while (gridStep * pxPerCycle < 6) gridStep *= 2
+  ctx.fillStyle = theme.gridline
+  for (let c = Math.ceil(firstCycle / gridStep) * gridStep; c <= lastCycle; c += gridStep) {
+    const x = toScreenX(c)
+    if (x < 0 || x > viewportWidth) continue
+    ctx.fillRect(x, 0, 1, height)
+  }
+
+  // Lanes.
+  scene.lanes.forEach((lane, idx) => {
+    const top = idx * rowHeight
+    if (idx % 2 === 1) {
+      ctx.fillStyle = theme.rowAlt
+      ctx.fillRect(0, top, viewportWidth, rowHeight)
+    }
+    if (laneRenderMode(pxPerCycle, lane.notes.length > 0) === 'density') {
+      drawDensity(ctx, lane, top, rowHeight, pxPerCycle, scene.peakDensity, firstCycle, lastCycle, toScreenX)
+    } else {
+      drawMarks(ctx, lane, top, rowHeight, pxPerCycle, viewportWidth, firstCycle, lastCycle, toScreenX)
+    }
+  })
+}
+
+function drawDensity(
+  ctx: CanvasRenderingContext2D,
+  lane: TimelineScene['lanes'][number],
+  top: number,
+  rowHeight: number,
+  pxPerCycle: number,
+  peak: number,
+  firstCycle: number,
+  lastCycle: number,
+  toScreenX: (c: number) => number,
+): void {
+  const padY = 4
+  const gap = pxPerCycle > 3 ? 1 : 0
+  const cellW = Math.max(1, pxPerCycle - gap)
+  const cellH = Math.max(1, rowHeight - 2 * padY)
+  const denom = peak > 0 ? peak : 1
+  ctx.fillStyle = lane.color
+  for (let c = firstCycle; c < lastCycle; c++) {
+    const count = lane.density[c] ?? 0
+    if (count <= 0) continue
+    ctx.globalAlpha = 0.25 + 0.75 * Math.min(1, count / denom)
+    ctx.fillRect(toScreenX(c), top + padY, cellW, cellH)
+  }
+  ctx.globalAlpha = 1
+}
+
+function drawMarks(
+  ctx: CanvasRenderingContext2D,
+  lane: TimelineScene['lanes'][number],
+  top: number,
+  rowHeight: number,
+  pxPerCycle: number,
+  viewportWidth: number,
+  firstCycle: number,
+  lastCycle: number,
+  toScreenX: (c: number) => number,
+): void {
+  const padY = 3
+  const markH = 3
+  const markW = Math.max(2, Math.min(6, pxPerCycle * 0.12))
+  const bandTop = top + padY
+  const bandH = Math.max(1, rowHeight - 2 * padY - markH)
+  const hasPitch =
+    lane.pitchMin != null && lane.pitchMax != null && lane.pitchMax > lane.pitchMin
+  ctx.fillStyle = lane.color
+  for (const n of lane.notes) {
+    if (n.cycle < firstCycle || n.cycle >= lastCycle) continue
+    const x = toScreenX(n.cycle)
+    if (x < -markW || x > viewportWidth) continue
+    let y: number
+    if (n.pitch != null && hasPitch) {
+      const t = (n.pitch - lane.pitchMin!) / (lane.pitchMax! - lane.pitchMin!)
+      y = bandTop + (1 - t) * bandH // high pitch near the band top (DAW convention)
+    } else {
+      y = bandTop + bandH / 2
+    }
+    ctx.globalAlpha = 0.4 + 0.6 * Math.min(1, Math.max(0, n.gain))
+    ctx.fillRect(x, y, markW, markH)
+  }
+  ctx.globalAlpha = 1
+}

--- a/packages/app/src/components/musicalTimeline/timelineMarks.ts
+++ b/packages/app/src/components/musicalTimeline/timelineMarks.ts
@@ -1,0 +1,59 @@
+/**
+ * timelineMarks — note-mark collection for the canvas Song timeline (#419).
+ *
+ * Split from `timelineScene.ts` because it needs the RUNTIME `collectCycles` /
+ * `laneKeyOf` from `@stave/editor` — importing those values pulls the whole
+ * editor bundle (and its CJS `gifenc` dep) into vitest, which breaks the loader.
+ * Keeping this in its own file lets `timelineScene.ts` (the pure builder) stay
+ * unit-testable without mocking. The real collection path is covered by the
+ * Playwright spec against a real evaluated song.
+ */
+
+import type { PatternIR } from '@stave/editor'
+import { collectCycles, laneKeyOf } from '@stave/editor'
+import { extractPitch } from './pitch'
+import { EMPTY_MARKS, type CollectedMarks, type SceneNote } from './timelineScene'
+
+/** Per-lane mini-note-mark cap, so a long/dense song can't retain unbounded
+ *  marks. Density (per-cycle counts) always covers the full span regardless. */
+export const NOTE_MARK_CAP_PER_LANE = 2000
+
+function clamp01(n: number): number {
+  if (!Number.isFinite(n)) return 1
+  return n < 0 ? 0 : n > 1 ? 1 : n
+}
+
+/**
+ * Collect read-only mini-note marks for the display span by querying the IR
+ * directly (`collectCycles`), grouped by the SAME `laneKeyOf` identity the
+ * analysis lanes use, capped per lane. `null` IR / non-positive span → empty.
+ *
+ * Deterministic for a given IR. Returns marks keyed by lane so the pure scene
+ * builder can merge them onto the matching analysis lanes.
+ */
+export function collectNoteMarks(
+  ir: PatternIR | null,
+  displayCycles: number,
+  capPerLane: number = NOTE_MARK_CAP_PER_LANE,
+): CollectedMarks {
+  if (!ir || !Number.isFinite(displayCycles) || displayCycles <= 0) return EMPTY_MARKS
+  const marksByLane = new Map<string, SceneNote[]>()
+  let capped = false
+  const events = collectCycles(ir, 0, Math.ceil(displayCycles))
+  for (const ev of events) {
+    const cycle = ev.begin
+    if (!Number.isFinite(cycle) || cycle < 0 || cycle >= displayCycles) continue
+    const key = laneKeyOf(ev)
+    let arr = marksByLane.get(key)
+    if (!arr) {
+      arr = []
+      marksByLane.set(key, arr)
+    }
+    if (arr.length >= capPerLane) {
+      capped = true
+      continue
+    }
+    arr.push({ cycle, pitch: extractPitch(ev)?.midi ?? null, gain: clamp01(ev.gain ?? 1) })
+  }
+  return { marksByLane, capped }
+}

--- a/packages/app/src/components/musicalTimeline/timelineScene.ts
+++ b/packages/app/src/components/musicalTimeline/timelineScene.ts
@@ -1,0 +1,118 @@
+/**
+ * timelineScene — the render-agnostic scene model for the canvas Song timeline
+ * (#419 / canvas milestone #416, design §4.4).
+ *
+ * The DOM `FullSongTimeline` drew its onset heatmap straight from `SongAnalysis`.
+ * The canvas view instead draws a `TimelineScene`: per-lane density (the same
+ * `onsetsByCycle` the heatmap used) PLUS capped mini-note marks (real note
+ * positions) so the renderer can show readable rhythm/pitch when zoomed in and
+ * coarse density when zoomed out (design §4.5). The scene is pure data over the
+ * shared content-space transform (PV116) — it knows nothing about canvas, DPR,
+ * or scroll. `drawTimeline` consumes it; `SongTimelineCanvas` owns the surface.
+ *
+ * This module is PURE (only TYPE imports from `@stave/editor`, so it stays out
+ * of vitest's CJS-`gifenc` trap). The note-mark COLLECTION — which needs the
+ * runtime `collectCycles`/`laneKeyOf` — lives in `timelineMarks.ts`; this
+ * builder merges its already-collected output as data.
+ */
+
+import type { SongAnalysis, SongSection } from '@stave/editor'
+import { paletteForTrack, trackIndexOf } from './colors'
+
+/** A single read-only mini-note mark within a lane. */
+export interface SceneNote {
+  /** Fractional song cycle of the onset (event `begin`), in `[0, displayCycles)`. */
+  readonly cycle: number
+  /** MIDI pitch for in-lane vertical placement, or null for percussive events. */
+  readonly pitch: number | null
+  /** Gain 0–1 — drives mark intensity. */
+  readonly gain: number
+}
+
+/** One timeline row. */
+export interface SceneLane {
+  readonly laneKey: string
+  readonly color: string
+  /** `onsetsByCycle` — onset count per integer cycle (the coarse density). */
+  readonly density: readonly number[]
+  /** Capped mini-note marks; empty when no IR / not collected. */
+  readonly notes: readonly SceneNote[]
+  /** Min/max MIDI across this lane's pitched marks (for in-lane Y auto-fit),
+   *  or null when the lane has no pitched marks (percussive). */
+  readonly pitchMin: number | null
+  readonly pitchMax: number | null
+}
+
+/** The full scene the canvas renderer draws. */
+export interface TimelineScene {
+  readonly lanes: readonly SceneLane[]
+  readonly sections: readonly SongSection[]
+  /** Display span in cycles (one loop period, or the analyzed horizon). ≥ 1. */
+  readonly displayCycles: number
+  /** Detected loop period, or null. */
+  readonly period: number | null
+  /** Peak onset count across all lanes — normalises density intensity. ≥ 1. */
+  readonly peakDensity: number
+  /** True when any lane's note marks were truncated at the cap (no silent loss
+   *  — the renderer can surface it; density still covers the whole span). */
+  readonly notesCapped: boolean
+}
+
+export interface CollectedMarks {
+  readonly marksByLane: ReadonlyMap<string, SceneNote[]>
+  /** True if any lane hit the cap (marks dropped — surfaced, not silent). */
+  readonly capped: boolean
+}
+
+/** A shared empty collection (the no-IR / no-marks default). */
+export const EMPTY_MARKS: CollectedMarks = { marksByLane: new Map(), capped: false }
+
+/**
+ * Build the render scene from the analysis (density, sections, span, period)
+ * merged with the collected note marks. PURE — no IR walk, no canvas. Lanes
+ * keep `analyzeSong`'s first-seen order and key, so the canvas rows line up
+ * with the DOM lane labels exactly.
+ */
+export function buildTimelineScene(
+  analysis: SongAnalysis | null,
+  marks: CollectedMarks = EMPTY_MARKS,
+): TimelineScene {
+  const displayCycles = analysis
+    ? Math.max(1, analysis.periodCycles ?? analysis.horizonCycles)
+    : 1
+  const lanesIn = analysis?.lanes ?? []
+
+  // Peak onset across all lanes (≥1) so the busiest cell is full-intensity.
+  let peakDensity = 1
+  for (const lane of lanesIn) {
+    for (const c of lane.onsetsByCycle) if (c > peakDensity) peakDensity = c
+  }
+
+  const lanes: SceneLane[] = lanesIn.map((lane) => {
+    const notes = marks.marksByLane.get(lane.laneKey) ?? []
+    let pitchMin: number | null = null
+    let pitchMax: number | null = null
+    for (const n of notes) {
+      if (n.pitch == null) continue
+      if (pitchMin == null || n.pitch < pitchMin) pitchMin = n.pitch
+      if (pitchMax == null || n.pitch > pitchMax) pitchMax = n.pitch
+    }
+    return {
+      laneKey: lane.laneKey,
+      color: paletteForTrack(trackIndexOf(lane.laneKey), lane.laneKey),
+      density: lane.onsetsByCycle,
+      notes,
+      pitchMin,
+      pitchMax,
+    }
+  })
+
+  return {
+    lanes,
+    sections: analysis?.sections ?? [],
+    displayCycles,
+    period: analysis?.periodCycles ?? null,
+    peakDensity,
+    notesCapped: marks.capped,
+  }
+}

--- a/packages/app/tests/full-song-canvas.spec.ts
+++ b/packages/app/tests/full-song-canvas.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * Full-song view: canvas display rewrite (#419 / #416) — Playwright observation.
+ *
+ * AnviDev observe gate: timelineScene + drawTimeline unit tests cover the scene
+ * merge and the coarsening switchover; FullSongTimeline.test mounts the canvas
+ * in jsdom (which has no 2D context). This drives the REAL app to confirm the
+ * canvas actually RENDERS against a real evaluated song —
+ *   1. The canvas body mounts (the per-cell DOM heatmap is gone).
+ *   2. Its backing store is DPR-sized and it draws CONTENT (not a blank fill) —
+ *      read back pixels and assert variance beyond the background colour.
+ *   3. Zoom + scroll + the #415 follow still drive it, no console errors.
+ *   4. Screenshots: fit (coarse density) and zoomed-in (mini-note marks).
+ *
+ * INPUT NOTE (as the sibling specs): eval reads the FILE STORE, so the analyzed
+ * song is the starter example — assertions are generic (canvas present, content
+ * drawn, lanes ≥ 1), never a fixed pixel value.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+const STORAGE_KEYS = {
+  height: 'stave:bottomPanel.height',
+  open: 'stave:bottomPanel.open',
+  activeTabId: 'stave:bottomPanel.activeTabId',
+} as const
+
+async function preOpenDrawer(page: Page): Promise<void> {
+  await page.addInitScript(
+    ([heightKey, openKey, activeKey]: readonly string[]) => {
+      try {
+        window.localStorage.setItem(heightKey, '320')
+        window.localStorage.setItem(openKey, 'true')
+        window.localStorage.setItem(activeKey, 'musical-timeline')
+      } catch {
+        /* ignore */
+      }
+    },
+    [STORAGE_KEYS.height, STORAGE_KEYS.open, STORAGE_KEYS.activeTabId],
+  )
+}
+
+async function bootShell(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => {
+      const m = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+      return (m?.editor?.getEditors?.()?.length ?? 0) > 0
+    },
+    { timeout: 20_000 },
+  )
+}
+
+async function evalStrudel(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+    const editors = (monaco?.editor?.getEditors?.() ?? []) as Array<{
+      getModel: () => { getLanguageId?: () => string } | null
+      focus: () => void
+    }>
+    const target = editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
+    target?.focus()
+  })
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1800)
+}
+
+/** True if the canvas has drawn content (pixels vary beyond a single flat fill). */
+async function canvasHasContent(page: Page): Promise<boolean> {
+  return page.locator('[data-full-song-canvas]').evaluate((el) => {
+    const canvas = el as HTMLCanvasElement
+    const ctx = canvas.getContext('2d')
+    if (!ctx || canvas.width === 0 || canvas.height === 0) return false
+    const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height)
+    // Sample for any pixel differing from the first — a blank/flat fill has none.
+    const r0 = data[0]
+    const g0 = data[1]
+    const b0 = data[2]
+    for (let i = 4; i < data.length; i += 4) {
+      if (data[i] !== r0 || data[i + 1] !== g0 || data[i + 2] !== b0) return true
+    }
+    return false
+  })
+}
+
+test('full-song view: canvas mounts, draws content, and zoom/scroll drive it', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await preOpenDrawer(page)
+  await bootShell(page)
+  await evalStrudel(page)
+
+  // Enter the full-song view.
+  const toggle = page.locator('[data-musical-timeline="view-toggle"]')
+  await toggle.waitFor({ timeout: 10_000 })
+  await toggle.click()
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+
+  // (1) The canvas body mounted; the old per-cell DOM heatmap is gone.
+  const canvas = page.locator('[data-full-song-canvas]')
+  await canvas.waitFor({ timeout: 10_000 })
+  expect(await page.locator('[data-full-song-cell]').count()).toBe(0)
+  expect(await page.locator('[data-full-song-lane]').count()).toBeGreaterThanOrEqual(1)
+
+  // (2) Backing store is DPR-sized and the canvas actually drew content.
+  const backing = await canvas.evaluate((el) => ({
+    w: (el as HTMLCanvasElement).width,
+    h: (el as HTMLCanvasElement).height,
+  }))
+  expect(backing.w).toBeGreaterThan(0)
+  expect(backing.h).toBeGreaterThan(0)
+  await expect.poll(() => canvasHasContent(page), { timeout: 5000 }).toBe(true)
+
+  // Screenshot — fit (coarse density across the whole song).
+  await page.screenshot({ path: 'test-results/full-song-canvas-fit.png' })
+
+  // (3) Zoom in hard → the canvas redraws (still content, no errors) and the
+  //     content overflows the viewport (scrollbar appears).
+  for (let i = 0; i < 6; i++) await page.locator('[data-full-song-zoom-in]').click()
+  await page.waitForTimeout(120)
+  const grid = page.locator('[data-full-song="grid"]')
+  const overflow = await grid.evaluate((el) => ({ sw: el.scrollWidth, cw: el.clientWidth }))
+  expect(overflow.sw).toBeGreaterThan(overflow.cw + 50)
+  await expect.poll(() => canvasHasContent(page), { timeout: 5000 }).toBe(true)
+
+  // Scroll the grid → canvas redraws the new slice (no error, still content).
+  await grid.evaluate((el) => {
+    el.scrollLeft = 200
+    el.dispatchEvent(new Event('scroll', { bubbles: true }))
+  })
+  await page.waitForTimeout(150)
+  await expect.poll(() => canvasHasContent(page), { timeout: 5000 }).toBe(true)
+
+  // Screenshot — zoomed in (mini-note marks where a cycle is wide).
+  await page.screenshot({ path: 'test-results/full-song-canvas-zoomed.png' })
+
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})

--- a/packages/app/tests/full-song-cold-eval.spec.ts
+++ b/packages/app/tests/full-song-cold-eval.spec.ts
@@ -89,7 +89,8 @@ test('Song view populates right after a cold eval — no round-trip, no empty ga
   // while still failing if the old multi-second empty gap regressed.
   await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 3_000 })
   expect(await page.locator('[data-full-song-lane]').count()).toBeGreaterThanOrEqual(1)
-  expect(await page.locator('[data-full-song-cell]').count()).toBeGreaterThan(0)
+  // Activity is drawn on the canvas now (#419); assert the surface mounted.
+  await page.locator('[data-full-song-canvas]').waitFor({ timeout: 3_000 })
 
   // A loop length / horizon is surfaced (not the misleading "press play").
   const period = await page

--- a/packages/app/tests/full-song-timeline.spec.ts
+++ b/packages/app/tests/full-song-timeline.spec.ts
@@ -119,9 +119,12 @@ test('full-song view: analysis renders, loop detected, ruler seek fires without 
   const laneCount = await page.locator('[data-full-song-lane]').count()
   expect(laneCount).toBeGreaterThanOrEqual(2)
 
-  // (2) Onset cells render.
-  const cellCount = await page.locator('[data-full-song-cell]').count()
-  expect(cellCount).toBeGreaterThan(0)
+  // (2) The lane activity is drawn on the canvas (the per-cell DOM heatmap was
+  //     replaced by SongTimelineCanvas in #419). Detailed canvas content/zoom
+  //     observation lives in full-song-canvas.spec.ts; here just assert the
+  //     surface mounted and the old DOM cells are gone.
+  await page.locator('[data-full-song-canvas]').waitFor({ timeout: 10_000 })
+  expect(await page.locator('[data-full-song-cell]').count()).toBe(0)
 
   // (3) A loop length is detected and surfaced.
   const period = await page


### PR DESCRIPTION
Phase 2 of the canvas clip-timeline milestone (#416). Replaces the Song view's DOM onset-heatmap with a **main-thread canvas** drawing per-track lanes over the shared content-space transform (PV116), keeping the #412 ruler/controls + #415 playhead/follow as the DOM overlay. **App-only — no editor dist.**

## What changed
- **`timelineScene.ts`** (pure) — `buildTimelineScene` merges analysis density (`onsetsByCycle`) with mini-note marks + per-lane pitch range. Only TYPE imports from `@stave/editor`, so it's unit-testable without the CJS-`gifenc` loader trap.
- **`timelineMarks.ts`** — `collectNoteMarks` derives capped mini-note marks app-side from the already-exported `collectCycles` + `laneKeyOf` over the display span (same lane identity `analyzeSong` uses). Isolated because it needs the editor *runtime*.
- **`drawTimeline.ts`** (pure) — `drawTimeline(ctx, scene, transform, theme)`: section bands, gridlines, then **density when a cycle is narrow** (marks would smear sub-pixel) / **mini-note marks when zoomed in** — the readability coarsening. Draws CSS-px into the visible window only; DPR is the host's job. Tested with a recording mock context.
- **`SongTimelineCanvas.tsx`** — canvas host: sticky at the grid viewport's left edge, DPR-scaled, **dirty-flagged** redraw (scene/scroll/size change — never a free-running loop; the playhead glides in the DOM overlay).
- **`FullSongTimeline`** — builds the scene (memoised on analysis/ir), swaps the heatmap for the canvas, keeps the lane gutter (now carrying `data-full-song-lane` for identity + a11y), ruler, controls, playhead, follow. New `ir` prop from `MusicalTimeline`. **Live toggle kept** (consolidation is a later call once the canvas view is validated).

## Test plan
- **Unit**: `timelineScene` (6 — span/period/peak, mark merge, pitch range, capped) + `drawTimeline` (6 — coarsening switchover, marks at fractional cycles vs density at integers, degenerate). App unit **507** green.
- **Component**: canvas mounts, ruler section chips intact, old DOM cells gone.
- **e2e** (`full-song-canvas.spec.ts`): drives the **real song** — canvas mounts, backing store DPR-sized, **pixel readback proves content is drawn**, zoom→overflow + redraw, scroll→redraw, no console errors. **Screenshots**: fit (density-capable) + zoomed (mini-note marks). Sibling `full-song-{timeline,cold-eval}` specs updated (cells → canvas).

## Observed
Fit view renders per-lane mini-note marks across the song; zoomed-in (1139%) shows individual marks spread by pitch with the ruler/follow/playhead overlay intact — screenshots in `test-results/`.

## Known watch-items (follow-ups, non-blocking)
- `collectNoteMarks` is synchronous on re-eval (bounded by the per-lane cap; the **worker move is Phase 4**, decided on profiled frames per design §4.7).
- Canvas theme is literal dark colors (not theme-aware yet).
- Density-coarsening isn't visually exercised by the short starter (period 4 → marks at all zooms); it's unit-tested.

## Non-goals (later phases)
Worker upgrade (Phase 4), click-to-expand + bind (Phase 3), clip-granularity + arrangement editing (Phase 5 / Phase-19).

Advances #416. Closes #419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)