### PR TITLE
🐛 fix(types): #454 — optional-call inline-monaco methods in glsl-per-track spec

### DIFF
--- a/packages/app/tests/glsl-per-track.spec.ts
+++ b/packages/app/tests/glsl-per-track.spec.ts
@@ -79,7 +79,7 @@ async function setCode(page: Page, code: string): Promise<void> {
       window as unknown as { monaco?: { editor?: { getEditors?: () => { getModel?: () => { setValue: (v: string) => void } | null }[] } } }
     ).monaco?.editor?.getEditors?.()?.[0]
     if (!e) return false
-    e.getModel()?.setValue(c)
+    e.getModel?.()?.setValue(c)
     return true
   }, code)
   expect(ok).toBe(true)
@@ -90,7 +90,7 @@ async function press(page: Page, key: string): Promise<void> {
   await page.evaluate(() =>
     (
       window as unknown as { monaco?: { editor?: { getEditors?: () => { focus?: () => void }[] } } }
-    ).monaco?.editor?.getEditors?.()?.[0]?.focus(),
+    ).monaco?.editor?.getEditors?.()?.[0]?.focus?.(),
   )
   await page.keyboard.press(key)
 }
@@ -99,7 +99,7 @@ async function scrollTo(page: Page, top: number): Promise<void> {
   await page.evaluate((t) => {
     ;(
       window as unknown as { monaco?: { editor?: { getEditors?: () => { setScrollTop?: (n: number) => void }[] } } }
-    ).monaco?.editor?.getEditors?.()?.[0]?.setScrollTop(t)
+    ).monaco?.editor?.getEditors?.()?.[0]?.setScrollTop?.(t)
   }, top)
 }
 


### PR DESCRIPTION
Closes #454.

## Problem

`packages/app/tests/glsl-per-track.spec.ts` tripped 3× **TS2722** ("cannot invoke an object which is possibly 'undefined'"). The locally-declared inline monaco type marks `getModel` / `focus` / `setScrollTop` as **optional** methods, but each was invoked with a plain call `()` instead of an optional call `?.()`.

`pnpm --filter @stave/app exec tsc --noEmit` failed only on these three lines. vitest and `next build` skip tsc on spec files, so runtime was unaffected — this was a clean-typecheck gap.

## Fix

Optional-call at each invocation site:

| Line | Before | After |
|------|--------|-------|
| L82  | `e.getModel()?.setValue(c)` | `e.getModel?.()?.setValue(c)` |
| L93 (`press`) | `?.[0]?.focus()` | `?.[0]?.focus?.()` |
| L102 (`scrollTo`) | `?.[0]?.setScrollTop(t)` | `?.[0]?.setScrollTop?.(t)` |

Type-only; no behavioral change to the e2e.

## Test plan

- [x] `pnpm --filter @stave/app exec tsc --noEmit` — was failing on exactly these 3 errors, now exits **0** with no output.