### PR TITLE
✨ feat(timeline): #440 — delete a clip on the Song canvas (select + remove arm)

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -93,6 +93,16 @@ export interface FullSongTimelineProps {
     armIndex: number
     weight: number
   }) => void
+  /** Delete a clip (Phase 5c, #386). Fired when a selected clip is removed
+   *  (click a clip to select, then Delete/Backspace). Receives the clip's lane
+   *  source anchor + arm index; the parent parses the arrangement at the anchor
+   *  and writes a surgical remove-arm edit. Optional — without it clips can't be
+   *  selected/deleted. A combinator's SOLE remaining arm is not deletable
+   *  (a lane keeps ≥1 clip, PV122 #5); the serializer no-ops that case. */
+  readonly onDeleteClip?: (req: {
+    sourceOffset: number | null
+    armIndex: number
+  }) => void
 }
 
 /** Display span: one loop period, or the analyzed horizon when none. ≥ 1. */
@@ -398,6 +408,41 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     weight: number
   } | null>(null)
 
+  // ── Select + delete a clip (Phase 5c, #386) ───────────────────────────────
+  // Clicking a clip's BODY selects it (and still seeks — seek-anywhere is
+  // preserved); Delete/Backspace then drops the arm. Only real arms
+  // (`armIndex ≥ 0`) are selectable; a bare track's implicit clip has no arm to
+  // remove. Selection is keyed by lane + arm; the highlight rect is re-derived
+  // in render from the live scene/layout so it tracks zoom, scroll, and re-eval.
+  const { onDeleteClip } = props
+  const [selected, setSelected] = useState<{
+    laneKey: string
+    armIndex: number
+    sourceOffset: number | null
+  } | null>(null)
+
+  // Hit-test a clip BODY (not its edge) under a client point → { lane, clip },
+  // or null. Mirrors `clipEdgeAt` but matches CONTAINMENT (`clipAtCycle`) and
+  // skips the bare implicit clip. Reads live refs so it stays closure-stable.
+  const clipBodyAt = React.useCallback(
+    (clientX: number, clientY: number) => {
+      const el = areaRef.current
+      if (!el) return null
+      const rect = el.getBoundingClientRect()
+      const cw = contentWidthFor(rect.width, zoomRef.current)
+      const contentX = clientX - rect.left + scrollLeftRef.current
+      const laneKey = laneAtY(layoutRef.current, clientY - rect.top)
+      if (laneKey == null) return null
+      const lane = sceneRef.current.lanes.find((l) => l.laneKey === laneKey)
+      if (!lane) return null
+      const cyc = xToSongCycle(contentX, displayCycles, cw)
+      const clip = clipAtCycle(lane, cyc)
+      if (!clip || clip.armIndex < 0) return null
+      return { lane, clip }
+    },
+    [displayCycles],
+  )
+
   // Hit-test a clip's right edge under a client point → the draggable clip, or
   // null. We scan the lane's clips and match proximity to each clip's RIGHT EDGE
   // directly (not `clipAtCycle`): that grabs the LAST clip's edge too (its end is
@@ -434,7 +479,15 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     (e: React.PointerEvent) => {
       const hit = clipEdgeAt(e.clientX, e.clientY)
       if (!hit) {
-        handleSeekAtClientX(e.clientX) // not on a clip edge → seek (unchanged)
+        // Not on a clip edge → select a clip body (Phase 5c) if over one, then
+        // seek (seek-anywhere preserved). Empty space clears the selection.
+        const body = onDeleteClip ? clipBodyAt(e.clientX, e.clientY) : null
+        setSelected(
+          body
+            ? { laneKey: body.lane.laneKey, armIndex: body.clip.armIndex, sourceOffset: body.lane.sourceOffset }
+            : null,
+        )
+        handleSeekAtClientX(e.clientX)
         return
       }
       // Begin a trim drag: capture the pointer so the whole gesture is ours and
@@ -458,7 +511,7 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
       const cw = contentWidthFor(areaRef.current!.getBoundingClientRect().width, zoomRef.current)
       setTrimEdgeX(songCycleToX(hit.clip.endCycle, displayCycles, cw))
     },
