### PR TITLE
🐛 fix(timeline): #457 — refresh the song timeline on a stopped code edit

### DIFF
--- a/packages/app/src/components/StrudelEditorClient.tsx
+++ b/packages/app/src/components/StrudelEditorClient.tsx
@@ -97,6 +97,11 @@ const STRUDEL_PASSES: readonly Pass<PatternIR>[] = [
 // other; if WINDOW_CYCLES changes there, update this to match.
 const TIMELINE_WINDOW_CYCLES = 2;
 
+// #457 — debounce for republishing the IR snapshot on a stopped code edit, so
+// the Song timeline / IR Inspector track the source as the user types without
+// thrashing analyzeSong on every keystroke. ~one comfortable typing pause.
+const SNAPSHOT_REFRESH_DEBOUNCE_MS = 300;
+
 /**
  * Parse the file's current source into IR and publish an IRSnapshot for the
  * Inspector + full-song timeline. parseStrudel + collect are pure and cheap on
@@ -708,6 +713,43 @@ export default function StrudelEditorClient({
   const [runtimeStates, setRuntimeStates] = useState<Map<string, {
     isPlaying: boolean; error: Error | null; bpm?: number; autoRefresh: boolean;
   }>>(new Map());
+  // Latest-value ref so the content-change subscription (#457, below) can read
+  // the active file's play/live state without re-binding the subscription on
+  // every state change.
+  const runtimeStatesRef = useRef(runtimeStates);
+  runtimeStatesRef.current = runtimeStates;
+
+  // #457 — keep the Song timeline + IR Inspector snapshot in sync with the
+  // SOURCE while the runtime isn't live-evaluating. The snapshot is otherwise
+  // republished only on a successful eval (onEvaluateSuccess) or on song-view
+  // entry (#394), so a code edit with no re-eval — every edit while stopped,
+  // since nothing auto-evaluates — left the timeline frozen at the last eval.
+  // subscribeToWorkspaceFile fires on BOTH typing and Pattern-panel write-backs
+  // (both mutate the workspace file); captureAndPublishSnapshot is pure on the
+  // source string (and a no-op for non-Strudel files), so it's safe off the
+  // eval lifecycle. Skipped while live-coding (playing && autoRefresh): there
+  // the runtime's own debounced re-eval owns the snapshot, so republishing here
+  // would double-publish and flash a mid-keystroke broken parse.
+  useEffect(() => {
+    const fid = watchedFileId;
+    if (!fid) return;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const unsub = subscribeToWorkspaceFile(fid, () => {
+      const st = runtimeStatesRef.current.get(fid);
+      if (st?.isPlaying && st.autoRefresh) return; // eval-path owns it
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        captureAndPublishSnapshot(
+          fid,
+          runtimesRef.current.get(fid)?.getCurrentCycle?.() ?? null,
+        );
+      }, SNAPSHOT_REFRESH_DEBOUNCE_MS);
+    });
+    return () => {
+      if (timer) clearTimeout(timer);
+      unsub();
+    };
+  }, [watchedFileId]);
 
   const getOrCreateRuntime = useCallback((fileId: string): LiveCodingRuntime | null => {
     if (runtimesRef.current.has(fileId)) return runtimesRef.current.get(fileId)!;

--- a/packages/app/tests/full-song-stopped-edit.spec.ts
+++ b/packages/app/tests/full-song-stopped-edit.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Full-song view: the timeline tracks the SOURCE on a code edit that is NOT
+ * re-evaluated (#457) — Playwright observation (AnviDev observe gate).
+ *
+ * The IR snapshot that the Song view analyzes was historically published only on
+ * a successful eval (onEvaluateSuccess) or on song-view entry (#394). So editing
+ * the code without pressing ⌘/Ctrl+Enter — which is every edit while stopped or
+ * with live-mode off — left the timeline frozen at the last eval. The fix
+ * subscribes to the active file's content and debounce-republishes the snapshot
+ * when the runtime isn't live-evaluating.
+ *
+ * This drives the bug directly: eval a 2-track program (2 lanes), then RETYPE a
+ * 3-track program WITHOUT evaluating, and assert a third lane appears.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+async function bootShell(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('stave:bottomPanel.height', '340')
+      localStorage.setItem('stave:bottomPanel.open', 'true')
+      localStorage.setItem('stave:bottomPanel.activeTabId', 'musical-timeline')
+    } catch { /* ignore */ }
+  })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => ((window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco?.editor?.getEditors?.()?.length ?? 0) > 0,
+    { timeout: 20_000 },
+  )
+}
+
+async function focusEditor(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string } | null; focus: () => void }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    t?.focus()
+  })
+  await page.locator('.monaco-editor').first().click()
+}
+
+async function retype(page: Page, code: string): Promise<void> {
+  await focusEditor(page)
+  await page.keyboard.press(`${MOD}+A`)
+  await page.keyboard.press('Backspace')
+  await page.keyboard.type(code, { delay: 8 })
+}
+
+test('Song view re-analyzes a code edit that is never re-evaluated (#457)', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(`console.error: ${m.text()}`) })
+
+  await bootShell(page)
+
+  // Eval a 2-track program → 2 lanes.
+  await retype(page, '$: s("bd*4")\n$: s("hh*8")')
+  await page.waitForTimeout(300)
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1500)
+
+  await page.locator('[data-musical-timeline="view-toggle"]').click()
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+  await expect.poll(() => page.locator('[data-full-song-lane]').count(), { timeout: 8_000 }).toBe(2)
+
+  // Now EDIT to a 3-track program, but DO NOT evaluate. The fix must republish
+  // the snapshot from the edited source → the Song view gains a third lane.
+  await retype(page, '$: s("bd*4")\n$: s("hh*8")\n$: s("cp*2")')
+  // No ⌘/Ctrl+Enter here. Wait past the 300ms snapshot debounce + analysis.
+  await expect.poll(() => page.locator('[data-full-song-lane]').count(), { timeout: 8_000 }).toBe(3)
+
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})


