### PR TITLE
🐛 fix(timeline): #456 — Song clip-ops write back inside a multi-track $: file

### DIFF
--- a/packages/app/src/components/musicalTimeline/timelineMarks.ts
+++ b/packages/app/src/components/musicalTimeline/timelineMarks.ts
@@ -51,6 +51,17 @@ export function collectNoteMarks(
   // then resolves the OUTER combinator (that offset lies only inside it, not the
   // inner one) so a nested combinator arm edits as one outer clip. `sourceByLane`
   // keeps the innermost (content) anchor for expand→bind. First-event-wins.
+  //
+  // #456 — in a MULTI-track (`$:`) file, `collect` appends a Track-WRAPPER loc
+  // spanning the whole `$:` line (`withWrapperLoc` in collect.ts), whose start is
+  // the line start = `ev.dollarPos` — STRICTLY before the combinator (which sits
+  // after the `$: ` prefix). The raw minimum then picks that wrapper offset, which
+  // lies OUTSIDE every combinator, so `detectArrangeAt` resolves null and the clip
+  // op silently no-ops (selection still works — it's display-side). A single-track
+  // file has no wrapper loc, which is why standalone arranges wrote back fine. So
+  // we EXCLUDE the wrapper loc (`start === ev.dollarPos`) from the minimum; the
+  // combinator start always exceeds `dollarPos`, so this never drops a real
+  // combinator and is a no-op when `dollarPos` is absent (hand-built IR).
   const arrangeByLane = new Map<string, number>()
   // Clip derivation (#386): per lane, the active arrange-arm index for each
   // integer cycle (events of one arm share a cycle; arms span whole cycles —
@@ -76,7 +87,11 @@ export function collectNoteMarks(
       let outer: number | undefined
       for (const l of ev.loc) {
         const s = l?.start
-        if (typeof s === 'number' && Number.isFinite(s) && (outer === undefined || s < outer)) outer = s
+        if (typeof s !== 'number' || !Number.isFinite(s)) continue
+        // Skip the `$:` Track-wrapper loc (#456) — it starts before every
+        // combinator and would make `detectArrangeAt` miss.
+        if (ev.dollarPos !== undefined && s === ev.dollarPos) continue
+        if (outer === undefined || s < outer) outer = s
       }
       if (outer !== undefined) arrangeByLane.set(key, outer)
     }

--- a/packages/app/tests/full-song-arrange-multitrack.spec.ts
+++ b/packages/app/tests/full-song-arrange-multitrack.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * Full-song view: a clip op on an `arrange(...)` lane must write back when the
+ * arrange lives inside a MULTI-track (`$:`) program, not only standalone (#456).
+ *
+ * The sibling arrange specs all use a single standalone `arrange(...)`. The bug:
+ * with sibling `$:` tracks present, `collect` appends a Track-WRAPPER loc (the
+ * whole `$:` line) whose start precedes the combinator, so the per-lane clip
+ * anchor (`arrangeByLane`, timelineMarks.ts) used to pick that wrapper offset →
+ * `detectArrangeAt` resolved null → the edit silently no-op'd while the clip
+ * still highlighted (selection is display-side, write-back is source-side).
+ *
+ * This drives the issue's exact reproduction: a 3-track file, select the d1
+ * arrange clip, press S, and assert the d1 line's arrange is rewritten while the
+ * two sibling track lines stay byte-identical.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+async function bootShell(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('stave:bottomPanel.height', '340')
+      localStorage.setItem('stave:bottomPanel.open', 'true')
+      localStorage.setItem('stave:bottomPanel.activeTabId', 'musical-timeline')
+    } catch {
+      /* ignore */
+    }
+  })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => ((window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco?.editor?.getEditors?.()?.length ?? 0) > 0,
+    { timeout: 20_000 },
+  )
+}
+
+async function typeSongAndEval(page: Page, code: string): Promise<void> {
+  await page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string } | null; focus: () => void }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    t?.focus()
+  })
+  await page.locator('.monaco-editor').first().click()
+  await page.keyboard.press(`${MOD}+A`)
+  await page.keyboard.press('Backspace')
+  await page.keyboard.type(code, { delay: 8 })
+  await page.waitForTimeout(400)
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1800)
+}
+
+function strudelSource(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string; getValue: () => string } | null }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    return t?.getModel()?.getValue() ?? ''
+  })
+}
+
+const SONG = [
+  '$: arrange([2, s("bd")], [2, s("hh")], [4, s("cp")])',
+  '$: s("bd*2, ~ sd, hh*8").bank("RolandTR909")',
+  '$: note("c2 eb2 g2 c3").s("sawtooth").slow(2)',
+].join('\n')
+
+test('split a clip on the arrange lane of a multi-track song rewrites that $: line only', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await bootShell(page)
+  await typeSongAndEval(page, SONG)
+
+  await page.locator('[data-musical-timeline="view-toggle"]').click()
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+  await page.locator('[data-full-song-canvas]').waitFor({ timeout: 10_000 })
+  await page.waitForTimeout(400)
+
+  // The arrange (d1) is the first lane. Arm 0 = bd, weight 2 of the 8-cycle
+  // song → the first ~25% of the width. Click near the start (cycle <2) to land
+  // in arm 0, on the top lane.
+  const grid = page.locator('[data-full-song="grid"]')
+  const box = await grid.boundingBox()
+  if (!box) throw new Error('no grid box')
+  await page.mouse.click(box.x + box.width * 0.08, box.y + 8)
+  await expect(page.locator('[data-full-song="clip-selection"]')).toBeVisible({ timeout: 5_000 })
+  await grid.press('s')
+
+  // The d1 arrange's arm 0 `[2, s("bd")]` is sliced into two `[1, s("bd")]`.
+  await expect.poll(() => strudelSource(page), { timeout: 8_000 }).toContain(
+    'arrange([1, s("bd")], [1, s("bd")], [2, s("hh")], [4, s("cp")])',
+  )
+
+  // The two sibling track lines must be byte-untouched.
+  const src = await strudelSource(page)
+  expect(src).toContain('$: s("bd*2, ~ sd, hh*8").bank("RolandTR909")')
+  expect(src).toContain('$: note("c2 eb2 g2 c3").s("sawtooth").slow(2)')
+
+  await page.screenshot({ path: 'test-results/arrange-multitrack-split.png' })
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})