-    [clipEdgeAt, handleSeekAtClientX, displayCycles],
+    [clipEdgeAt, clipBodyAt, handleSeekAtClientX, displayCycles, onDeleteClip],
   )
 
   const handleGridPointerMove = React.useCallback(
@@ -505,6 +558,32 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     },
     [onTrimClip],
   )
+
+  // Delete/Backspace on the focused grid removes the selected clip. The grid is
+  // focusable (tabIndex) so a click-to-select leaves it ready for the keystroke.
+  const handleGridKeyDown = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key !== 'Delete' && e.key !== 'Backspace') return
+      if (!selected || !onDeleteClip) return
+      e.preventDefault()
+      onDeleteClip({ sourceOffset: selected.sourceOffset, armIndex: selected.armIndex })
+      setSelected(null)
+    },
+    [selected, onDeleteClip],
+  )
+
+  // The selection highlight rect, derived from the LIVE scene + layout so it
+  // follows zoom/scroll and vanishes if the arm disappears after a re-eval.
+  const selectionRect = useMemo(() => {
+    if (!selected) return null
+    const lane = scene.lanes.find((l) => l.laneKey === selected.laneKey)
+    const clip = lane?.clips.find((c) => c.armIndex === selected.armIndex)
+    const box = layout.boxes.find((b) => b.laneKey === selected.laneKey)
+    if (!lane || !clip || !box) return null
+    const left = songCycleToX(clip.startCycle, displayCycles, contentWidth)
+    const right = songCycleToX(clip.endCycle, displayCycles, contentWidth)
+    return { left, width: Math.max(1, right - left), top: box.top, height: box.height }
+  }, [selected, scene, layout, displayCycles, contentWidth])
 
   const periodLabel =
     analysis == null
@@ -709,11 +788,13 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
           data-full-song="grid"
           ref={areaRef}
           style={styles.grid}
+          tabIndex={0}
           onScroll={handleGridScroll}
           onPointerDown={handleGridPointerDown}
           onPointerMove={handleGridPointerMove}
           onPointerUp={(e) => endTrimDrag(e, true)}
           onPointerCancel={(e) => endTrimDrag(e, false)}
