### PR TITLE
✨ Song timeline: expand + bind — read-only inline notes → Pattern panel (#422)

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -28,6 +28,7 @@ import type { SongAnalysis, PatternIR } from '@stave/editor'
 import { paletteForTrack, trackIndexOf } from './musicalTimeline/colors'
 import { buildTimelineScene } from './musicalTimeline/timelineScene'
 import { collectNoteMarks } from './musicalTimeline/timelineMarks'
+import { computeLaneLayout, laneAtY, type LaneLayout } from './musicalTimeline/laneLayout'
 import { SongTimelineCanvas } from './SongTimelineCanvas'
 import {
   songCycleToX,
@@ -50,6 +51,9 @@ const CONTROLS_HEIGHT = 26
 const TOPBAR_HEIGHT = 28
 const GUTTER_WIDTH = 90
 const ROW_HEIGHT = 22
+/** Height of an expanded ("accordion") lane — tall enough for the read-only
+ *  note detail (pitch spread + per-beat grid) to be legible (#422, design §4.5). */
+const EXPANDED_ROW_HEIGHT = 96
 const FONT_MONO = '"JetBrains Mono", "Fira Code", ui-monospace, monospace'
 
 /** Ruler units (#412). CYCLES = Strudel's native numbering; BARS = DAW
@@ -70,6 +74,12 @@ export interface FullSongTimelineProps {
   readonly getDrawerOpen: () => boolean
   /** Active tab id — must equal the timeline tab for the rAF loop to run. */
   readonly getActiveTabId: () => string | null
+  /** Bind a clicked lane into the Pattern panel (#422, design §3.1). Receives the
+   *  lane's representative source-character offset (or null when the IR has no
+   *  source provenance). The parent maps it to a line and moves the editor
+   *  cursor, which re-detects the active chunk and rebinds the Sequencer/Piano
+   *  Roll. Optional — the view degrades to display-only when unset. */
+  readonly onBindLane?: (sourceOffset: number | null) => void
 }
 
 /** Display span: one loop period, or the analyzed horizon when none. ≥ 1. */
@@ -299,7 +309,6 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     [displayCycles, onSeek],
   )
 
-  const lanes = analysis?.lanes ?? []
   const sections = analysis?.sections ?? []
 
   // Canvas scene: per-lane density (from analysis) + capped mini-note marks
@@ -308,6 +317,55 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
   // zoom (those only move the shared transform the canvas already redraws against).
   const marks = useMemo(() => collectNoteMarks(props.ir ?? null, displayCycles), [props.ir, displayCycles])
   const scene = useMemo(() => buildTimelineScene(analysis, marks), [analysis, marks])
+
+  // ── Expand + bind (#422) ─────────────────────────────────────────────────
+  // Click/expand a lane → accordion it taller (read-only note detail) AND bind
+  // its pattern into the Pattern panel. Multi-expand is a Set (cross-track
+  // alignment). The layout is the single vertical source of truth shared by the
+  // canvas draw, the canvas host height, the DOM lane labels, and the hit-test.
+  const { onBindLane } = props
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set())
+  const layout = useMemo(
+    () => computeLaneLayout(scene.lanes, expanded, ROW_HEIGHT, EXPANDED_ROW_HEIGHT),
+    [scene.lanes, expanded],
+  )
+  // Refs so the double-click hit-test reads live scene/layout without stale
+  // closures (mirrors the scrollLeftRef/zoomRef pattern above).
+  const sceneRef = useRef(scene)
+  sceneRef.current = scene
+  const layoutRef = useRef<LaneLayout>(layout)
+  layoutRef.current = layout
+
+  // Toggle a lane's expansion and bind it into the Pattern panel. Binding fires
+  // on every activation (expand OR collapse) — clicking a lane selects it.
+  const activateLane = React.useCallback(
+    (laneKey: string) => {
+      const lane = sceneRef.current.lanes.find((l) => l.laneKey === laneKey)
+      onBindLane?.(lane?.sourceOffset ?? null)
+      setExpanded((prev) => {
+        const next = new Set(prev)
+        if (next.has(laneKey)) next.delete(laneKey)
+        else next.add(laneKey)
+        return next
+      })
+    },
+    [onBindLane],
+  )
+
+  // Double-click in the grid body → hit-test the Y to a lane (the spatial index
+  // is the layout) → activate it. Single click stays a seek (seek-anywhere).
+  const handleExpandAtClientY = React.useCallback(
+    (clientY: number) => {
+      const el = areaRef.current
+      if (!el) return
+      // The grid is full-height (vertical scroll lives on the parent body, which
+      // moves the grid's rect), so content-Y is just clientY minus the rect top.
+      const contentY = clientY - el.getBoundingClientRect().top
+      const laneKey = laneAtY(layoutRef.current, contentY)
+      if (laneKey != null) activateLane(laneKey)
+    },
+    [activateLane],
+  )
 
   const periodLabel =
     analysis == null
@@ -453,23 +511,34 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
       {/* Body: lane labels + onset heatmap grid */}
       <div style={styles.body}>
         <div data-full-song="lane-labels" style={styles.labels}>