### PR DESCRIPTION
Closes #457.

## Problem

Editing the code — by **typing** or via the **Pattern panel** (Sequencer/Piano Roll) — did **not** update the Song timeline / IR Inspector when the runtime wasn't playing (stopped, or playing with live-mode off). The view only refreshed after a successful eval (⌘/Ctrl+Enter).

## Root cause

The Song view re-analyzes on every new IR snapshot (`MusicalTimeline` analyze effect, deps `[viewMode, snapshot]`). But the snapshot was published in only two places: `runtime.onEvaluateSuccess` and the #394 song-view-entry on-demand path. There was **no content-change → republish path**, so any edit without a re-eval — every edit while stopped, since nothing auto-evaluates — left the snapshot frozen at the last eval.

## Fix

A new effect in `StrudelEditorClient` (keyed on the active file) subscribes via `subscribeToWorkspaceFile` — the same seam the runtime uses for live-mode re-eval, which fires on **both** typing and Pattern-panel write-backs — and **debounce-republishes** the snapshot through `captureAndPublishSnapshot` (pure on the source string, a no-op for non-Strudel files, reused from #394).

**Gated** to skip while live-coding (`isPlaying && autoRefresh`): there the runtime's own debounced re-eval already owns the snapshot, so republishing would double-publish and flash a mid-keystroke broken parse. Covers both reported cases — stopped, and playing with live-mode off. No publish loop (`publishIRSnapshot` writes to the irInspector store, not the workspace file).

## Test plan

- [x] New e2e `full-song-stopped-edit.spec.ts`: eval a 2-track program (2 lanes) → **retype** a 3-track program **without** evaluating → a third lane appears.
- [x] **Discriminates**: confirmed to FAIL without the fix (stays 2 lanes) and pass with it.
- [x] No regression: `full-song-cold-eval` (#394) + `full-song-arrange-split` e2e green; app unit suite **569 passed**; `tsc --noEmit` clean (only the pre-existing `glsl-per-track` errors, addressed in #455).