+          onKeyDown={handleGridKeyDown}
           onDoubleClick={(e) => handleExpandAtClientY(e.clientY)}
         >
           {/* Inner content is contentWidth wide (the scroll spacer for the native
@@ -739,6 +820,18 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
             )}
             {trimEdgeX != null && (
               <div data-full-song="trim-edge" style={{ ...styles.trimEdge, left: trimEdgeX }} />
+            )}
+            {selectionRect && (
+              <div
+                data-full-song="clip-selection"
+                style={{
+                  ...styles.clipSelection,
+                  left: selectionRect.left,
+                  width: selectionRect.width,
+                  top: selectionRect.top,
+                  height: selectionRect.height,
+                }}
+              />
             )}
           </div>
         </div>
@@ -995,5 +1088,16 @@ const styles = {
     opacity: 0.9,
     boxShadow: '0 0 6px var(--accent, rgba(110,168,254,0.6))',
     pointerEvents: 'none' as const,
+  },
+  // Selected-clip highlight (Phase 5c): an accent outline + faint fill over the
+  // arm's [start,end) × lane box, in content space (tracks zoom/scroll).
+  clipSelection: {
+    position: 'absolute' as const,
+    border: '1.5px solid var(--accent, #6ea8fe)',
+    borderRadius: 2,
+    background: 'var(--accent-faint, rgba(110,168,254,0.14))',
+    boxShadow: '0 0 6px var(--accent, rgba(110,168,254,0.5))',
+    pointerEvents: 'none' as const,
+    boxSizing: 'border-box' as const,
   },
 } satisfies Record<string, React.CSSProperties>

--- a/packages/app/src/components/MusicalTimeline.tsx
+++ b/packages/app/src/components/MusicalTimeline.tsx
@@ -51,6 +51,7 @@ import {
   applyOffsetEditsToFile,
   detectArrangeAt,
   setWeight,
+  removeArm,
   useTrackMeta,
   getMusicalTimelineSubRowHeight,
   onMusicalTimelineSubRowHeightChange,
@@ -1038,6 +1039,26 @@ export function MusicalTimeline(
     [snapshot],
   )
 
+  // Delete a clip on the Song canvas (Phase 5c, #386): the timeline hands up the
+  // selected clip's lane source anchor + arm index. We parse the arrangement at
+  // that anchor against the SAME snapshot text the offsets came from, build a
+  // surgical remove-arm edit (the serializer drops the arm + one separator), and
+  // route it through the write-back (source `arrange.structure`, the reserved
+  // structural-edit channel). A combinator's sole remaining arm is NOT removed
+  // (a lane keeps ≥1 clip, PV122 #5) — `removeArm` returns no edits, so this
+  // no-ops. The debounced re-eval republishes the IR and the lane re-derives.
+  const handleDeleteClip = React.useCallback(
+    (req: { sourceOffset: number | null; armIndex: number }) => {
+      if (!snapshot?.source || req.sourceOffset == null) return
+      const call = detectArrangeAt(snapshot.code, req.sourceOffset)
+      if (!call || req.armIndex < 0 || req.armIndex >= call.arms.length) return
+      const edits = removeArm(snapshot.code, call, req.armIndex)
+      if (edits.length === 0) return
+      applyOffsetEditsToFile(snapshot.source, edits, 'arrange.structure', snapshot.code)
+    },
+    [snapshot],
+  )
+
   const bpm = cpsToBpm(currentCps)
   const barBeat = formatBarBeat(currentCycle)
 
@@ -1118,6 +1139,7 @@ export function MusicalTimeline(
           getDrawerOpen={props.getDrawerOpen}
           getActiveTabId={props.getActiveTabId}
           onTrimClip={handleTrimClip}
+          onDeleteClip={handleDeleteClip}
           onBindLane={handleBindLane}
         />
       ) : (

--- a/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
+++ b/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
@@ -344,3 +344,74 @@ describe('FullSongTimeline — trim a clip (drag right edge → set-weight, #437
     expect(onTrimClip).not.toHaveBeenCalled()
   })
 })
+
+describe('FullSongTimeline — delete a clip (select body + Delete → remove-arm, #386)', () => {
+  // Same `arrange([2, s("bd")], [2, s("hh")])`-shaped fixture: the bd lane has two
+  // real clips (arm 0 [0,2), arm 1 [2,4)) at 200px/cycle, so arm 0's body centre
+  // sits at x≈200 and arm 1's at x≈600 (bd row y≈10). The hh lane carries no
+  // armIndex events, so it gets ONE implicit clip (armIndex −1, not deletable).
+  function renderDeletable(onDeleteClip: ReturnType<typeof vi.fn>) {
+    const utils = renderFull({ ir: {} as never, onDeleteClip })
+    const grid = utils.container.querySelector('[data-full-song="grid"]') as HTMLElement
+    grid.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 800, height: 48, right: 800, bottom: 48, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect
+    return { ...utils, grid }
+  }
+
+  const settle = () => act(async () => { await Promise.resolve() })
+
+  it('selecting arm 0’s body then Delete → onDeleteClip(arm 0)', async () => {
+    const onDeleteClip = vi.fn()
+    const { grid, container } = renderDeletable(onDeleteClip)
+    await settle()
+    // Click arm 0's body (x≈200 = cycle 1, bd row) → selects it (highlight shows).
+    fireEvent.pointerDown(grid, { clientX: 200, clientY: 10, pointerId: 1 })
+    fireEvent.pointerUp(grid, { clientX: 200, clientY: 10, pointerId: 1 })
+    expect(container.querySelector('[data-full-song="clip-selection"]')).not.toBeNull()
+    // Delete removes that arm — assert the VALUE (sourceOffset = bd lane anchor 9).
+    fireEvent.keyDown(grid, { key: 'Delete' })
+    expect(onDeleteClip).toHaveBeenCalledTimes(1)
+    expect(onDeleteClip).toHaveBeenCalledWith({ sourceOffset: 9, armIndex: 0 })
+    // Selection clears after the delete fires.
+    expect(container.querySelector('[data-full-song="clip-selection"]')).toBeNull()
+  })
+
+  it('Backspace also deletes the selected clip (arm 1)', async () => {
+    const onDeleteClip = vi.fn()
+    const { grid } = renderDeletable(onDeleteClip)
+    await settle()
+    fireEvent.pointerDown(grid, { clientX: 600, clientY: 10, pointerId: 1 }) // arm 1 body
+    fireEvent.pointerUp(grid, { clientX: 600, clientY: 10, pointerId: 1 })
+    fireEvent.keyDown(grid, { key: 'Backspace' })
+    expect(onDeleteClip).toHaveBeenCalledWith({ sourceOffset: 9, armIndex: 1 })
+  })
+
+  it('Delete with nothing selected is a no-op', async () => {
+    const onDeleteClip = vi.fn()
+    const { grid } = renderDeletable(onDeleteClip)
+    await settle()
+    fireEvent.keyDown(grid, { key: 'Delete' })
+    expect(onDeleteClip).not.toHaveBeenCalled()
+  })
+
+  it('clicking the bare/implicit clip (hh lane) does not select → Delete no-ops', async () => {
+    const onDeleteClip = vi.fn()
+    const { grid, container } = renderDeletable(onDeleteClip)
+    await settle()
+    // hh row (y≈30) has only the implicit clip (armIndex −1) — not selectable.
+    fireEvent.pointerDown(grid, { clientX: 200, clientY: 30, pointerId: 1 })
+    fireEvent.pointerUp(grid, { clientX: 200, clientY: 30, pointerId: 1 })
+    expect(container.querySelector('[data-full-song="clip-selection"]')).toBeNull()
+    fireEvent.keyDown(grid, { key: 'Delete' })
+    expect(onDeleteClip).not.toHaveBeenCalled()
+  })
+
+  it('clicking a clip still seeks (seek-anywhere preserved alongside select)', async () => {
+    const onDeleteClip = vi.fn()
+    const { grid, onSeek } = renderDeletable(onDeleteClip)
+    await settle()
+    fireEvent.pointerDown(grid, { clientX: 200, clientY: 10, pointerId: 1 })
+    fireEvent.pointerUp(grid, { clientX: 200, clientY: 10, pointerId: 1 })
+    expect(onSeek).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/app/tests/full-song-arrange-delete.spec.ts
+++ b/packages/app/tests/full-song-arrange-delete.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Full-song view: DELETE a clip by selecting it + pressing Delete (#386 /
+ * Phase 5c) — Playwright observation (AnviDev observe gate).
+ *
+ * The unit tests cover the substrate (editor arrange.test.ts: removeArm) and the
+ * gesture (FullSongTimeline.test.tsx: select body + Delete → onDeleteClip). This
+ * drives the REAL app end-to-end to prove the whole write-back loop works:
+ *   click a clip body → select → Delete → remove-arm serializer → registry
+ *   write-back → the editor SOURCE loses that arm → the debounced re-eval
+ *   republishes the IR → the lane disappears.
+ *
+ * We TYPE the song (not setValue) so the onChange → file store → IR-snapshot
+ * path fires (same reason as the trim spec).
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+// Two arms, period 2 + 2 = 4. Arm 0 (bd) spans cycles [0,2) → its body sits in
+// the first half of the first lane. Bare patterns so the body isn't obscured.
+const ARRANGE_SONG = 'arrange([2, s("bd")], [2, s("hh")])'
+
+async function bootShell(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('stave:bottomPanel.height', '340')
+      localStorage.setItem('stave:bottomPanel.open', 'true')
+      localStorage.setItem('stave:bottomPanel.activeTabId', 'musical-timeline')
+    } catch {
+      /* ignore */
+    }
+  })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => ((window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco?.editor?.getEditors?.()?.length ?? 0) > 0,
+    { timeout: 20_000 },
+  )
+}
+
+async function typeSongAndEval(page: Page, code: string): Promise<void> {
+  await page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string } | null; focus: () => void }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    t?.focus()
+  })
+  await page.locator('.monaco-editor').first().click()
+  await page.keyboard.press(`${MOD}+A`)
+  await page.keyboard.press('Backspace')
+  await page.keyboard.type(code, { delay: 8 })
+  await page.waitForTimeout(400)
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1800)
+}
+
+function strudelSource(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string; getValue: () => string } | null }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    return t?.getModel()?.getValue() ?? ''
+  })
+}
+
+test('selecting arm 0’s clip and pressing Delete removes the arm from the source', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await bootShell(page)
+  await typeSongAndEval(page, ARRANGE_SONG)
+
+  await page.locator('[data-musical-timeline="view-toggle"]').click()
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+  await page.locator('[data-full-song-canvas]').waitFor({ timeout: 10_000 })
+  await page.waitForTimeout(400)
+
+  expect(await strudelSource(page)).toContain('arrange([2, s("bd")]')
+
+  // Click arm 0's body (the bd lane, first half = cycle ~1 of 4 → 0.25·W) to
+  // select it — well clear of the edges at 0 and 0.5·W so it's a body, not a trim.
+  const grid = page.locator('[data-full-song="grid"]')
+  const box = await grid.boundingBox()
+  if (!box) throw new Error('no grid box')
+  const y = box.y + 8 // first (bd) lane row
+  await page.mouse.click(box.x + box.width * 0.25, y)
+  await expect(page.locator('[data-full-song="clip-selection"]')).toBeVisible({ timeout: 5_000 })
+
+  // Delete the selected clip → the arm (and one separator) is removed.
+  await page.keyboard.press('Delete')
+
+  // The remove-arm edit applied to the model; the debounced re-eval follows.
+  await expect.poll(() => strudelSource(page), { timeout: 8_000 }).toContain('arrange([2, s("hh")])')
+  // arm 0 (bd) is gone entirely.
+  expect(await strudelSource(page)).not.toContain('s("bd")')
+
+  await page.screenshot({ path: 'test-results/arrange-delete.png' })
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})


