### PR TITLE
✨ feat(timeline): #459 — Song view honors the timeline row-height setting (rows + bars)

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -25,10 +25,14 @@
 import * as React from 'react'
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import type { SongAnalysis, PatternIR } from '@stave/editor'
+import {
+  getMusicalTimelineSubRowHeight,
+  onMusicalTimelineSubRowHeightChange,
+} from '@stave/editor'
 import { paletteForTrack, trackIndexOf } from './musicalTimeline/colors'
 import { buildTimelineScene, clipAtCycle } from './musicalTimeline/timelineScene'
 import { collectNoteMarks } from './musicalTimeline/timelineMarks'
-import { computeLaneLayout, laneAtY, SUB_ROW_HEIGHT, type LaneLayout } from './musicalTimeline/laneLayout'
+import { computeLaneLayout, laneAtY, type LaneLayout } from './musicalTimeline/laneLayout'
 import { SongTimelineCanvas } from './SongTimelineCanvas'
 import {
   songCycleToX,
@@ -50,7 +54,6 @@ const USER_SCROLL_GUARD_MS = 1200
 const CONTROLS_HEIGHT = 26
 const TOPBAR_HEIGHT = 28
 const GUTTER_WIDTH = 90
-const ROW_HEIGHT = 22
 /** Height of an expanded ("accordion") lane — tall enough for the read-only
  *  note detail (pitch spread + per-beat grid) to be legible (#422, design §4.5). */
 const EXPANDED_ROW_HEIGHT = 96
@@ -381,9 +384,17 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
   // canvas draw, the canvas host height, the DOM lane labels, and the hit-test.
   const { onBindLane } = props
   const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set())
+  // Lane + per-voice sub-row height follow the shared "timeline row height"
+  // editor setting (#459) — the same source the Live monitor reads — so the
+  // Song view matches it instead of a private constant. The setting governs
+  // every row in the Live view (each leaf voice is one `subRowHeight`), so it
+  // feeds BOTH the collapsed lane height and the expanded sub-row height here;
+  // the EXPANDED single-band note-detail height stays a fixed zoom.
+  const [rowH, setRowH] = useState<number>(() => getMusicalTimelineSubRowHeight())
+  useEffect(() => onMusicalTimelineSubRowHeightChange(setRowH), [])
   const layout = useMemo(
-    () => computeLaneLayout(scene.lanes, expanded, ROW_HEIGHT, EXPANDED_ROW_HEIGHT, SUB_ROW_HEIGHT),
-    [scene.lanes, expanded],
+    () => computeLaneLayout(scene.lanes, expanded, rowH, EXPANDED_ROW_HEIGHT, rowH),
+    [scene.lanes, expanded, rowH],
   )
   // Refs so the double-click hit-test reads live scene/layout without stale
   // closures (mirrors the scrollLeftRef/zoomRef pattern above).

--- a/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
+++ b/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
@@ -54,6 +54,11 @@ vi.mock('@stave/editor', () => ({
   collectCycles: (ir: { bare?: boolean; nested?: boolean } | null) =>
     ir?.bare ? BARE_EVENTS : ir?.nested ? NESTED_EVENTS : ir ? TRIM_EVENTS : [],
   laneKeyOf: (ev: { trackId?: string; s?: string }) => ev?.trackId ?? ev?.s ?? '$default',
+  // #459 — Song view now reads the shared timeline row-height setting. Mock it
+  // to 22 (the height these layout assertions were written for) + a no-op
+  // subscribe, mirroring MusicalTimeline.test's mock.
+  getMusicalTimelineSubRowHeight: () => 22,
+  onMusicalTimelineSubRowHeightChange: () => () => {},
 }))
 
 import { FullSongTimeline } from '../FullSongTimeline'

