### PR TITLE
🐛 fix(timeline): #448 — clear clip selection after move/duplicate/split

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -717,9 +717,14 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
       if (mv.armIndex >= 0) {
         if (mv.toIndex !== mv.armIndex) {
           onMoveClip?.({ kind: 'reorder', sourceOffset: mv.sourceOffset, fromIndex: mv.armIndex, toIndex: mv.toIndex })
+          // The arm list reindexes after a reorder, so the held armIndex would
+          // now point at a different clip — clear it (matching DELETE).
+          setSelected(null)
         }
       } else if (mv.leadCycle > 0) {
         onMoveClip?.({ kind: 'wrap', sourceOffset: mv.sourceOffset, leadingWeight: mv.leadCycle, patternWeight: 1 })
+        // §2.1 wrap rewrites the bare clip into an arrange() — drop the stale selection.
+        setSelected(null)
       }
     },
     [handleSeekAtClientX, onMoveClip],
@@ -758,6 +763,9 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
         if (!onDuplicateClip) return
         e.preventDefault()
         onDuplicateClip({ sourceOffset: selected.sourceOffset, armIndex: selected.armIndex })
+        // A clone arm is inserted after the selection, shifting later indices —
+        // clear the held armIndex so a follow-up keystroke can't hit the wrong clip.
+        setSelected(null)
         return
       }
       if (e.key === 'Delete' || e.key === 'Backspace') {
@@ -782,6 +790,8 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
           armIndex: selected.armIndex,
           firstWeight: Math.floor(weight / 2),
         })
+        // Split inserts a second arm, reindexing the list — clear the selection.
+        setSelected(null)
       }
     },
     [selected, onDeleteClip, onDuplicateClip, onSplitClip],

--- a/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
+++ b/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
@@ -477,6 +477,22 @@ describe('FullSongTimeline — move a clip (drag body → reorder / §2.1 wrap, 
     expect(onMoveClip).not.toHaveBeenCalled()
   })
 
+  it('clears a held selection after a reorder (no stale armIndex, #448)', async () => {
+    const onMoveClip = vi.fn()
+    const { grid, container } = renderReorderable(onMoveClip)
+    await settle()
+    // Select arm 1 (a non-drag click) — the highlight shows.
+    fireEvent.pointerDown(grid, { clientX: 600, clientY: 10, pointerId: 1 })
+    fireEvent.pointerUp(grid, { clientX: 600, clientY: 10, pointerId: 1 })
+    expect(container.querySelector('[data-full-song="clip-selection"]')).not.toBeNull()
+    // Now reorder arm 0 → arm 1's span; the arm list reindexes, so selection clears.
+    fireEvent.pointerDown(grid, { clientX: 200, clientY: 10, pointerId: 1 })
+    fireEvent.pointerMove(grid, { clientX: 600, clientY: 10, pointerId: 1 })
+    fireEvent.pointerUp(grid, { clientX: 600, clientY: 10, pointerId: 1 })
+    expect(onMoveClip).toHaveBeenCalledWith({ kind: 'reorder', sourceOffset: 9, fromIndex: 0, toIndex: 1 })
+    expect(container.querySelector('[data-full-song="clip-selection"]')).toBeNull()
+  })
+
   it('dragging a BARE track’s clip → onMoveClip wrap (§2.1, lead = drop cycle)', async () => {
     const onMoveClip = vi.fn()
     const { grid } = renderWrappable(onMoveClip)
@@ -532,6 +548,17 @@ describe('FullSongTimeline — duplicate a clip (select + ⌘/Ctrl-D → insert 
     fireEvent.keyDown(grid, { key: 'd', metaKey: true })
     expect(onDuplicateClip).not.toHaveBeenCalled()
   })
+
+  it('clears the selection after duplicating (no stale armIndex, #448)', async () => {
+    const onDuplicateClip = vi.fn()
+    const { grid, container } = renderDuplicatable(onDuplicateClip)
+    await settle()
+    fireEvent.pointerDown(grid, { clientX: 200, clientY: 10, pointerId: 1 }) // select arm 0
+    fireEvent.pointerUp(grid, { clientX: 200, clientY: 10, pointerId: 1 })
+    expect(container.querySelector('[data-full-song="clip-selection"]')).not.toBeNull()
+    fireEvent.keyDown(grid, { key: 'd', metaKey: true })
+    expect(container.querySelector('[data-full-song="clip-selection"]')).toBeNull()
+  })
 })
 
 describe('FullSongTimeline — split a clip (select + S → split arm at midpoint, #386)', () => {
@@ -562,6 +589,17 @@ describe('FullSongTimeline — split a clip (select + S → split arm at midpoin
     await settle()
     fireEvent.keyDown(grid, { key: 's' })
     expect(onSplitClip).not.toHaveBeenCalled()
+  })
+
+  it('clears the selection after splitting (#448)', async () => {
+    const onSplitClip = vi.fn()
+    const { grid, container } = renderSplittable(onSplitClip)
+    await settle()
+    fireEvent.pointerDown(grid, { clientX: 200, clientY: 10, pointerId: 1 }) // select arm 0 [0,2)
+    fireEvent.pointerUp(grid, { clientX: 200, clientY: 10, pointerId: 1 })
+    expect(container.querySelector('[data-full-song="clip-selection"]')).not.toBeNull()
+    fireEvent.keyDown(grid, { key: 's' })
+    expect(container.querySelector('[data-full-song="clip-selection"]')).toBeNull()
   })
 
   it('⌘-S (save) does not trigger a split', async () => {


### PR DESCRIPTION
Follow-up from the P5c critical self-review. Closes #448.

## Problem
`FullSongTimeline` kept `selected.armIndex` after a structural edit. DELETE cleared it, but **MOVE-reorder / §2.1 wrap / DUPLICATE / SPLIT did not**. Those ops reindex the arm list (a reorder swaps indices; duplicate/split insert arms), so the held `armIndex` could resolve to a *different* clip — a follow-up keystroke (Delete / S / ⌘-D) would then act on the wrong clip. Low severity (the highlight re-derives from the live scene and users usually re-click), but a latent footgun.

## Fix
`setSelected(null)` in each commit path that dispatches a structural edit, matching DELETE:
- **reorder** — only when `toIndex !== armIndex` (a real move, not a no-op drag back onto its own span)
- **§2.1 wrap** — when there's a leading gap
- **duplicate** / **split** — after dispatch

`setSelected` is a stable `useState` setter, so the `useCallback` dep arrays are unchanged.

## Test plan
- `pnpm --filter @stave/app test` — **566 passed** (3 new: duplicate / split / reorder each assert `[data-full-song="clip-selection"]` shows on select then clears after the op, mirroring the DELETE test).
- Observation: unit assertions check the *rendered* selection highlight element (not just the mock), since this is a pure client-state change. The op→source-rewrite loop is already covered by the existing `full-song-arrange-*.spec.ts` e2e, so those weren't re-extended.

## Known follow-up (unchanged, out of scope)
A nested-combinator arm (arrange-of-cat) — `detectArrangeAt` resolves the inner combinator while `armIndex` indexes the outer → the op guards to a safe no-op. Tracked as the nested-editing follow-up.