### PR DESCRIPTION
## Problem
The Song timeline could trim a clip (#437) but not remove one. A clip is one arm of an `arrange`/`cat` combinator; deleting it must drop that arm structurally — and there was no selection model or gesture for it.

## Fix
Adds a **selected-clip** model and the DELETE gesture (Phase 5c, second of four ops after TRIM):

- **Click a clip body** → selects it (accent highlight). The click **still seeks** — seek-anywhere is preserved.
- **Delete/Backspace** → removes the selected arm via the shipped `removeArm` serializer → `applyOffsetEditsToFile` (source `arrange.structure`).
- Only real arms (`armIndex ≥ 0`) are selectable; a bare track's implicit clip has no arm to drop.
- A combinator's **sole remaining arm is not removable** (a lane keeps ≥1 clip, PV122 #5) — `removeArm` no-ops that case.

Mirrors the TRIM spine: `FullSongTimeline` (`clipBodyAt` hit-test → `onDeleteClip`) → `MusicalTimeline.handleDeleteClip` → `detectArrangeAt` → `removeArm` → write-back → debounced re-eval → lane re-derives. **App-only** (reuses the shipped primitive — no editor/dist change). The selection model is the substrate MOVE/DUPLICATE/SPLIT will build on.

## Test plan
- **Verify:** app **553 green** — 5 new `FullSongTimeline` delete-gesture tests (select body + Delete/Backspace → `onDeleteClip` VALUE; bare clip not selectable; nothing-selected no-op; seek-still-fires). PointerEvent shim + assert-VALUE-not-count (P176).
- **Observe (e2e):** `full-song-arrange-delete` — real-browser click-select + Delete rewrote `arrange([2, s("bd")], [2, s("hh")])` → `arrange([2, s("hh")])` (bd arm + separator gone), no console/page errors.

Stacked on TRIM's spine; base `studio_v0.2.0`. Part of the P5c arc → MOVE/DUPLICATE/SPLIT follow.

closes #440