--- a/packages/app/src/components/__tests__/FullSongTimeline.voices.test.tsx
+++ b/packages/app/src/components/__tests__/FullSongTimeline.voices.test.tsx
@@ -22,6 +22,10 @@ const DRUM_EVENTS = [
 vi.mock('@stave/editor', () => ({
   collectCycles: () => DRUM_EVENTS,
   laneKeyOf: (ev: { trackId?: string; s?: string }) => ev?.trackId ?? ev?.s ?? '$default',
+  // #459 — Song view reads the shared timeline row-height setting; mock to 22
+  // (the SUB_ROW_HEIGHT these sub-row layout assertions were written for).
+  getMusicalTimelineSubRowHeight: () => 22,
+  onMusicalTimelineSubRowHeightChange: () => () => {},
 }))
 
 import { FullSongTimeline } from '../FullSongTimeline'

--- a/packages/app/src/components/__tests__/drawTimeline.barscale.test.ts
+++ b/packages/app/src/components/__tests__/drawTimeline.barscale.test.ts
@@ -1,0 +1,80 @@
+/**
+ * #459 — the Song-view note bar scales with the row height, mirroring the live
+ * monitor (leafBarHeight). Canvas draws aren't DOM-queryable, so this drives
+ * drawTimeline with a mock 2D context that records fillRect(x,y,w,h) and asserts
+ * the NOTE mark's height grows with the lane's row height.
+ */
+import { describe, it, expect } from 'vitest'
+import { drawTimeline, type DrawTheme, type DrawTransform } from '../musicalTimeline/drawTimeline'
+import type { TimelineScene } from '../musicalTimeline/timelineScene'
+import type { LaneLayout } from '../musicalTimeline/laneLayout'
+
+interface Rect { x: number; y: number; w: number; h: number }
+
+/** Minimal 2D-context mock — records fillRect, no-ops the rest. */
+function mockCtx(): { ctx: CanvasRenderingContext2D; rects: Rect[] } {
+  const rects: Rect[] = []
+  const ctx = {
+    fillStyle: '#000',
+    globalAlpha: 1,
+    clearRect: () => {},
+    setTransform: () => {},
+    fillRect: (x: number, y: number, w: number, h: number) => rects.push({ x, y, w, h }),
+    beginPath: () => {},
+    moveTo: () => {},
+    lineTo: () => {},
+    stroke: () => {},
+    fillText: () => {},
+  } as unknown as CanvasRenderingContext2D
+  return { ctx, rects }
+}
+
+const THEME: DrawTheme = {
+  background: '#0f0f1a', rowAlt: 'rgba(255,255,255,0.02)', section: '#111', sectionAlt: '#222',
+  gridline: '#333', clipFill: '#444', clipBorder: '#555',
+}
+const TRANSFORM: DrawTransform = { scrollLeft: 0, contentWidth: 100, viewportWidth: 100 }
+
+// One percussive note at cycle 0.1 spanning 0.1 cycle → 10px wide at pxPerCycle 100.
+function scene(): TimelineScene {
+  return {
+    lanes: [{
+      laneKey: 'd1', color: '#7af', density: [1],
+      notes: [{ cycle: 0.1, end: 0.2, pitch: null, gain: 1 }],
+      pitchMin: null, pitchMax: null, voices: [],
+      clips: [{ armIndex: -1, startCycle: 0, endCycle: 1, label: null }],
+      sourceOffset: null, arrangeOffset: null,
+    }],
+    sections: [], displayCycles: 1, period: null, peakDensity: 1, notesCapped: false,
+  }
+}
+
+function layout(rowHeight: number): LaneLayout {
+  return { boxes: [{ laneKey: 'd1', top: 0, height: rowHeight, expanded: false }], totalHeight: rowHeight }
+}
+
+/** The note mark is the only ~10px-wide fill (background/clip span ~100px;
+ *  gridlines/borders are 1px). Return its height. */
+function noteMarkHeight(rects: Rect[]): number {
+  const marks = rects.filter((r) => r.w >= 5 && r.w <= 20)
+  expect(marks.length, 'exactly one note mark drawn').toBe(1)
+  return marks[0].h
+}
+
+describe('#459 Song note bar scales with row height (live-monitor parity)', () => {
+  it('a taller row draws a taller note bar', () => {
+    const a = mockCtx()
+    drawTimeline(a.ctx, scene(), TRANSFORM, THEME, layout(20))
+    const short = noteMarkHeight(a.rects)
+
+    const b = mockCtx()
+    drawTimeline(b.ctx, scene(), TRANSFORM, THEME, layout(40))
+    const tall = noteMarkHeight(b.rects)
+
+    // leafBarHeight-style scaling: max(3, band - 12). At rowHeight 20 → ~3px;
+    // at 40 → ~22px. The bar MUST grow, not stay a fixed dab.
+    expect(tall).toBeGreaterThan(short)
+    expect(short).toBeLessThanOrEqual(6)
+    expect(tall).toBeGreaterThanOrEqual(18)
+  })
+})

--- a/packages/app/src/components/musicalTimeline/__tests__/drawTimeline.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/drawTimeline.test.ts
@@ -89,10 +89,12 @@ describe('drawTimeline', () => {
     const { ctx: ctx2, rects: rects2 } = mockCtx()
     drawTimeline(ctx2, scene, { ...transform, scrollLeft: 2400 }, theme, flat)
     const screenXof = (cycle: number) => (cycle / 4) * 4000 - 2400
-    const markAt25 = rects2.some((r) => Math.abs(r.x - screenXof(2.5)) < 1 && r.h === 3)
+    // #459 — mark height now scales with the row: at rowHeight 22 it's
+    // barHeightForBand(22 − 2·3) = max(3, 16 − 12) = 4 (was a fixed 3).
+    const markAt25 = rects2.some((r) => Math.abs(r.x - screenXof(2.5)) < 1 && r.h === 4)
     expect(markAt25).toBe(true)
-    // sanity: marks are short (h=3), unlike full-height bands/gridlines.
-    expect(rects2.some((r) => r.h === 3)).toBe(true)
+    // sanity: marks are short (h=4), unlike full-height bands/gridlines.
+    expect(rects2.some((r) => r.h === 4)).toBe(true)
     expect(rects.length).toBeGreaterThan(0)
   })
 
@@ -155,7 +157,7 @@ describe('drawTimeline', () => {
     // 4000px / 4 cycles = 1000 px/cycle ≫ COARSEN_PX → marks mode.
     const { ctx, rects } = mockCtx()
     drawTimeline(ctx, durScene, { scrollLeft: 0, contentWidth: 4000, viewportWidth: 4000 }, theme, flat)
-    const marks = rects.filter((r) => r.h === 3) // mark height (collapsed)
+    const marks = rects.filter((r) => r.h === 4) // mark height (collapsed, rowHeight 22 → 4; #459)
     const short = marks.find((r) => Math.abs(r.x - 0) < 1)!
     const long = marks.find((r) => Math.abs(r.x - 1000) < 1)! // cycle 1 → x=1000
     expect(short.w).toBe(MIN_MARK_W) // floored
@@ -195,9 +197,10 @@ describe('drawTimeline', () => {
     expect(layout.boxes[0].subRows?.length).toBe(2)
     const { ctx, rects } = mockCtx()
     drawTimeline(ctx, drumScene, { scrollLeft: 0, contentWidth: 4000, viewportWidth: 4000 }, theme, layout)
-    // Marks are the short (h=3) rects at x≈0 (cycle 0). The two voices must land
-    // on DIFFERENT baselines — bd in sub-row 0, sd in sub-row 1.
-    const marks = rects.filter((r) => r.h === 3 && Math.abs(r.x - 0) < 1)
+    // Marks are the short rects at x≈0 (cycle 0). #459 — the sub-row mark scales
+    // with the sub-row height: barHeightForBand(22 − 2·2) = max(3, 18 − 12) = 6.
+    // The two voices must land on DIFFERENT baselines — bd sub-row 0, sd sub-row 1.
+    const marks = rects.filter((r) => r.h === 6 && Math.abs(r.x - 0) < 1)
     expect(marks.length).toBe(2)
     const ys = marks.map((r) => r.y).sort((a, b) => a - b)
     expect(ys[1] - ys[0]).toBeGreaterThanOrEqual(20) // ~one SUB_ROW_HEIGHT apart

--- a/packages/app/src/components/musicalTimeline/drawTimeline.ts
+++ b/packages/app/src/components/musicalTimeline/drawTimeline.ts
@@ -60,6 +60,18 @@ export const COARSEN_PX = 28
  *  stays clickable — mirrors the live view's `MIN_BLOCK_PX` (timeAxis.ts). */
 export const MIN_MARK_W = 2
 
+/** Note-bar height scales with its band — mirrors the live monitor's
+ *  `leafBarHeight` (MusicalTimeline): the bar fills most of the band, reserving
+ *  ~`BAR_PITCH_RESERVE`px for melodic pitch motion, floored so a tiny band still
+ *  shows a mark. This is what makes resizing the timeline row-height setting grow
+ *  the Song bars, just like it grows the live monitor's bars (#459). At the
+ *  default row height the result is ~3px (unchanged); larger rows → taller bars. */
+const BAR_PITCH_RESERVE = 12
+const BAR_HEIGHT_MIN = 3
+function barHeightForBand(bandHeight: number): number {
+  return Math.max(BAR_HEIGHT_MIN, bandHeight - BAR_PITCH_RESERVE)
+}
+
 /** Minimum px between per-beat gridlines in an expanded lane — below this they
  *  crowd into a smear, so they're suppressed (rhythm grid only when legible). */
 const BEAT_GRID_MIN_PX = 10
@@ -254,9 +266,11 @@ function drawMarks(
   toScreenX: (c: number) => number,
 ): void {
   const padY = 3
-  // Expanded lanes draw a slightly taller mark over the much taller band, so
-  // the pitch spread reads as a clear note layout rather than a thin smear.
-  const markH = expanded ? 4 : 3
+  // Collapsed lane: the bar scales with the row height, so the timeline
+  // row-height setting grows it like the live monitor (#459). An expanded
+  // single-band lane keeps a thin mark so its pitch spread reads as a contour
+  // over the much taller note-detail band, not one fat bar.
+  const markH = expanded ? 4 : barHeightForBand(rowHeight - 2 * padY)
   placeMarks(
     ctx,
     lane.notes,
@@ -293,11 +307,13 @@ function drawVoiceMarks(
   toScreenX: (c: number) => number,
 ): void {
   const padY = 2
-  const markH = 3
   const voiceByKey = new Map(lane.voices.map((v) => [v.key, v]))
   for (const sr of subRows) {
     const voice = voiceByKey.get(sr.voiceKey)
     const notes = lane.notes.filter((n) => (n.voice ?? NO_VOICE) === sr.voiceKey)
+    // Per-voice bar scales with the sub-row height, so resizing the row-height
+    // setting grows the sub-row bars just like the live monitor's (#459).
+    const markH = barHeightForBand(sr.height - 2 * padY)
     placeMarks(
       ctx,
       notes,

--- a/packages/app/tests/full-song-row-height-setting.spec.ts
+++ b/packages/app/tests/full-song-row-height-setting.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * Full-song view honors the shared "timeline row height" editor setting (#459) —
+ * Playwright observation (AnviDev observe gate).
+ *
+ * The Live view already reads getMusicalTimelineSubRowHeight(); the Song view used
+ * to hardcode a 22px lane height. The fix wires the same setting into
+ * FullSongTimeline → computeLaneLayout (collapsed lane + per-voice sub-row). This
+ * seeds the setting (localStorage) to a distinctive value and asserts the Song
+ * lane box measures that height — discriminates the fix (without it, height is a
+ * fixed 22 regardless of the setting).
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+const ROW_KEY = 'stave:musicalTimeline.subRowHeight'
+const ROW_VALUE = 40 // within the clamp (12–48), clearly != the old 22 default
+
+async function bootShell(page: Page): Promise<void> {
+  await page.addInitScript(
+    ([rowKey, rowVal]: [string, number]) => {
+      try {
+        localStorage.setItem('stave:bottomPanel.height', '360')
+        localStorage.setItem('stave:bottomPanel.open', 'true')
+        localStorage.setItem('stave:bottomPanel.activeTabId', 'musical-timeline')
+        localStorage.setItem(rowKey, String(rowVal))
+      } catch { /* ignore */ }
+    },
+    [ROW_KEY, ROW_VALUE] as [string, number],
+  )
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => ((window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco?.editor?.getEditors?.()?.length ?? 0) > 0,
+    { timeout: 20_000 },
+  )
+}
+
+async function typeAndEval(page: Page, code: string): Promise<void> {
+  await page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string } | null; focus: () => void }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    t?.focus()
+  })
+  await page.locator('.monaco-editor').first().click()
+  await page.keyboard.press(`${MOD}+A`)
+  await page.keyboard.press('Backspace')
+  await page.keyboard.type(code, { delay: 8 })
+  await page.waitForTimeout(300)
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1500)
+}
+
+test('Song view lane height follows the timeline row-height setting (#459)', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(`console.error: ${m.text()}`) })
+
+  await bootShell(page)
+  await typeAndEval(page, '$: s("bd*4")\n$: s("hh*8")')
+
+  await page.locator('[data-musical-timeline="view-toggle"]').click()
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+
+  const box = await page.locator('[data-full-song-lane]').first().boundingBox()
+  if (!box) throw new Error('no lane box')
+  // The lane row's height is set directly from the layout (box.height = rowH).
+  // Allow a small slack for sub-pixel rounding / borders, but it must clearly
+  // track 40 and NOT the old fixed 22.
+  expect(box.height, `lane height should follow the setting (${ROW_VALUE})`).toBeGreaterThanOrEqual(36)
+  expect(box.height).toBeLessThanOrEqual(44)
+
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})


### PR DESCRIPTION
Closes #459.

## Problem

The Live monitor reads the **timeline row height** editor setting (`getMusicalTimelineSubRowHeight`, 12–48), but the Song view hardcoded a 22px lane height and a fixed 3px note bar. So the setting had no effect on Song mode, and — unlike the Live view — resizing it did **not** grow the note bars.

## Fix (app-only)

- **`FullSongTimeline`** reads the setting (state + `onMusicalTimelineSubRowHeightChange`, mirroring `MusicalTimeline`) and feeds it to `computeLaneLayout` as both the collapsed-lane height and the per-voice sub-row height. The layout is the single vertical source of truth (PV120), so it flows to the canvas draw, host height, lane labels, and hit-test together. The expanded single-band note-detail height stays a fixed zoom.
- **`drawTimeline`** scales the note bar with its band, mirroring the live monitor's `leafBarHeight`: `barHeightForBand(band) = max(3, band − 12)`. Applied to the collapsed marks and the per-voice sub-row marks; the density heatmap already scaled; the expanded single-band keeps a thin mark so its pitch spread reads as a contour. At the default row height bars are unchanged (~3px); larger rows draw taller bars — matching Live.

**Note on scope:** the Live view applies the setting only to *expanded* leaf sub-rows (collapsed tracks stay a fixed height). This PR applies it to **collapsed Song lanes too**, so the setting visibly affects Song mode everywhere (the "adhere to the setting" ask), while the bar-scaling behavior matches Live. Easy to restrict to sub-rows-only if exact Live parity is preferred.

## Test plan

- [x] New unit `drawTimeline.barscale.test.ts`: a taller row draws a taller note bar (mock 2D context capturing `fillRect` heights) — 20px row → ~3px bar, 40px → ~22px.
- [x] New e2e `full-song-row-height-setting.spec.ts`: seed the setting to 40 → the Song lane measures ~40px. **Discriminates** (22 without the fix).
- [x] Updated `drawTimeline.test.ts` mark-height assertions to the scaled values (rowHeight 22 → 4; sub-row 22 → 6) and the two `FullSongTimeline` test mocks to export the setting.
- [x] App unit suite **570 passed**; `tsc --noEmit` clean (only the pre-existing `glsl-per-track` errors, addressed in #455); `full-song-voice-subrows` + `full-song-expand-bind` e2e green.