--- a/packages/app/tests/full-song-clip-ops-e2e.spec.ts
+++ b/packages/app/tests/full-song-clip-ops-e2e.spec.ts
@@ -1,0 +1,232 @@
+/**
+ * Full-song clip ops — comprehensive end-to-end coverage of ALL FIVE operations
+ * (delete / move / duplicate / split / trim) on a MULTI-track `$:` song, the
+ * real-world case (#456 / #386 / #416 phase 4). Each op is its own test so a
+ * failure localizes to one gesture. The arrange lives on the FIRST lane, with
+ * two sibling tracks present — so these also prove the multi-track write-back
+ * (#461) end-to-end, not just the standalone path the per-op specs cover.
+ *
+ * Every test asserts the d1 `arrange(...)` line is rewritten AND the two sibling
+ * `$:` lines stay byte-identical (other tracks must never be touched).
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+// 8-cycle arrange (2+2+4) on the top lane + two sibling tracks below it.
+const SIB1 = '$: s("bd*2, ~ sd, hh*8").bank("RolandTR909")'
+const SIB2 = '$: note("c2 eb2 g2 c3").s("sawtooth").slow(2)'
+const ARRANGE = '$: arrange([2, s("bd")], [2, s("hh")], [4, s("cp")])'
+const SONG = [ARRANGE, SIB1, SIB2].join('\n')
+
+async function bootShell(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('stave:bottomPanel.height', '340')
+      localStorage.setItem('stave:bottomPanel.open', 'true')
+      localStorage.setItem('stave:bottomPanel.activeTabId', 'musical-timeline')
+    } catch {
+      /* ignore */
+    }
+  })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => ((window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco?.editor?.getEditors?.()?.length ?? 0) > 0,
+    { timeout: 20_000 },
+  )
+}
+
+async function typeSongAndEval(page: Page, code: string): Promise<void> {
+  await page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string } | null; focus: () => void }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    t?.focus()
+  })
+  await page.locator('.monaco-editor').first().click()
+  await page.keyboard.press(`${MOD}+A`)
+  await page.keyboard.press('Backspace')
+  await page.keyboard.type(code, { delay: 8 })
+  await page.waitForTimeout(400)
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1800)
+}
+
+function strudelSource(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string; getValue: () => string } | null }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    return t?.getModel()?.getValue() ?? ''
+  })
+}
+
+async function openSongView(page: Page): Promise<void> {
+  await page.locator('[data-musical-timeline="view-toggle"]').click()
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+  await page.locator('[data-full-song-canvas]').waitFor({ timeout: 10_000 })
+  await page.waitForTimeout(400)
+}
+
+async function gridBox(page: Page) {
+  const grid = page.locator('[data-full-song="grid"]')
+  const box = await grid.boundingBox()
+  if (!box) throw new Error('no grid box')
+  return { grid, box }
+}
+
+// Siblings must be byte-identical after every op.
+async function expectSiblingsUntouched(page: Page): Promise<void> {
+  const src = await strudelSource(page)
+  expect(src, 'sibling track 1 must be untouched').toContain(SIB1)
+  expect(src, 'sibling track 2 must be untouched').toContain(SIB2)
+}
+
+function setup(page: Page): string[] {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+  return errors
+}
+
+test.describe('full-song clip ops on a multi-track $: song', () => {
+  test('SPLIT — select arm 0 (bd) + S slices it into two halves', async ({ page }) => {
+    const errors = setup(page)
+    await bootShell(page)
+    await typeSongAndEval(page, SONG)
+    await openSongView(page)
+
+    const { grid, box } = await gridBox(page)
+    await page.mouse.click(box.x + box.width * 0.08, box.y + 8) // arm 0, top lane
+    await expect(page.locator('[data-full-song="clip-selection"]')).toBeVisible({ timeout: 5_000 })
+    await grid.press('s')
+
+    await expect.poll(() => strudelSource(page), { timeout: 8_000 }).toContain(
+      'arrange([1, s("bd")], [1, s("bd")], [2, s("hh")], [4, s("cp")])',
+    )
+    await expectSiblingsUntouched(page)
+    await page.screenshot({ path: 'test-results/clipop-split.png' })
+    expect(errors, errors.join('\n')).toEqual([])
+  })
+
+  test('DELETE — select arm 0 (bd) + Delete removes the arm', async ({ page }) => {
+    const errors = setup(page)
+    await bootShell(page)
+    await typeSongAndEval(page, SONG)
+    await openSongView(page)
+
+    const { grid, box } = await gridBox(page)
+    await page.mouse.click(box.x + box.width * 0.08, box.y + 8)
+    await expect(page.locator('[data-full-song="clip-selection"]')).toBeVisible({ timeout: 5_000 })
+    await grid.press('Delete')
+
+    await expect.poll(() => strudelSource(page), { timeout: 8_000 }).toContain(
+      'arrange([2, s("hh")], [4, s("cp")])',
+    )
+    await expectSiblingsUntouched(page)
+    await page.screenshot({ path: 'test-results/clipop-delete.png' })
+    expect(errors, errors.join('\n')).toEqual([])
+  })
+
+  test('DUPLICATE — select arm 0 (bd) + ⌘D clones it after itself', async ({ page }) => {
+    const errors = setup(page)
+    await bootShell(page)
+    await typeSongAndEval(page, SONG)
+    await openSongView(page)
+
+    const { grid, box } = await gridBox(page)
+    await page.mouse.click(box.x + box.width * 0.08, box.y + 8)
+    await expect(page.locator('[data-full-song="clip-selection"]')).toBeVisible({ timeout: 5_000 })
+    await grid.press(`${MOD}+d`)
+
+    await expect.poll(() => strudelSource(page), { timeout: 8_000 }).toContain(
+      'arrange([2, s("bd")], [2, s("bd")], [2, s("hh")], [4, s("cp")])',
+    )
+    await expectSiblingsUntouched(page)
+    await page.screenshot({ path: 'test-results/clipop-duplicate.png' })
+    expect(errors, errors.join('\n')).toEqual([])
+  })
+
+  test('MOVE (reorder) — drag arm 0 (bd) into arm 1 (hh) span swaps order', async ({ page }) => {
+    const errors = setup(page)
+    await bootShell(page)
+    await typeSongAndEval(page, SONG)
+    await openSongView(page)
+
+    const { box } = await gridBox(page)
+    const y = box.y + 8 // top (arrange) lane
+    // arm 0 (bd) spans cycles [0,2) of 8 → first 25% of width. Drag it right into
+    // arm 1 (hh) span (cycles [2,4) → ~0.375·W) to reorder bd after hh.
+    await page.mouse.move(box.x + box.width * 0.1, y)
+    await page.mouse.down()
+    await page.mouse.move(box.x + box.width * 0.28, y, { steps: 4 })
+    await page.mouse.move(box.x + box.width * 0.36, y, { steps: 4 })
+    await page.mouse.up()
+
+    await expect.poll(() => strudelSource(page), { timeout: 8_000 }).toContain(
+      'arrange([2, s("hh")], [2, s("bd")], [4, s("cp")])',
+    )
+    await expectSiblingsUntouched(page)
+    await page.screenshot({ path: 'test-results/clipop-move-reorder.png' })
+    expect(errors, errors.join('\n')).toEqual([])
+  })
+
+  test('MOVE (wrap) — drag a BARE sibling track introduces a combinator (§2.1)', async ({ page }) => {
+    const errors = setup(page)
+    await bootShell(page)
+    // sibling 2 (note(...).slow(2)) is a 2-cycle BARE track — room to drag its
+    // implicit clip right so wrapBare introduces arrange([lead, silence], [1, …]).
+    await typeSongAndEval(page, SONG)
+    await openSongView(page)
+
+    const { box } = await gridBox(page)
+    // The bare sibling sits on the 3rd lane. Use that lane element's absolute
+    // vertical centre (lanes stack; the grid overlay aligns to them).
+    const lane3 = page.locator('[data-full-song-lane]').nth(2)
+    const lb = await lane3.boundingBox()
+    if (!lb) throw new Error('no lane-3 box')
+    const y = lb.y + lb.height / 2
+    await page.mouse.move(box.x + box.width * 0.1, y)
+    await page.mouse.down()
+    await page.mouse.move(box.x + box.width * 0.4, y, { steps: 4 })
+    await page.mouse.move(box.x + box.width * 0.6, y, { steps: 4 })
+    await page.mouse.up()
+
+    // The bare sibling line is rewritten into an arrange(...) with a leading
+    // silence; the arrange track + the OTHER sibling stay byte-identical.
+    await expect
+      .poll(() => strudelSource(page), { timeout: 8_000 })
+      .toMatch(/arrange\(\[\d+, silence\], \[1, note\("c2 eb2 g2 c3"\)\.s\("sawtooth"\)\.slow\(2\)\]\)/)
+    const src = await strudelSource(page)
+    expect(src, 'the arrange track must be untouched').toContain(ARRANGE)
+    expect(src, 'sibling 1 must be untouched').toContain(SIB1)
+    await page.screenshot({ path: 'test-results/clipop-move-wrap.png' })
+    expect(errors, errors.join('\n')).toEqual([])
+  })
+
+  test('TRIM — drag arm 0 (bd) right edge from 2 → 3 cycles', async ({ page }) => {
+    const errors = setup(page)
+    await bootShell(page)
+    await typeSongAndEval(page, SONG)
+    await openSongView(page)
+
+    const { box } = await gridBox(page)
+    const y = box.y + 8 // top (arrange) lane
+    // arm 0 (bd) right edge sits at cycle 2 of 8 → 0.25·W. Grab 4px inside it and
+    // drag to cycle 3 → 0.375·W. weight 2 → 3.
+    const grabX = box.x + box.width * 0.25 - 4
+    await page.mouse.move(grabX, y)
+    await page.mouse.down()
+    await page.mouse.move(box.x + box.width * 0.31, y, { steps: 4 })
+    await page.mouse.move(box.x + box.width * 0.375, y, { steps: 4 })
+    await page.mouse.up()
+
+    await expect.poll(() => strudelSource(page), { timeout: 8_000 }).toContain(
+      'arrange([3, s("bd")], [2, s("hh")], [4, s("cp")])',
+    )
+    await expectSiblingsUntouched(page)
+    await page.screenshot({ path: 'test-results/clipop-trim.png' })
+    expect(errors, errors.join('\n')).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem

A Song-view clip op (split / delete / move / duplicate / trim) on an `arrange(…)` lane **selected the clip but the source edit silently no-op'd** when the `arrange` lived inside a multi-track `$:` program. It worked on a standalone `arrange(…)`.

The asymmetry — **selection works (display side), write-back fails (source side)** — traced to the per-lane clip anchor `arrangeByLane` in `timelineMarks.ts`. In a multi-track file, `collect` appends a **Track-wrapper loc** spanning the whole `$:` line (`withWrapperLoc`), whose start equals `ev.dollarPos` — *strictly before* the combinator (which sits after the `$: ` prefix). The raw minimum-start then picked that wrapper offset, which lies **outside every combinator**, so `detectArrangeAt` resolved `null` and every clip-op serializer returned no edits. A single-track file has no wrapper loc, which is why standalone arranges resolved fine.

Observed via the real pass pipeline (`runPasses(IR.code, STRUDEL_PASSES)` → `collectCycles`):
- standalone arm loc `[leaf, arrange{3,52}]` → min = 3 → `detectArrangeAt` **FOUND**
- multi-track arm loc `[leaf, arrange{3,52}, trackWrapper{0,53}]` → min = 0 → **NULL**

## Fix

Exclude the `$:` Track-wrapper loc (`start === ev.dollarPos`) from the minimum-start scan. The combinator start always exceeds `dollarPos`, so this never drops a real combinator and is a no-op when `dollarPos` is absent (hand-built IR / single track). **App-only** — the wrapper loc stays (it's load-bearing for `trackId` / `dollarPos` / click-to-source row identity); only its consumer is corrected. The nested-combinator outer-arm resolution (#451) is preserved (verified: outer `arrange` still wins, the inner `cat` and `.p()` suffix are untouched).

## Test plan

- New `full-song-arrange-multitrack.spec.ts` — the issue's exact 3-track reproduction: select the d1 `arrange` clip → **S** → the d1 line rewrites to `arrange([1, s("bd")], [1, s("bd")], [2, s("hh")], [4, s("cp")])` while both sibling `$:` lines stay byte-identical. **Discriminates** (git-stash the fix → the spec fails on the no-op, restore → passes).
- Regression: standalone `full-song-arrange-{split,nested,move,delete}` specs all green; app unit suite 569 green; `tsc` clean.

Closes #456