-          {lanes.length === 0 ? (
+          {layout.boxes.length === 0 ? (
             <div style={styles.emptyLabel}>No song to map yet — press play.</div>
           ) : (
-            lanes.map((lane) => (
+            layout.boxes.map((box) => (
               <div
-                key={lane.laneKey}
-                data-full-song-lane={lane.laneKey}
-                style={styles.laneLabel}
-                title={lane.laneKey}
+                key={box.laneKey}
+                data-full-song-lane={box.laneKey}
+                data-expanded={box.expanded ? 'true' : 'false'}
+                style={{ ...styles.laneLabel, height: box.height }}
+                title={box.laneKey}
               >
+                <button
+                  type="button"
+                  data-full-song-lane-expand={box.laneKey}
+                  aria-pressed={box.expanded}
+                  aria-label={box.expanded ? `Collapse ${box.laneKey}` : `Expand ${box.laneKey} to view its notes`}
+                  onClick={() => activateLane(box.laneKey)}
+                  style={styles.laneCaret}
+                >
+                  {box.expanded ? '▾' : '▸'}
+                </button>
                 <span
                   style={{
                     ...styles.laneDot,
-                    background: paletteForTrack(trackIndexOf(lane.laneKey), lane.laneKey),
+                    background: paletteForTrack(trackIndexOf(box.laneKey), box.laneKey),
                   }}
                 />
-                <span style={styles.laneName}>{lane.laneKey}</span>
+                <span style={styles.laneName}>{box.laneKey}</span>
               </div>
             ))
           )}
@@ -480,6 +549,7 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
           style={styles.grid}
           onScroll={handleGridScroll}
           onPointerDown={(e) => handleSeekAtClientX(e.clientX)}
+          onDoubleClick={(e) => handleExpandAtClientY(e.clientY)}
         >
           {/* Inner content is contentWidth wide (the scroll spacer for the native
               scrollbar); the canvas sits sticky inside and redraws the visible
@@ -496,7 +566,7 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
                 scrollLeft={scrollLeft}
                 contentWidth={contentWidth}
                 viewportWidth={areaWidth}
-                rowHeight={ROW_HEIGHT}
+                layout={layout}
               />
             )}
             {playheadVisible && (
@@ -664,13 +734,29 @@ const styles = {
   },
   laneLabel: {
     height: ROW_HEIGHT,
-    padding: '0 8px',
+    padding: '5px 8px 0',
     display: 'flex',
-    alignItems: 'center',
-    gap: 6,
+    // Top-align so the dot/name sit at the lane's TOP edge — when a lane is
+    // expanded (taller) the label still lines up with the canvas row top.
+    alignItems: 'flex-start',
+    gap: 5,
     borderBottom: '1px solid var(--border-subtle, rgba(255,255,255,0.08))',
+    overflow: 'hidden',
   },
-  laneDot: { width: 7, height: 7, borderRadius: '50%', flexShrink: 0, display: 'inline-block' },
+  laneCaret: {
+    fontFamily: FONT_MONO,
+    fontSize: 9,
+    lineHeight: 1,
+    padding: 0,
+    marginTop: 1,
+    width: 11,
+    flexShrink: 0,
+    border: 'none',
+    background: 'transparent',
+    color: 'var(--text-tertiary, rgba(255,255,255,0.45))',
+    cursor: 'pointer' as const,
+  },
+  laneDot: { width: 7, height: 7, borderRadius: '50%', flexShrink: 0, display: 'inline-block', marginTop: 2 },
   laneName: {
     color: 'var(--text-tertiary, rgba(255,255,255,0.4))',
     fontSize: 10,

--- a/packages/app/src/components/MusicalTimeline.tsx
+++ b/packages/app/src/components/MusicalTimeline.tsx
@@ -1002,6 +1002,19 @@ export function MusicalTimeline(
     [snapshot],
   )
 
+  // Expand-to-bind for the Song view (#422, design §3.1): the canvas timeline
+  // hands up a lane's representative source offset; the SAME cursor-move seam as
+  // handleNoteClick reveals it, which re-detects the active chunk and rebinds the
+  // Pattern panel (Sequencer/Piano Roll) to that track. No second note editor.
+  const handleBindLane = React.useCallback(
+    (sourceOffset: number | null) => {
+      if (!snapshot?.source || sourceOffset == null) return
+      const line = countLines(snapshot.code, sourceOffset)
+      revealLineInFile(snapshot.source, line)
+    },
+    [snapshot],
+  )
+
   const bpm = cpsToBpm(currentCps)
   const barBeat = formatBarBeat(currentCycle)
 
@@ -1081,6 +1094,7 @@ export function MusicalTimeline(
           onSeek={props.onSeek ?? (() => {})}
           getDrawerOpen={props.getDrawerOpen}
           getActiveTabId={props.getActiveTabId}
+          onBindLane={handleBindLane}
         />
       ) : (
         <>

--- a/packages/app/src/components/SongTimelineCanvas.tsx
+++ b/packages/app/src/components/SongTimelineCanvas.tsx
@@ -22,6 +22,7 @@
 import * as React from 'react'
 import { useEffect, useRef } from 'react'
 import type { TimelineScene } from './musicalTimeline/timelineScene'
+import type { LaneLayout } from './musicalTimeline/laneLayout'
 import { drawTimeline, type DrawTheme } from './musicalTimeline/drawTimeline'
 
 export interface SongTimelineCanvasProps {
@@ -32,8 +33,9 @@ export interface SongTimelineCanvasProps {
   readonly contentWidth: number
   /** Visible width (the grid's clientWidth). */
   readonly viewportWidth: number
-  /** Per-lane row height (CSS px). */
-  readonly rowHeight: number
+  /** Per-lane vertical layout (top/height, total) — the single source the draw,
+   *  the host height, the DOM labels and the hit-test all share (#422). */
+  readonly layout: LaneLayout
 }
 
 /** Literal dark-theme colors (canvas can't read CSS custom properties); these
@@ -51,9 +53,9 @@ const DEFAULT_THEME: DrawTheme = {
 const MAX_DPR = 2
 
 export function SongTimelineCanvas(props: SongTimelineCanvasProps): React.ReactElement {
-  const { scene, scrollLeft, contentWidth, viewportWidth, rowHeight } = props
+  const { scene, scrollLeft, contentWidth, viewportWidth, layout } = props
   const canvasRef = useRef<HTMLCanvasElement>(null)
-  const height = Math.max(rowHeight, scene.lanes.length * rowHeight)
+  const height = layout.totalHeight
 
   useEffect(() => {
     const canvas = canvasRef.current
@@ -70,15 +72,10 @@ export function SongTimelineCanvas(props: SongTimelineCanvasProps): React.ReactE
       const ctx = canvas.getContext('2d')
       if (!ctx) return
       ctx.setTransform(dpr, 0, 0, dpr, 0, 0) // draw in CSS px
-      drawTimeline(
-        ctx,
-        scene,
-        { scrollLeft, contentWidth, viewportWidth: cssW, rowHeight, height: cssH },
-        DEFAULT_THEME,
-      )
+      drawTimeline(ctx, scene, { scrollLeft, contentWidth, viewportWidth: cssW }, DEFAULT_THEME, layout)
     })
     return () => cancelAnimationFrame(raf)
-  }, [scene, scrollLeft, contentWidth, viewportWidth, rowHeight, height])
+  }, [scene, scrollLeft, contentWidth, viewportWidth, layout, height])
 
   return (
     <canvas
@@ -88,9 +85,12 @@ export function SongTimelineCanvas(props: SongTimelineCanvasProps): React.ReactE
       // surface is the DOM overlay (lane labels, period, ruler) — design §4.3.
       aria-hidden="true"
       style={{
+        // Sticky LEFT only (not top): it pins horizontally as the grid scrolls
+        // X, but must scroll vertically WITH the lane labels when expanded lanes
+        // grow the content past the viewport — a `top` anchor would freeze it
+        // against the body's vertical scroll and desync the rows (#422).
         position: 'sticky',
         left: 0,
-        top: 0,
         display: 'block',
         width: viewportWidth,
         height,

--- a/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
+++ b/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
@@ -129,6 +129,41 @@ describe('FullSongTimeline', () => {
     expect(typeof onSeek.mock.calls[0][0]).toBe('number')
   })
 
+  it('toggles a lane expansion and binds it when the disclosure caret is clicked', async () => {
+    const onBindLane = vi.fn()
+    const { container } = renderFull({ onBindLane })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const row = () => container.querySelector('[data-full-song-lane="bd"]') as HTMLElement
+    expect(row().getAttribute('data-expanded')).toBe('false')
+    const caret = container.querySelector('[data-full-song-lane-expand="bd"]') as HTMLElement
+    await act(async () => {
+      caret.click()
+    })
+    expect(row().getAttribute('data-expanded')).toBe('true') // accordion expanded
+    expect(onBindLane).toHaveBeenCalledTimes(1) // bound into the Pattern panel
+    // no `ir` in this fixture → no source provenance, so the offset is null.
+    expect(onBindLane).toHaveBeenLastCalledWith(null)
+    await act(async () => {
+      ;(container.querySelector('[data-full-song-lane-expand="bd"]') as HTMLElement).click()
+    })
+    expect(row().getAttribute('data-expanded')).toBe('false') // collapses again
+  })
+
+  it('supports multi-expand (two lanes expanded for cross-track alignment)', async () => {
+    const { container } = renderFull()
+    await act(async () => {
+      await Promise.resolve()
+    })
+    await act(async () => {
+      ;(container.querySelector('[data-full-song-lane-expand="bd"]') as HTMLElement).click()
+      ;(container.querySelector('[data-full-song-lane-expand="hh"]') as HTMLElement).click()
+    })
+    expect(container.querySelector('[data-full-song-lane="bd"]')!.getAttribute('data-expanded')).toBe('true')
+    expect(container.querySelector('[data-full-song-lane="hh"]')!.getAttribute('data-expanded')).toBe('true')
+  })
+
   it('exposes the loop length for observation', async () => {
     const { container } = renderFull()
     await act(async () => {

--- a/packages/app/src/components/musicalTimeline/__tests__/drawTimeline.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/drawTimeline.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { drawTimeline, laneRenderMode, COARSEN_PX, type DrawTransform, type DrawTheme } from '../drawTimeline'
+import { drawTimeline, laneRenderMode, COARSEN_PX, MIN_MARK_W, type DrawTransform, type DrawTheme } from '../drawTimeline'
 import { computeLaneLayout } from '../laneLayout'
 import type { TimelineScene } from '../timelineScene'
 
@@ -40,9 +40,9 @@ const scene: TimelineScene = {
       color: '#0af',
       density: [1, 0, 2, 0], // onsets at integer cycles 0 and 2
       notes: [
-        { cycle: 0, pitch: 60, gain: 1 },
-        { cycle: 2, pitch: 72, gain: 0.5 },
-        { cycle: 2.5, pitch: 64, gain: 0.8 }, // fractional → only marks render here
+        { cycle: 0, end: 0.25, pitch: 60, gain: 1 },
+        { cycle: 2, end: 2.25, pitch: 72, gain: 0.5 },
+        { cycle: 2.5, end: 2.75, pitch: 64, gain: 0.8 }, // fractional → only marks render here
       ],
       pitchMin: 60,
       pitchMax: 72,
@@ -132,5 +132,29 @@ describe('drawTimeline', () => {
     // A beat gridline is a 1px-wide column the full height of the 88px band.
     const beatGrid = rects.filter((r) => r.w === 1 && r.h === 88 && r.y === 0)
     expect(beatGrid.length).toBeGreaterThan(0)
+  })
+
+  it('draws marks with DURATION-proportional width (a sustained note is a long bar)', () => {
+    const durScene: TimelineScene = {
+      ...scene,
+      lanes: [
+        {
+          ...scene.lanes[0],
+          notes: [
+            { cycle: 0, end: 0, pitch: 60, gain: 1 }, // zero-duration trigger → MIN_MARK_W
+            { cycle: 1, end: 2, pitch: 64, gain: 1 }, // a whole cycle long
+          ],
+        },
+      ],
+    }
+    // 4000px / 4 cycles = 1000 px/cycle ≫ COARSEN_PX → marks mode.
+    const { ctx, rects } = mockCtx()
+    drawTimeline(ctx, durScene, { scrollLeft: 0, contentWidth: 4000, viewportWidth: 4000 }, theme, flat)
+    const marks = rects.filter((r) => r.h === 3) // mark height (collapsed)
+    const short = marks.find((r) => Math.abs(r.x - 0) < 1)!
+    const long = marks.find((r) => Math.abs(r.x - 1000) < 1)! // cycle 1 → x=1000
+    expect(short.w).toBe(MIN_MARK_W) // floored
+    expect(long.w).toBe(1000) // (2 − 1) cycles × 1000 px/cycle
+    expect(long.w).toBeGreaterThan(short.w)
   })
 })

--- a/packages/app/src/components/musicalTimeline/__tests__/drawTimeline.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/drawTimeline.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { drawTimeline, laneRenderMode, COARSEN_PX, type DrawTransform, type DrawTheme } from '../drawTimeline'
+import { computeLaneLayout } from '../laneLayout'
 import type { TimelineScene } from '../timelineScene'
 
 const theme: DrawTheme = {
@@ -45,9 +46,13 @@ const scene: TimelineScene = {
       ],
       pitchMin: 60,
       pitchMax: 72,
+      sourceOffset: null,
     },
   ],
 }
+
+/** Default collapsed layout (one 22px row), the common case for these tests. */
+const flat = computeLaneLayout(scene.lanes, new Set(), 22, 88)
 
 describe('laneRenderMode', () => {
   it('shows marks when a cycle is wide enough, density when narrow', () => {
@@ -60,6 +65,10 @@ describe('laneRenderMode', () => {
   it('degenerate pxPerCycle → density', () => {
     expect(laneRenderMode(Number.NaN, true)).toBe('density')
   })
+  it('an expanded lane with marks forces marks even when zoomed out', () => {
+    expect(laneRenderMode(COARSEN_PX - 1, true, true)).toBe('marks')
+    expect(laneRenderMode(1000, false, true)).toBe('density') // still no marks → density
+  })
 })
 
 describe('drawTimeline', () => {
@@ -67,13 +76,13 @@ describe('drawTimeline', () => {
 
   it('draws mini-note marks when zoomed in (a mark lands at the fractional cycle 2.5)', () => {
     // contentWidth 4000 over 4 cycles = 1000px/cycle ≫ COARSEN_PX → marks mode.
-    const transform: DrawTransform = { scrollLeft: 0, contentWidth: 4000, viewportWidth: vw, rowHeight: 22, height: 22 }
+    const transform: DrawTransform = { scrollLeft: 0, contentWidth: 4000, viewportWidth: vw }
     const { ctx, rects } = mockCtx()
-    drawTimeline(ctx, scene, transform, theme)
+    drawTimeline(ctx, scene, transform, theme, flat)
     // cycle 2.5 → contentX = (2.5/4)*4000 = 2500; with scrollLeft 0 it's off-screen
     // (vw=400). Scroll so it's visible and re-check instead:
     const { ctx: ctx2, rects: rects2 } = mockCtx()
-    drawTimeline(ctx2, scene, { ...transform, scrollLeft: 2400 }, theme)
+    drawTimeline(ctx2, scene, { ...transform, scrollLeft: 2400 }, theme, flat)
     const screenXof = (cycle: number) => (cycle / 4) * 4000 - 2400
     const markAt25 = rects2.some((r) => Math.abs(r.x - screenXof(2.5)) < 1 && r.h === 3)
     expect(markAt25).toBe(true)
@@ -84,9 +93,9 @@ describe('drawTimeline', () => {
 
   it('draws coarse density when zoomed out (no fractional-cycle rect)', () => {
     // contentWidth 40 over 4 cycles = 10px/cycle < COARSEN_PX → density mode.
-    const transform: DrawTransform = { scrollLeft: 0, contentWidth: 40, viewportWidth: vw, rowHeight: 22, height: 22 }
+    const transform: DrawTransform = { scrollLeft: 0, contentWidth: 40, viewportWidth: vw }
     const { ctx, rects } = mockCtx()
-    drawTimeline(ctx, scene, transform, theme)
+    drawTimeline(ctx, scene, transform, theme, flat)
     const screenXof = (cycle: number) => (cycle / 4) * 40
     // density only draws at integer cycles 0 and 2 — never at 2.5.
     expect(rects.some((r) => Math.abs(r.x - screenXof(2.5)) < 0.5 && r.h !== 22)).toBe(false)
@@ -96,7 +105,32 @@ describe('drawTimeline', () => {
 
   it('no-ops cleanly on a degenerate transform', () => {
     const { ctx, rects } = mockCtx()
-    drawTimeline(ctx, scene, { scrollLeft: 0, contentWidth: 0, viewportWidth: 0, rowHeight: 22, height: 22 }, theme)
+    drawTimeline(ctx, scene, { scrollLeft: 0, contentWidth: 0, viewportWidth: 0 }, theme, flat)
     expect(rects.length).toBe(0)
+  })
+
+  it('places a second lane at its layout top (variable row heights)', () => {
+    const two: TimelineScene = {
+      ...scene,
+      lanes: [scene.lanes[0], { ...scene.lanes[0], laneKey: 'bass' }],
+    }
+    // 'lead' expanded to 88px → 'bass' starts at y=88, not y=22.
+    const layout = computeLaneLayout(two.lanes, new Set(['lead']), 22, 88)
+    expect(layout.boxes[1].top).toBe(88)
+    const { ctx, rects } = mockCtx()
+    // Zoomed out so each lane draws density (integer cells) at its own top.
+    drawTimeline(ctx, two, { scrollLeft: 0, contentWidth: 40, viewportWidth: vw }, theme, layout)
+    // bass density cells sit in its band [88, 110) — i.e. at least one rect with y >= 88.
+    expect(rects.some((r) => r.y >= 88 && r.y < 110)).toBe(true)
+  })
+
+  it('an expanded lane draws per-beat gridlines spanning its taller band', () => {
+    // 1000px/cycle → 250px/beat ≫ BEAT_GRID_MIN_PX → beat grid shows.
+    const layout = computeLaneLayout(scene.lanes, new Set(['lead']), 22, 88)
+    const { ctx, rects } = mockCtx()
+    drawTimeline(ctx, scene, { scrollLeft: 0, contentWidth: 4000, viewportWidth: vw }, theme, layout)
+    // A beat gridline is a 1px-wide column the full height of the 88px band.
+    const beatGrid = rects.filter((r) => r.w === 1 && r.h === 88 && r.y === 0)
+    expect(beatGrid.length).toBeGreaterThan(0)
   })
 })

--- a/packages/app/src/components/musicalTimeline/__tests__/laneLayout.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/laneLayout.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest'
+import { computeLaneLayout, laneAtY } from '../laneLayout'
+
+const lanes = [{ laneKey: 'bd' }, { laneKey: 'lead' }, { laneKey: 'bass' }]
+
+describe('computeLaneLayout', () => {
+  it('stacks uniform rows when nothing is expanded', () => {
+    const layout = computeLaneLayout(lanes, new Set(), 22, 88)
+    expect(layout.boxes.map((b) => b.top)).toEqual([0, 22, 44])
+    expect(layout.boxes.every((b) => b.height === 22)).toBe(true)
+    expect(layout.boxes.every((b) => !b.expanded)).toBe(true)
+    expect(layout.totalHeight).toBe(66)
+  })
+
+  it('gives an expanded lane the bigger height and pushes the lanes below it down', () => {
+    const layout = computeLaneLayout(lanes, new Set(['lead']), 22, 88)
+    expect(layout.boxes[0]).toMatchObject({ laneKey: 'bd', top: 0, height: 22, expanded: false })
+    expect(layout.boxes[1]).toMatchObject({ laneKey: 'lead', top: 22, height: 88, expanded: true })
+    // 'bass' starts after the tall 'lead' row (22 + 88), not at 44.
+    expect(layout.boxes[2]).toMatchObject({ laneKey: 'bass', top: 110, height: 22 })
+    expect(layout.totalHeight).toBe(132)
+  })
+
+  it('supports multi-expand (cross-track alignment)', () => {
+    const layout = computeLaneLayout(lanes, new Set(['bd', 'bass']), 22, 88)
+    expect(layout.boxes.map((b) => b.height)).toEqual([88, 22, 88])
+    expect(layout.totalHeight).toBe(198)
+  })
+
+  it('preserves lane order so boxes line up with scene.lanes and the labels', () => {
+    const layout = computeLaneLayout(lanes, new Set(['lead']), 22, 88)
+    expect(layout.boxes.map((b) => b.laneKey)).toEqual(['bd', 'lead', 'bass'])
+  })
+
+  it('floors degenerate heights to 0 instead of producing NaN geometry', () => {
+    const layout = computeLaneLayout(lanes, new Set(), Number.NaN, 50)
+    expect(layout.totalHeight).toBe(0)
+    expect(layout.boxes.every((b) => b.top === 0 && b.height === 0)).toBe(true)
+  })
+
+  it('falls back to the base height when expandedHeight is not larger', () => {
+    const layout = computeLaneLayout(lanes, new Set(['lead']), 22, 10)
+    expect(layout.boxes[1].height).toBe(22) // 10 < 22 → no shrink
+  })
+})
+
+describe('laneAtY', () => {
+  const layout = computeLaneLayout(lanes, new Set(['lead']), 22, 88)
+  // boxes: bd [0,22), lead [22,110), bass [110,132)
+
+  it('maps a y inside a box to that lane', () => {
+    expect(laneAtY(layout, 0)).toBe('bd')
+    expect(laneAtY(layout, 21)).toBe('bd')
+    expect(laneAtY(layout, 22)).toBe('lead') // top edge inclusive
+    expect(laneAtY(layout, 100)).toBe('lead')
+    expect(laneAtY(layout, 110)).toBe('bass') // exclusive bottom of lead
+    expect(laneAtY(layout, 131)).toBe('bass')
+  })
+
+  it('returns null above the first box and below the last', () => {
+    expect(laneAtY(layout, -1)).toBeNull()
+    expect(laneAtY(layout, 132)).toBeNull()
+    expect(laneAtY(layout, 9999)).toBeNull()
+  })
+
+  it('returns null for a non-finite y', () => {
+    expect(laneAtY(layout, Number.NaN)).toBeNull()
+  })
+
+  it('returns null when there are no lanes', () => {
+    expect(laneAtY(computeLaneLayout([], new Set(), 22, 88), 5)).toBeNull()
+  })
+})

--- a/packages/app/src/components/musicalTimeline/__tests__/timelineScene.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/timelineScene.test.ts
@@ -16,8 +16,16 @@ const analysisFixture: SongAnalysis = {
   ],
 }
 
-function marks(entries: Record<string, SceneNote[]>, capped = false): CollectedMarks {
-  return { marksByLane: new Map(Object.entries(entries)), capped }
+function marks(
+  entries: Record<string, SceneNote[]>,
+  capped = false,
+  sources: Record<string, number> = {},
+): CollectedMarks {
+  return {
+    marksByLane: new Map(Object.entries(entries)),
+    sourceByLane: new Map(Object.entries(sources)),
+    capped,
+  }
 }
 
 describe('buildTimelineScene', () => {
@@ -80,6 +88,19 @@ describe('buildTimelineScene', () => {
   it('propagates the capped flag', () => {
     const scene = buildTimelineScene(analysisFixture, marks({ bd: [] }, true))
     expect(scene.notesCapped).toBe(true)
+  })
+
+  it('merges the per-lane source offset for binding (null when absent)', () => {
+    const scene = buildTimelineScene(analysisFixture, marks({}, false, { bd: 42 }))
+    const bd = scene.lanes.find((l) => l.laneKey === 'bd')!
+    const lead = scene.lanes.find((l) => l.laneKey === 'lead')!
+    expect(bd.sourceOffset).toBe(42) // bound to source char offset 42
+    expect(lead.sourceOffset).toBeNull() // no source provenance for this lane
+  })
+
+  it('leaves every lane source offset null when no marks were collected', () => {
+    const scene = buildTimelineScene(analysisFixture)
+    expect(scene.lanes.every((l) => l.sourceOffset === null)).toBe(true)
   })
 })
 

--- a/packages/app/src/components/musicalTimeline/__tests__/timelineScene.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/timelineScene.test.ts
@@ -59,11 +59,11 @@ describe('buildTimelineScene', () => {
     const scene = buildTimelineScene(
       analysisFixture,
       marks({
-        bd: [{ cycle: 0, pitch: null, gain: 1 }], // percussive → no pitch range
+        bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1 }], // percussive → no pitch range
         lead: [
-          { cycle: 0, pitch: 60, gain: 0.5 },
-          { cycle: 1, pitch: 72, gain: 1 },
-          { cycle: 2, pitch: 64, gain: 0.8 },
+          { cycle: 0, end: 0.5, pitch: 60, gain: 0.5 },
+          { cycle: 1, end: 1.5, pitch: 72, gain: 1 },
+          { cycle: 2, end: 2.5, pitch: 64, gain: 0.8 },
         ],
       }),
     )
@@ -78,7 +78,7 @@ describe('buildTimelineScene', () => {
   })
 
   it('assigns a stable color per lane and leaves note-less lanes empty', () => {
-    const scene = buildTimelineScene(analysisFixture, marks({ bd: [{ cycle: 0, pitch: null, gain: 1 }] }))
+    const scene = buildTimelineScene(analysisFixture, marks({ bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1 }] }))
     expect(typeof scene.lanes[0].color).toBe('string')
     expect(scene.lanes[0].color.length).toBeGreaterThan(0)
     const lead = scene.lanes.find((l) => l.laneKey === 'lead')!

--- a/packages/app/src/components/musicalTimeline/drawTimeline.ts
+++ b/packages/app/src/components/musicalTimeline/drawTimeline.ts
@@ -49,6 +49,10 @@ export interface DrawTheme {
  *  the lane falls back to coarse density blocks (design §4.2 readability). */
 export const COARSEN_PX = 28
 
+/** Minimum mark width (px) so a zero/near-zero-duration trigger still shows and
+ *  stays clickable — mirrors the live view's `MIN_BLOCK_PX` (timeAxis.ts). */
+export const MIN_MARK_W = 2
+
 /** Minimum px between per-beat gridlines in an expanded lane — below this they
  *  crowd into a smear, so they're suppressed (rhythm grid only when legible). */
 const BEAT_GRID_MIN_PX = 10
@@ -204,7 +208,6 @@ function drawMarks(
   // Expanded lanes draw a slightly taller mark over the much taller band, so
   // the pitch spread reads as a clear note layout rather than a thin smear.
   const markH = expanded ? 4 : 3
-  const markW = Math.max(2, Math.min(6, pxPerCycle * 0.12))
   const bandTop = top + padY
   const bandH = Math.max(1, rowHeight - 2 * padY - markH)
   const hasPitch =
@@ -213,6 +216,11 @@ function drawMarks(
   for (const n of lane.notes) {
     if (n.cycle < firstCycle || n.cycle >= lastCycle) continue
     const x = toScreenX(n.cycle)
+    // DURATION-proportional width (mirrors the live view's `eventToRect`): a
+    // sustained note reads as a long bar, a one-shot as a short one. Floored at
+    // MIN_MARK_W so a zero-duration trigger still shows; canvas clips the right
+    // edge, so a note crossing the viewport just truncates.
+    const markW = Math.max(MIN_MARK_W, (n.end - n.cycle) * pxPerCycle)
     if (x < -markW || x > viewportWidth) continue
     let y: number
     if (n.pitch != null && hasPitch) {

--- a/packages/app/src/components/musicalTimeline/drawTimeline.ts
+++ b/packages/app/src/components/musicalTimeline/drawTimeline.ts
@@ -1,5 +1,5 @@
 /**
- * drawTimeline — pure canvas renderer for the Song timeline scene (#419).
+ * drawTimeline — pure canvas renderer for the Song timeline scene (#419, #422).
  *
  * Draws a `TimelineScene` against the shared content-space transform (PV116):
  * section bands, cycle gridlines, then per lane either the coarse onset DENSITY
@@ -10,13 +10,23 @@
  * so this function never touches `devicePixelRatio` — which also keeps it pure
  * and testable against a recording mock context.
  *
+ * Per-lane VERTICAL geometry comes from a `LaneLayout` (expand + bind, #422):
+ * each lane has its own `top`/`height`, and an expanded ("accordion") lane
+ * renders RICHER read-only detail — forced mini-note marks with full pitch
+ * spread over the taller band, plus faint per-beat gridlines for rhythm
+ * readability (design §4.5). Collapsed lanes are unchanged. The same layout
+ * drives the host height, the DOM labels, and the hit-test, so nothing drifts.
+ *
  * No React, no DOM, no canvas creation — just draw calls. The host
  * (`SongTimelineCanvas`) owns the surface, sizing, and dirty-flagged scheduling.
  */
 
-import type { TimelineScene } from './timelineScene'
+import type { TimelineScene, SceneLane } from './timelineScene'
+import type { LaneLayout } from './laneLayout'
+import { BEATS_PER_BAR } from './songAxis'
 
-/** The view transform + geometry the draw needs, all in CSS pixels. */
+/** The HORIZONTAL view transform + viewport, all in CSS pixels. Vertical
+ *  geometry (per-lane top/height, total height) lives in the `LaneLayout`. */
 export interface DrawTransform {
   /** Horizontal scroll offset (content px hidden to the left). */
   readonly scrollLeft: number
@@ -24,10 +34,6 @@ export interface DrawTransform {
   readonly contentWidth: number
   /** Visible canvas width (CSS px). */
   readonly viewportWidth: number
-  /** Per-lane row height (CSS px). */
-  readonly rowHeight: number
-  /** Total canvas height (CSS px) = `lanes.length * rowHeight`. */
-  readonly height: number
 }
 
 /** Resolved literal colors (canvas can't read CSS custom properties). */
@@ -43,12 +49,23 @@ export interface DrawTheme {
  *  the lane falls back to coarse density blocks (design §4.2 readability). */
 export const COARSEN_PX = 28
 
+/** Minimum px between per-beat gridlines in an expanded lane — below this they
+ *  crowd into a smear, so they're suppressed (rhythm grid only when legible). */
+const BEAT_GRID_MIN_PX = 10
+
 /**
  * Which rendering a lane uses at a given zoom. Pure + exported so the readability
  * switchover is unit-tested directly. A lane with no marks always draws density.
+ * An EXPANDED lane with marks always draws marks (detail on demand overrides the
+ * zoom coarsening — the user asked to see this lane's notes).
  */
-export function laneRenderMode(pxPerCycle: number, hasNotes: boolean): 'density' | 'marks' {
+export function laneRenderMode(
+  pxPerCycle: number,
+  hasNotes: boolean,
+  expanded = false,
+): 'density' | 'marks' {
   if (!hasNotes || !Number.isFinite(pxPerCycle)) return 'density'
+  if (expanded) return 'marks'
   return pxPerCycle >= COARSEN_PX ? 'marks' : 'density'
 }
 
@@ -58,8 +75,10 @@ export function drawTimeline(
   scene: TimelineScene,
   transform: DrawTransform,
   theme: DrawTheme,
+  layout: LaneLayout,
 ): void {
-  const { scrollLeft, contentWidth, viewportWidth, rowHeight, height } = transform
+  const { scrollLeft, contentWidth, viewportWidth } = transform
+  const height = layout.totalHeight
   ctx.clearRect(0, 0, viewportWidth, height)
   const dc = scene.displayCycles
   if (dc <= 0 || contentWidth <= 0 || viewportWidth <= 0) return
@@ -95,24 +114,57 @@ export function drawTimeline(
     ctx.fillRect(x, 0, 1, height)
   }
 
-  // Lanes.
+  // Lanes — each at its own top/height from the layout.
   scene.lanes.forEach((lane, idx) => {
-    const top = idx * rowHeight
+    const box = layout.boxes[idx]
+    if (!box || box.height <= 0) return
+    const { top, height: rowHeight, expanded } = box
     if (idx % 2 === 1) {
       ctx.fillStyle = theme.rowAlt
       ctx.fillRect(0, top, viewportWidth, rowHeight)
     }
-    if (laneRenderMode(pxPerCycle, lane.notes.length > 0) === 'density') {
+    const mode = laneRenderMode(pxPerCycle, lane.notes.length > 0, expanded)
+    if (expanded) {
+      drawBeatGrid(ctx, top, rowHeight, pxPerCycle, firstCycle, lastCycle, viewportWidth, theme, toScreenX)
+    }
+    if (mode === 'density') {
       drawDensity(ctx, lane, top, rowHeight, pxPerCycle, scene.peakDensity, firstCycle, lastCycle, toScreenX)
     } else {
-      drawMarks(ctx, lane, top, rowHeight, pxPerCycle, viewportWidth, firstCycle, lastCycle, toScreenX)
+      drawMarks(ctx, lane, top, rowHeight, expanded, pxPerCycle, viewportWidth, firstCycle, lastCycle, toScreenX)
     }
   })
 }
 
+/** Faint per-beat vertical guides inside an expanded lane (rhythm readability).
+ *  Cycle boundaries are already drawn by the global gridlines; this adds the
+ *  in-between beats (BEATS_PER_BAR subdivisions), suppressed when they'd crowd. */
+function drawBeatGrid(
+  ctx: CanvasRenderingContext2D,
+  top: number,
+  rowHeight: number,
+  pxPerCycle: number,
+  firstCycle: number,
+  lastCycle: number,
+  viewportWidth: number,
+  theme: DrawTheme,
+  toScreenX: (c: number) => number,
+): void {
+  if (pxPerCycle / BEATS_PER_BAR < BEAT_GRID_MIN_PX) return
+  ctx.fillStyle = theme.gridline
+  ctx.globalAlpha = 0.5
+  for (let c = Math.floor(firstCycle); c < lastCycle; c++) {
+    for (let b = 1; b < BEATS_PER_BAR; b++) {
+      const x = toScreenX(c + b / BEATS_PER_BAR)
+      if (x < 0 || x > viewportWidth) continue
+      ctx.fillRect(x, top, 1, rowHeight)
+    }
+  }
+  ctx.globalAlpha = 1
+}
+
 function drawDensity(
   ctx: CanvasRenderingContext2D,
-  lane: TimelineScene['lanes'][number],
+  lane: SceneLane,
   top: number,
   rowHeight: number,
   pxPerCycle: number,
@@ -138,9 +190,10 @@ function drawDensity(
 
 function drawMarks(
   ctx: CanvasRenderingContext2D,
-  lane: TimelineScene['lanes'][number],
+  lane: SceneLane,
   top: number,
   rowHeight: number,
+  expanded: boolean,
   pxPerCycle: number,
   viewportWidth: number,
   firstCycle: number,
@@ -148,7 +201,9 @@ function drawMarks(
   toScreenX: (c: number) => number,
 ): void {
   const padY = 3
-  const markH = 3
+  // Expanded lanes draw a slightly taller mark over the much taller band, so
+  // the pitch spread reads as a clear note layout rather than a thin smear.
+  const markH = expanded ? 4 : 3
   const markW = Math.max(2, Math.min(6, pxPerCycle * 0.12))
   const bandTop = top + padY
   const bandH = Math.max(1, rowHeight - 2 * padY - markH)

--- a/packages/app/src/components/musicalTimeline/laneLayout.ts
+++ b/packages/app/src/components/musicalTimeline/laneLayout.ts
@@ -1,0 +1,72 @@
+/**
+ * laneLayout — the per-lane vertical layout for the canvas Song timeline
+ * (expand + bind, #422 / canvas milestone #416, design §4.5).
+ *
+ * Before expand, every lane was a uniform `ROW_HEIGHT` row and three places
+ * independently assumed that: the canvas draw (`drawTimeline` y-offsets), the
+ * canvas host height, and the DOM lane labels. Click-to-expand makes a lane
+ * taller (accordion) so its read-only note detail is legible — which means the
+ * row height is no longer uniform. If each consumer recomputed y-offsets on its
+ * own they would drift apart (PV116 — the shared transform must stay single-
+ * sourced). So this module is the ONE place that turns `(lanes, expanded)` into
+ * a `top`/`height` box per lane; the draw, the host height, the labels, AND the
+ * hit-test all read the same `LaneLayout`.
+ *
+ * PURE — no React, no canvas, only the lane keys. Unit-tested directly.
+ */
+
+/** One lane's vertical box in content space (CSS px, before DPR). */
+export interface LaneBox {
+  readonly laneKey: string
+  /** Top edge (px from the canvas top). */
+  readonly top: number
+  /** Row height (px) — `expandedHeight` when expanded, else `rowHeight`. */
+  readonly height: number
+  /** True when this lane is accordion-expanded (drives the richer draw). */
+  readonly expanded: boolean
+}
+
+/** The full vertical layout: one box per lane (in lane order) + the total. */
+export interface LaneLayout {
+  readonly boxes: readonly LaneBox[]
+  /** Sum of all box heights — the canvas/grid content height. ≥ 0. */
+  readonly totalHeight: number
+}
+
+/**
+ * Stack the lanes top-to-bottom, giving each its expanded or collapsed height.
+ * Lane order is preserved (it must match `scene.lanes` and the DOM labels), so
+ * the returned `boxes[i]` lines up with `lanes[i]`. Non-finite/negative heights
+ * are floored to 0 so a bad input can't produce NaN geometry downstream.
+ */
+export function computeLaneLayout(
+  lanes: readonly { readonly laneKey: string }[],
+  expanded: ReadonlySet<string>,
+  rowHeight: number,
+  expandedHeight: number,
+): LaneLayout {
+  const base = Number.isFinite(rowHeight) && rowHeight > 0 ? rowHeight : 0
+  const big = Number.isFinite(expandedHeight) && expandedHeight > base ? expandedHeight : base
+  let top = 0
+  const boxes: LaneBox[] = lanes.map((lane) => {
+    const isExpanded = expanded.has(lane.laneKey)
+    const height = isExpanded ? big : base
+    const box: LaneBox = { laneKey: lane.laneKey, top, height, expanded: isExpanded }
+    top += height
+    return box
+  })
+  return { boxes, totalHeight: top }
+}
+
+/**
+ * Which lane contains content-space `y` (px from the layout top), or null if
+ * `y` is above the first box or below the last. Inclusive of the top edge,
+ * exclusive of the bottom — adjacent boxes never both claim a pixel.
+ */
+export function laneAtY(layout: LaneLayout, y: number): string | null {
+  if (!Number.isFinite(y) || y < 0) return null
+  for (const box of layout.boxes) {
+    if (y >= box.top && y < box.top + box.height) return box.laneKey
+  }
+  return null
+}

--- a/packages/app/src/components/musicalTimeline/timelineMarks.ts
+++ b/packages/app/src/components/musicalTimeline/timelineMarks.ts
@@ -62,7 +62,8 @@ export function collectNoteMarks(
       capped = true
       continue
     }
-    arr.push({ cycle, pitch: extractPitch(ev)?.midi ?? null, gain: clamp01(ev.gain ?? 1) })
+    const end = Number.isFinite(ev.end) && ev.end > cycle ? ev.end : cycle
+    arr.push({ cycle, end, pitch: extractPitch(ev)?.midi ?? null, gain: clamp01(ev.gain ?? 1) })
   }
   return { marksByLane, sourceByLane, capped }
 }

--- a/packages/app/src/components/musicalTimeline/timelineMarks.ts
+++ b/packages/app/src/components/musicalTimeline/timelineMarks.ts
@@ -38,12 +38,21 @@ export function collectNoteMarks(
 ): CollectedMarks {
   if (!ir || !Number.isFinite(displayCycles) || displayCycles <= 0) return EMPTY_MARKS
   const marksByLane = new Map<string, SceneNote[]>()
+  // Per-lane representative source offset for expand-to-bind: the FIRST event of
+  // the lane that carries a `loc` (char offsets into the evaluated source). The
+  // bind maps this → editor cursor → the Pattern panel rebinds (#422). First-
+  // wins so the anchor is stable (doesn't jump as later events stream in).
+  const sourceByLane = new Map<string, number>()
   let capped = false
   const events = collectCycles(ir, 0, Math.ceil(displayCycles))
   for (const ev of events) {
     const cycle = ev.begin
     if (!Number.isFinite(cycle) || cycle < 0 || cycle >= displayCycles) continue
     const key = laneKeyOf(ev)
+    if (!sourceByLane.has(key)) {
+      const offset = ev.loc?.[0]?.start
+      if (typeof offset === 'number' && Number.isFinite(offset)) sourceByLane.set(key, offset)
+    }
     let arr = marksByLane.get(key)
     if (!arr) {
       arr = []
@@ -55,5 +64,5 @@ export function collectNoteMarks(
     }
     arr.push({ cycle, pitch: extractPitch(ev)?.midi ?? null, gain: clamp01(ev.gain ?? 1) })
   }
-  return { marksByLane, capped }
+  return { marksByLane, sourceByLane, capped }
 }

--- a/packages/app/src/components/musicalTimeline/timelineScene.ts
+++ b/packages/app/src/components/musicalTimeline/timelineScene.ts
@@ -41,6 +41,11 @@ export interface SceneLane {
    *  or null when the lane has no pitched marks (percussive). */
   readonly pitchMin: number | null
   readonly pitchMax: number | null
+  /** Source-character offset of a representative event for this lane (the first
+   *  collected event carrying a `loc`), or null when the IR has no source
+   *  provenance. Drives expand-to-bind: lane → offset → editor cursor → the
+   *  Pattern panel rebinds (#422, design §3.1). Not used for drawing. */
+  readonly sourceOffset: number | null
 }
 
 /** The full scene the canvas renderer draws. */
@@ -60,12 +65,19 @@ export interface TimelineScene {
 
 export interface CollectedMarks {
   readonly marksByLane: ReadonlyMap<string, SceneNote[]>
+  /** Per-lane representative source offset (first event's `loc[0].start`) for
+   *  expand-to-bind. Absent lane → no source provenance (hand-built IR). */
+  readonly sourceByLane: ReadonlyMap<string, number>
   /** True if any lane hit the cap (marks dropped — surfaced, not silent). */
   readonly capped: boolean
 }
 
 /** A shared empty collection (the no-IR / no-marks default). */
-export const EMPTY_MARKS: CollectedMarks = { marksByLane: new Map(), capped: false }
+export const EMPTY_MARKS: CollectedMarks = {
+  marksByLane: new Map(),
+  sourceByLane: new Map(),
+  capped: false,
+}
 
 /**
  * Build the render scene from the analysis (density, sections, span, period)
@@ -104,6 +116,7 @@ export function buildTimelineScene(
       notes,
       pitchMin,
       pitchMax,
+      sourceOffset: marks.sourceByLane.get(lane.laneKey) ?? null,
     }
   })
 

--- a/packages/app/src/components/musicalTimeline/timelineScene.ts
+++ b/packages/app/src/components/musicalTimeline/timelineScene.ts
@@ -23,6 +23,10 @@ import { paletteForTrack, trackIndexOf } from './colors'
 export interface SceneNote {
   /** Fractional song cycle of the onset (event `begin`), in `[0, displayCycles)`. */
   readonly cycle: number
+  /** Fractional song cycle of the offset (event `end`), `≥ cycle`. The mark's
+   *  width is `(end − cycle) × pxPerCycle` — DURATION-proportional, mirroring the
+   *  live view's note blocks (`eventToRect`), not a fixed dab. */
+  readonly end: number
   /** MIDI pitch for in-lane vertical placement, or null for percussive events. */
   readonly pitch: number | null
   /** Gain 0–1 — drives mark intensity. */

--- a/packages/app/tests/full-song-expand-bind.spec.ts
+++ b/packages/app/tests/full-song-expand-bind.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * Full-song view: expand + bind (#422 / #416) — Playwright observation.
+ *
+ * AnviDev observe gate. The pure layer (laneLayout, drawTimeline per-lane boxes,
+ * scene sourceOffset) is unit-tested; FullSongTimeline.test covers the caret →
+ * expand-state + onBindLane callback in jsdom. This drives the REAL app to
+ * confirm the end-to-end behaviour against a real evaluated song:
+ *   1. Clicking a lane's disclosure caret accordions it (data-expanded=true) AND
+ *      grows the canvas backing height (the taller content is really laid out).
+ *   2. The SAME click binds the lane into the editing seam: the Monaco cursor
+ *      jumps to that lane's source line (this is what `revealLineInFile` drives;
+ *      the Pattern panel then re-detects the active chunk — `useActiveChunk`).
+ *   3. Multi-expand: two lanes expand at once (cross-track alignment) and the
+ *      canvas grows further.
+ *   4. Double-click in the grid body also expands the lane under the pointer.
+ *   5. No console/page errors; screenshots of collapsed vs expanded.
+ *
+ * INPUT NOTE (as the sibling specs): eval reads the FILE STORE, so the analyzed
+ * song is the starter example — assertions are generic (≥1 lane, height grew,
+ * cursor moved), never a fixed line or pixel.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const STORAGE_KEYS = {
+  height: 'stave:bottomPanel.height',
+  open: 'stave:bottomPanel.open',
+  activeTabId: 'stave:bottomPanel.activeTabId',
+} as const
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+async function preOpenDrawer(page: Page): Promise<void> {
+  await page.addInitScript(
+    ([heightKey, openKey, activeKey]: readonly string[]) => {
+      try {
+        window.localStorage.setItem(heightKey, '360')
+        window.localStorage.setItem(openKey, 'true')
+        window.localStorage.setItem(activeKey, 'musical-timeline')
+      } catch {
+        /* ignore */
+      }
+    },
+    [STORAGE_KEYS.height, STORAGE_KEYS.open, STORAGE_KEYS.activeTabId],
+  )
+}
+
+async function bootShell(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => {
+      const m = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+      return (m?.editor?.getEditors?.()?.length ?? 0) > 0
+    },
+    { timeout: 20_000 },
+  )
+}
+
+async function evalStrudel(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+    const editors = (monaco?.editor?.getEditors?.() ?? []) as Array<{
+      getModel: () => { getLanguageId?: () => string } | null
+      focus: () => void
+    }>
+    const target = editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
+    target?.focus()
+  })
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1800)
+}
+
+/** Canvas backing-store height (px) — grows when a lane is expanded. */
+async function canvasHeight(page: Page): Promise<number> {
+  return page.locator('[data-full-song-canvas]').evaluate((el) => (el as HTMLCanvasElement).height)
+}
+
+/** The strudel editor's cursor line, plus the model line count (for a sentinel
+ *  that's guaranteed distinct from any real pattern line). */
+async function cursor(page: Page): Promise<{ line: number; lineCount: number }> {
+  return page.evaluate(() => {
+    const monaco = (window as unknown as {
+      monaco?: { editor?: { getEditors?: () => unknown[] } }
+    }).monaco
+    const editors = (monaco?.editor?.getEditors?.() ?? []) as Array<{
+      getModel: () => { getLanguageId?: () => string; getLineCount?: () => number } | null
+      getPosition: () => { lineNumber: number } | null
+      setPosition: (p: { lineNumber: number; column: number }) => void
+    }>
+    const ed = editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
+    const model = ed?.getModel()
+    return { line: ed?.getPosition?.()?.lineNumber ?? 0, lineCount: model?.getLineCount?.() ?? 0 }
+  })
+}
+
+/** Park the cursor on the last line so any bind-driven jump is observable. */
+async function parkCursorAtEnd(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const monaco = (window as unknown as {
+      monaco?: { editor?: { getEditors?: () => unknown[] } }
+    }).monaco
+    const editors = (monaco?.editor?.getEditors?.() ?? []) as Array<{
+      getModel: () => { getLanguageId?: () => string; getLineCount?: () => number } | null
+      setPosition: (p: { lineNumber: number; column: number }) => void
+    }>
+    const ed = editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
+    const last = ed?.getModel()?.getLineCount?.() ?? 1
+    ed?.setPosition?.({ lineNumber: last, column: 1 })
+    return last
+  })
+}
+
+test('full-song view: expand a lane (taller canvas) + bind it to the editor cursor', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await preOpenDrawer(page)
+  await bootShell(page)
+  await evalStrudel(page)
+
+  // Enter the full-song view.
+  const toggle = page.locator('[data-musical-timeline="view-toggle"]')
+  await toggle.waitFor({ timeout: 10_000 })
+  await toggle.click()
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+
+  const laneCount = await page.locator('[data-full-song-lane]').count()
+  expect(laneCount).toBeGreaterThanOrEqual(1)
+
+  // Collapsed baseline.
+  const heightCollapsed = await canvasHeight(page)
+  expect(heightCollapsed).toBeGreaterThan(0)
+  await page.screenshot({ path: 'test-results/full-song-expand-collapsed.png' })
+
+  // (1)+(2) Click the first lane's caret → it expands AND binds. Park the cursor
+  // at the end first so the bind-driven jump to the lane's source line is visible.
+  const sentinel = await parkCursorAtEnd(page)
+  const firstCaret = page.locator('[data-full-song-lane-expand]').first()
+  const firstLaneKey = await firstCaret.getAttribute('data-full-song-lane-expand')
+  await firstCaret.click()
+  await page.waitForTimeout(150)
+
+  // Expanded: the row reports it and the canvas grew taller.
+  await expect(
+    page.locator(`[data-full-song-lane="${firstLaneKey}"]`),
+  ).toHaveAttribute('data-expanded', 'true')
+  const heightExpanded = await canvasHeight(page)
+  expect(heightExpanded).toBeGreaterThan(heightCollapsed)
+
+  // Bind: the cursor jumped off the sentinel onto the lane's pattern line.
+  const afterBind = await cursor(page)
+  expect(afterBind.line).toBeGreaterThan(0)
+  if (sentinel > 1) expect(afterBind.line).not.toBe(sentinel)
+
+  await page.screenshot({ path: 'test-results/full-song-expand-expanded.png' })
+
+  // (3) Multi-expand a second lane (if present) → canvas grows further.
+  if (laneCount >= 2) {
+    await page.locator('[data-full-song-lane-expand]').nth(1).click()
+    await page.waitForTimeout(120)
+    const expandedLanes = await page.locator('[data-full-song-lane][data-expanded="true"]').count()
+    expect(expandedLanes).toBe(2)
+    expect(await canvasHeight(page)).toBeGreaterThan(heightExpanded)
+    await page.screenshot({ path: 'test-results/full-song-expand-multi.png' })
+  }
+
+  // (4) Collapse the first lane again via its caret (toggle).
+  await page.locator(`[data-full-song-lane-expand="${firstLaneKey}"]`).click()
+  await page.waitForTimeout(120)
+  await expect(
+    page.locator(`[data-full-song-lane="${firstLaneKey}"]`),
+  ).toHaveAttribute('data-expanded', 'false')
+
+  // (5) Double-click the grid body → expands the lane under the pointer.
+  const grid = page.locator('[data-full-song="grid"]')
+  const box = await grid.boundingBox()
+  if (box) {
+    await page.mouse.dblclick(box.x + 40, box.y + 10) // top band = first lane
+    await page.waitForTimeout(120)
+    expect(await page.locator('[data-full-song-lane][data-expanded="true"]').count()).toBeGreaterThanOrEqual(1)
+  }
+
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})


### PR DESCRIPTION
Closes #422 · part of #416 (canvas clip-timeline) · roadmap **item A**.

> **Stacked on `feat/song-timeline-canvas` (PR #421).** Base it on #421; GitHub will retarget this to `studio_v0.2.0` once #421 merges. Review/merge #421 first.

## What
Click/expand a lane (a "clip" = a track's pattern chunk) in the canvas Song timeline to **(a)** accordion it taller with **read-only** note detail, and **(b)** **bind** that pattern into the existing Sequencer / Piano Roll **Pattern panel** — no second note editor (PV117). Multi-expand supported (cross-track alignment).

## How
- **`laneLayout.ts`** (pure) — the single vertical source of truth: `(lanes, expanded) → {top,height,expanded}` per lane + `totalHeight`, plus a `laneAtY` hit-test. The canvas draw, the host height, the DOM labels, and the hit-test all read it, so variable row heights never desync (PV116 shared transform).
- **`drawTimeline`** generalized to per-lane boxes; an expanded lane renders richer read-only detail — forced mini-note marks over the taller band (pitch spread) + faint per-beat gridlines for rhythm readability (design §4.5).
- **Bind seam (item A):** the scene carries a per-lane `sourceOffset` (first event's `loc[0].start`, captured in the runtime `collectNoteMarks` walk — kept out of the pure module per the gifenc trap). `FullSongTimeline` fires `onBindLane(offset)`; `MusicalTimeline` maps it → line → `revealLineInFile` — the **same cursor-move seam as note-click**, which re-detects the active chunk and rebinds the panel. Reuse, not rebuild.
- **Gesture (DAW-grounded):** seek-anywhere stays; a lane disclosure **caret** (and a grid **double-click** hit-test) expands + binds.
- **`SongTimelineCanvas`** takes the layout and sticks **left only** (dropped `top:0`) so it scrolls vertically with the labels once expanded lanes overflow.

## Test plan
- **Unit:** `laneLayout` (stacking, multi-expand, hit-test, degenerate); `drawTimeline` per-lane placement + expanded beat-grid + forced marks; scene `sourceOffset` merge.
- **Component (jsdom):** caret → `data-expanded` toggle + `onBindLane` fired; multi-expand.
- **E2E (real app):** expand → taller canvas + cursor jumps to the lane's source line; multi-expand; double-click body expands; no console errors.
- **Observed (screenshots):** d1 caret → tall pitch-spread band + per-beat grid, cursor → line 7; second caret → d2 expands, cursor → line 13.
- App suite **401 green**; lint clean.

## Non-goals (honest)
In-place inline note **editing** (routes to the panel), real-time per-note monitor, true clip segments (cat/arrange = a later phase), worker rendering (profiled-jank-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)