### PR TITLE
🐛 fix(inspector): handle NamedPick tag so pickRestart songs don't white-screen

### DIFF
--- a/packages/app/src/components/IRInspectorChrome.ts
+++ b/packages/app/src/components/IRInspectorChrome.ts
@@ -39,6 +39,9 @@ export function summarize(node: PatternIR): string {
     case 'Struct':   return `mask="${node.mask}"`
     case 'Swing':    return `n=${node.n}`
     case 'Pick':     return `${node.lookup.length} entries`
+    // #463 / #475 — named/object pick family. Developer chrome shows the
+    // combinator + the named keys so the structure is visible at a glance.
+    case 'NamedPick': return `${node.method} {${node.entries.map((e) => e.key).join(', ')}}`
     case 'Shuffle':  return `n=${node.n}`
     case 'Scramble': return `n=${node.n}`
     case 'Chop':     return `n=${node.n}`
@@ -145,6 +148,11 @@ export function children(node: PatternIR): readonly PatternIR[] {
     // distinguished selector child — render selector first, then the
     // lookup entries as siblings.
     case 'Pick':  return [node.selector, ...node.lookup]
+    // #463 / #475 — named/object pick family; same selector-first shape as
+    // Pick, entries' patterns as siblings. (children() already degraded
+    // safely via `default: return []`, but the explicit case lets irMode
+    // drill into the entries too — parity with projectedChildren.)
+    case 'NamedPick': return [node.selector, ...node.entries.map((e) => e.pattern)]
     // Phase 20-04 T-12 / D-05 (developer tree expansion).
     // Wrapper case: expose via.inner as a child so the inspector tree can
     // drill into the wrapped receiver. Parse-failure case (no via): leaf.

--- a/packages/app/src/components/IRInspectorPanel.tsx
+++ b/packages/app/src/components/IRInspectorPanel.tsx
@@ -147,6 +147,11 @@ const TAG_COLOR: Record<PatternIR["tag"], string> = {
   // timeline-clip combinator). Teal-300 placeholder, distinct from Cycle's
   // cyan (#06b6d4) and Builder's green; final token lands in the design pass.
   Arrange:  "var(--ir-arrange, #2dd4bf)",
+  // #463 / #475 — NamedPick tag (object/named-key pick family:
+  // pickRestart/pickReset/pick). Same pick family as Pick (#34d399) so it
+  // shares the emerald hue, but a darker emerald-600 keeps the two chips
+  // distinguishable; final token lands in the design pass.
+  NamedPick: "var(--ir-named-pick, #059669)",
 };
 
 // summarize / children moved to IRInspectorChrome.ts (Phase 20-04 wave δ)

--- a/packages/app/src/components/__tests__/IRInspectorPanel.chrome.test.ts
+++ b/packages/app/src/components/__tests__/IRInspectorPanel.chrome.test.ts
@@ -134,4 +134,34 @@ describe('20-11 — Track developer chrome (musician-track-identity / PV35)', ()
     expect(kids.length).toBe(1)
     expect(kids[0]).toBe(body)
   })
+
+  // #463 / #475 — NamedPick developer chrome.
+  it('summarize(NamedPick) shows the method + named keys', () => {
+    const node = IR.namedPick(
+      IR.code('"<a b>"'),
+      [
+        { key: 'verse', pattern: IR.play('bd', 1) },
+        { key: 'chorus', pattern: IR.play('hh', 1) },
+      ],
+      'pickRestart',
+      '{verse: s("bd"), chorus: s("hh")}',
+    ) as PatternIR
+    expect(summarize(node)).toBe('pickRestart {verse, chorus}')
+  })
+
+  it('children(NamedPick) returns [selector, ...entries.patterns]', () => {
+    const selector = IR.code('"<a b>"')
+    const verse = IR.play('bd', 1)
+    const chorus = IR.play('hh', 1)
+    const node = IR.namedPick(
+      selector,
+      [
+        { key: 'verse', pattern: verse },
+        { key: 'chorus', pattern: chorus },
+      ],
+      'pickRestart',
+      '{verse: s("bd"), chorus: s("hh")}',
+    ) as PatternIR
+    expect(children(node)).toEqual([selector, verse, chorus])
+  })
 })

--- a/packages/app/src/components/__tests__/irProjection.test.ts
+++ b/packages/app/src/components/__tests__/irProjection.test.ts
@@ -851,3 +851,64 @@ describe('20-12 α-5 — flattenLeafVoices', () => {
     expect(leaves).toHaveLength(1)
   })
 })
+
+// -----------------------------------------------------------------------------
+// #463 / #475 — NamedPick projection (regression: the `kids is not iterable`
+// white-screen). NamedPick was added producer-side but never projected; the
+// `default` arm returned the node object → spliceHiddenChildren threw on the
+// non-iterable, unmounting the editor shell.
+// -----------------------------------------------------------------------------
+
+describe('#475 — NamedPick projection (object/named-key pick family)', () => {
+  it('projectedChildren returns [selector, ...entries.patterns] (NOT the node — the crash)', () => {
+    const root = parseStrudel(
+      '"<a b>".pickRestart({ verse: s("bd"), chorus: s("hh") })',
+    )
+    const np = find(root, (n) => n.tag === 'NamedPick')
+    expect(np?.tag).toBe('NamedPick')
+
+    // The exact call that threw: projectedChildren must be iterable.
+    const kids = projectedChildren(np as PatternIR)
+    expect(Array.isArray(kids)).toBe(true)
+    expect(() => {
+      for (const _k of kids) void _k
+    }).not.toThrow()
+    // selector first, then one child per named entry (verse, chorus).
+    expect(kids).toHaveLength(3)
+    if (np?.tag === 'NamedPick') {
+      expect(kids[0]).toBe(np.selector)
+      expect(kids.slice(1)).toEqual(np.entries.map((e) => e.pattern))
+    }
+  })
+
+  it('projectedLabel returns the user method ("pickRestart"), never the IR tag (PV32)', () => {
+    const root = parseStrudel(
+      '"<a b>".pickRestart({ verse: s("bd"), chorus: s("hh") })',
+    )
+    const np = find(root, (n) => n.tag === 'NamedPick') as PatternIR
+    expect(projectedLabel(np)).toBe('pickRestart')
+    expect(projectedLabel(np)).not.toBe('NamedPick')
+  })
+
+  it('projectedLabel falls back to node.method for a hand-built node with no userMethod', () => {
+    const np = IR.namedPick(
+      IR.code('"<a b>"'),
+      [{ key: 'verse', pattern: IR.play('bd', 1) }],
+      'pickReset',
+      '{verse: s("bd")}',
+    )
+    // Hand-built (no tagMeta) → userMethod undefined → method token shown.
+    expect(np.tag === 'NamedPick' && np.userMethod).toBeUndefined()
+    expect(projectedLabel(np)).toBe('pickReset')
+  })
+
+  it('the hardened default arm degrades a future unhandled tag to an opaque leaf (no crash)', () => {
+    // Simulate a producer-added tag that slipped past tsc. The old arm
+    // returned the node object (non-iterable, the crash); the hardened arm
+    // returns [] for children and the raw tag for the label.
+    const ghost = { tag: 'FutureTag', loc: [] } as unknown as PatternIR
+    expect(projectedChildren(ghost)).toEqual([])
+    expect(() => projectedLabel(ghost)).not.toThrow()
+    expect(projectedLabel(ghost)).toBe('FutureTag')
+  })
+})

--- a/packages/app/src/components/irProjection.ts
+++ b/packages/app/src/components/irProjection.ts
@@ -184,12 +184,40 @@ export function projectedLabel(node: PatternIR): string | undefined {
     // combinator name (the source token), never the IR tag (PV32).
     case 'Arrange':
       return node.mode
+    // #463 / #475 — object/named-key pick family. The userMethod short-circuit
+    // above returns the method ('pickRestart'/'pickReset'/'pick') for parser-
+    // produced nodes; this arm covers hand-built nodes with no userMethod,
+    // falling back to `method` (the source token, never the IR tag — PV32).
+    case 'NamedPick':
+      return node.method
     default: {
-      // Exhaustiveness check — TS error if a tag is missing.
-      const _exhaustive: never = node
-      return _exhaustive
+      // Exhaustiveness guard (compile-time) + runtime fail-safe (#475). A tag
+      // added to PatternIR but not handled above is a `tsc` error here. If it
+      // slips past an un-typechecked build, degrade to the raw tag name rather
+      // than returning the node object — see reportUnhandledTag.
+      reportUnhandledTag(node)
+      return (node as { tag: string }).tag
     }
   }
+}
+
+/**
+ * Compile-time exhaustiveness guard with a runtime fail-safe (#475).
+ *
+ * The `node: never` parameter makes an unhandled PatternIR tag a `tsc` error
+ * at the call site — preserving the original `const _exhaustive: never`
+ * guarantee that forces every new tag to be projected. But unlike the old
+ * arm (which `return`ed the node object, making projectedChildren yield a
+ * non-iterable and white-screen the inspector — the #475 crash), this only
+ * warns. The caller supplies a safe structural fallback (empty children /
+ * raw tag label), matching children()'s existing `default: return []`.
+ */
+function reportUnhandledTag(node: never): void {
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[IR Inspector] unhandled PatternIR tag "${(node as { tag?: string }).tag}" ` +
+      `in projection — rendering as an opaque leaf. Add a projection case (#475).`,
+  )
 }
 
 export function projectedChildren(node: PatternIR): readonly PatternIR[] {
@@ -309,9 +337,20 @@ export function projectedChildren(node: PatternIR): readonly PatternIR[] {
     // patterns ARE the structural children (ordered, one per timeline clip).
     case 'Arrange':
       return node.arms.map((a) => a.pattern)
+    // #463 / #475 — object/named-key pick family. Mirrors Pick: the selector
+    // is the distinguished child, the entries' patterns are the structural
+    // siblings the user typed (one per named key). Without this case the tag
+    // fell through to `default` and returned the node object → the
+    // `kids is not iterable` white-screen.
+    case 'NamedPick':
+      return [node.selector, ...node.entries.map((e) => e.pattern)]
     default: {
-      const _exhaustive: never = node
-      return _exhaustive
+      // Exhaustiveness guard (compile-time) + runtime fail-safe (#475).
+      // The old arm `return _exhaustive` returned the node object here — a
+      // non-iterable that crashed spliceHiddenChildren. Degrade to an opaque
+      // leaf instead (matches children()'s `default: return []`).
+      reportUnhandledTag(node)
+      return []
     }
   }
 }

--- a/packages/app/tests/ir339-inspector-crash.spec.ts
+++ b/packages/app/tests/ir339-inspector-crash.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * ir339-inspector-crash.spec.ts — #475 regression driver. Reproduces the IR
+ * Inspector white-screen on a pickRestart song in the LIVE app: opens the
+ * bottom timeline + IR inspector, evaluates, expands the whole tree, clicks
+ * rows, flips IR-mode + pass tabs, steps the playhead — and captures any
+ * pageerror / console error. Before the #475 fix this threw
+ * `kids is not iterable` (NamedPick unhandled in projectedChildren); after,
+ * it runs clean (0 errors). Gated IR339=1 — inert in CI.
+ *   IR339=1 pnpm --filter @stave/app exec playwright test ir339-inspector-crash.spec.ts --workers=1 --timeout=120000
+ */
+import { test, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+const CODE = `// drums — backbeat verses, four-on-the-floor choruses
+drums: "<~@4 verse@8 chorus@8 verse@8 chorus@8 ~@4>".pickRestart({
+  verse: s("[bd,sd] ~ sd ~ [bd,sd] ~ [bd,sd] ~").bank("RolandTR909").lpf(800),
+  chorus: s("bd ~ [bd,sd] ~ bd ~ [bd,sd] ~").bank("RolandTR909"),
+})
+
+hats: "<~@4 verse@8 chorus@8 verse@8 chorus@8 ~@4>".pickRestart({
+  verse: s("[bd,lt,hh] [bd,hh] [bd,hh] [bd,hh]").bank("RolandTR909").gain(1.36).dist(1.5).lpf(800).room(0.5),
+  chorus: s("~ oh [lt,sh] oh ~ oh ~ oh").bank("RolandTR909").gain(0.5),
+})._pianoroll().lpf(800).room(0.59).delay(0.4).speed(1.5).gain(0.8).distort(0.3)
+
+bass: "<~@4 verse@8 chorus@8 verse@8 chorus@8 ~@4>".pickRestart({
+  verse: note("<[a1 ~ ~ [a1,g2] ~ ~ a1 ~] [f1 ~ d2 f1 ~ ~ f1 ~] [c2 a2 ~ c2 ~ ~ c2 ~] [g1 ~ ~ g1 ~ ~ g1 ~]>").s("sawtooth").lpf(500),
+  chorus: note("<[a1 a1 a1 a1] [f1 f1 f1 f1] [c2 c2 c2 c2] [g1 g1 g1 g1]>").s("sawtooth").lpf(700),
+})
+
+keys: "<pads@12 chorus@8 pads@8 chorus@8 pads@4>".pickRestart({
+  pads: note("<[a3,c4,e4] [a3,c4,f4] [g3,c4,e4] [g3,b3,d4]>").s("recorder_alto_stacc").room(0.6).lpf(600),
+  verse: note("<[a1 ~ ~ [a1,g2] ~ ~ a1 ~] [f1 ~ d2 f1 ~ ~ f1 ~] [c2 a2 ~ c2 ~ ~ c2 ~] [g1 ~ ~ g1 ~ ~ g1 ~]>").s("sawtooth").lpf(500),
+  chorus: note("<[a3,c4,e4,a4] [a3,c4,f4,a4] [g3,c4,e4,g4] [g3,b3,d4,g4]>").piano().room(0.4),
+})
+
+lead: "<~@4 ~@8 chorus@8 ~@8 chorus@8 ~@4>".pickRestart({
+  chorus: note("<[e5 ~ ~ d5 c5 ~ d5 ~] [c5 ~ a4 ~ ~ ~ ~ ~] [e5 ~ ~ d5 c5 ~ d5 ~] [d5 ~ b4 ~ g4 ~ ~ ~]>").piano().room(0.5),
+})`
+
+// Synth-only structural twin (no samples → eval succeeds headless, P146):
+// same pickRestart + named blocks + _pianoroll + FX chain + <> alternation.
+const CODE_SYNTH = CODE
+  .replace(/s\("\[bd,sd\][^"]*"\)\.bank\("RolandTR909"\)/g, 'note("c2 ~ e2 ~ c2 ~ c2 ~").s("sawtooth")')
+  .replace(/s\("bd[^"]*"\)\.bank\("RolandTR909"\)/g, 'note("c2 ~ e2 ~ c2 ~ e2 ~").s("sawtooth")')
+  .replace(/s\("\[bd,lt,hh\][^"]*"\)\.bank\("RolandTR909"\)/g, 'note("c4 c4 c4 c4").s("triangle")')
+  .replace(/s\("~ oh[^"]*"\)\.bank\("RolandTR909"\)/g, 'note("~ c4 e4 c4 ~ c4 ~ c4").s("triangle")')
+  .replace(/\.s\("recorder_alto_stacc"\)/g, '.s("sawtooth")')
+  .replace(/\.piano\(\)/g, '.s("sawtooth")')
+
+async function setCode(page: Page, code: string): Promise<void> {
+  await page.evaluate((c) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ed = (window as any).monaco?.editor?.getEditors?.()?.[0]
+    ed?.getModel()?.setValue(c)
+    ed?.focus()
+  }, code)
+  await page.waitForTimeout(200)
+}
+
+async function snapshotState(page: Page) {
+  return page.evaluate(() => {
+    const tabs = [...document.querySelectorAll('[data-testid="ir-passes-tablist"] [role="tab"]')].map((t) => t.textContent)
+    const sec = document.querySelector('[data-testid="ir-tree-section"]')
+    const tl = document.querySelector('[aria-label="Timeline"]') ? 'present' : 'absent'
+    return {
+      tabs: tabs.join('|'),
+      treeChildren: sec ? sec.querySelectorAll('*').length : -1,
+      treeText: (sec instanceof HTMLElement ? sec.innerText : '(none)').slice(0, 220).replace(/\n/g, ' / '),
+      timeline: tl,
+    }
+  })
+}
+
+async function drive(page: Page, label: string, code: string, errors: string[]): Promise<void> {
+  /* eslint-disable no-console */
+  const mon = page.locator('.monaco-editor').first()
+  if (!(await mon.count())) {
+    console.log(`[339] ${label}: SKIP — .monaco-editor absent (prior crash unmounted the shell)`)
+    return
+  }
+  await setCode(page, code)
+  await mon.click({ timeout: 5000 }).catch((e) => console.log(`[339] ${label}: click failed — ${String(e).split('\n')[0]}`))
+  await page.evaluate(() => (window as any).monaco?.editor?.getEditors?.()?.[0]?.focus()).catch(() => {}) // eslint-disable-line @typescript-eslint/no-explicit-any
+  await page.keyboard.press(`${MOD}+Enter`).catch(() => {})
+  await page.waitForTimeout(2500)
+  const st = await snapshotState(page).catch(() => null)
+  console.log(`[339] ${label}: tabs=[${st?.tabs}] treeChildren=${st?.treeChildren} timeline=${st?.timeline} errors=${errors.length}`)
+  console.log(`[339] ${label}: treeText="${st?.treeText}"`)
+  // step the playhead (J/K) — a common crash trigger for the inspector timeline
+  for (let i = 0; i < 6; i++) { await page.keyboard.press('j').catch(() => {}); await page.waitForTimeout(120) }
+  await page.waitForTimeout(800)
+  // exercise the inspector render surfaces that the bare eval+playhead path missed:
+  // expand every tree node, click rows (reveal/source-map), flip IR mode + pass tabs.
+  await expandAndPoke(page, label)
+  console.log(`[339] ${label}: after interaction errors=${errors.length}`)
+  await page.screenshot({ path: `/tmp/ir339-${label}.png` }).catch(() => {})
+  /* eslint-enable no-console */
+}
+
+async function expandAndPoke(page: Page, label: string): Promise<void> {
+  /* eslint-disable no-console */
+  try {
+    // Expand-all in the IR tree (deep nodes are where opaque pickRestart holes live).
+    for (let pass = 0; pass < 8; pass++) {
+      const toggles = page.locator('[data-testid="ir-tree-section"] [aria-expanded="false"]')
+      const n = await toggles.count().catch(() => 0)
+      if (!n) break
+      for (let i = 0; i < n; i++) {
+        await toggles.nth(i).click({ timeout: 1000 }).catch(() => {})
+      }
+      await page.waitForTimeout(120)
+    }
+    // Click the first several tree rows (triggers reveal-in-editor / source mapping).
+    const rows = page.locator('[data-testid="ir-tree-section"] [role="treeitem"], [data-testid="ir-tree-section"] button')
+    const rn = Math.min(await rows.count().catch(() => 0), 12)
+    for (let i = 0; i < rn; i++) await rows.nth(i).click({ timeout: 800 }).catch(() => {})
+    await page.waitForTimeout(200)
+    // Flip IR mode toggle (the raw-IR render path) and step through pass tabs.
+    await page.locator('[data-testid="ir-mode-toggle"]').click({ timeout: 800 }).catch(() => {})
+    await page.waitForTimeout(200)
+    const tabs = page.locator('[data-testid="ir-passes-tablist"] [role="tab"]')
+    const tn = await tabs.count().catch(() => 0)
+    for (let i = 0; i < tn; i++) { await tabs.nth(i).click({ timeout: 800 }).catch(() => {}); await page.waitForTimeout(150) }
+  } catch (e) {
+    console.log(`[339] ${label}: expandAndPoke aborted — ${String(e).split('\n')[0]}`)
+  }
+  /* eslint-enable no-console */
+}
+
+test('IR339 — exact + synth-twin pickRestart song; capture crash', async ({ page }) => {
+  test.skip(!process.env.IR339, 'manual repro — set IR339=1')
+  const errors: string[] = []
+  /* eslint-disable no-console */
+  page.on('pageerror', (e) => {
+    const entry = `PAGEERROR: ${e.message}\n${(e.stack ?? '').split('\n').slice(0, 24).join('\n')}`
+    errors.push(entry)
+    console.log(`\n[339] >>> LIVE PAGEERROR #${errors.length}\n${entry}\n[339] <<<\n`)
+  })
+  page.on('console', (m) => {
+    if (m.type() !== 'error') return
+    // m.text() collapses component stacks; pull each arg's full string too.
+    const entry = `CONSOLE.ERROR: ${m.text()}`
+    errors.push(entry)
+    console.log(`\n[339] >>> LIVE CONSOLE.ERROR #${errors.length}: ${m.text().slice(0, 2000)}\n[339] <<<\n`)
+  })
+  /* eslint-enable no-console */
+
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('stave:bottomPanel.open', 'true') // timeline visible
+    } catch { /* ignore */ }
+  })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('.monaco-editor').first().waitFor({ timeout: 20000 })
+  await page.waitForTimeout(600)
+  // Open the IR Inspector panel.
+  await page.locator('button[aria-label="IR Inspector"]').first().click().catch(() => {})
+  await page.waitForTimeout(500)
+
+  await drive(page, 'EXACT-samples', CODE, errors)
+  await drive(page, 'SYNTH-twin', CODE_SYNTH, errors)
+
+  /* eslint-disable no-console */
+  console.log(`\n[339] ===== TOTAL ${errors.length} error(s) =====`)
+  for (const e of errors.slice(0, 12)) console.log('[339] ' + e + '\n')
+  /* eslint-enable no-console */
+})


### PR DESCRIPTION
Closes #475.

## Problem

Opening the IR Inspector on a song using the named/object pick family (`"<…>".pickRestart({verse, chorus})`) and expanding the tree threw `TypeError: kids is not iterable` and unmounted the whole editor — a full white-screen.

**Root cause (observed via a live Playwright + Chromium driver, not inferred):** #463 added the `NamedPick` IR tag producer-side (`PatternIR`/`parseStrudel`/`collect`/`toStrudel`) but never propagated it to the app-side inspector projection. Expanding a `NamedPick` row made `projectedChildren` fall through to its `default` arm — a *compile-time-only* `never` exhaustiveness check that at runtime returns the **node object itself** (non-iterable), so `spliceHiddenChildren`'s `for…of` threw, and React then failed to unwind the subtree (`removeChild … not a child`). It shipped because Next dev only transpiles; `tsc --noEmit` flags every gap.

## Fix

1. **Handle `NamedPick` at all four consumer sites** — `projectedChildren` (the crash) + `projectedLabel` (`irProjection.ts`), `summarize` + `children` (`IRInspectorChrome.ts`), and a `TAG_COLOR` entry (`IRInspectorPanel.tsx`). Projection mirrors `Pick`: `[selector, ...entries.map(e => e.pattern)]`; label = the method token (`pickRestart`/`pickReset`/`pick`) — never the IR tag (PV32).
2. **Harden both `never` default arms** — keep the compile-time exhaustiveness guarantee (`reportUnhandledTag(node: never)` still errors in `tsc` for any unhandled tag) but degrade to an opaque leaf + `console.warn` at runtime instead of returning the node. The next producer-added tag can't white-screen the inspector again. Matches `children()`'s existing `default: return []`.

## Test plan

- `tsc --noEmit`: **0 errors** (was 4 — the exact consumer gaps).
- Full app vitest suite: **576/576** (incl. 6 new NamedPick tests; one proves the hardened arm degrades a future unknown tag gracefully).
- Editor `namedPick` producer test: 9/9 (untouched, sanity).
- Live gated Playwright driver (`IR339=1`, inert in CI): expands the whole tree + clicks rows + flips IR-mode/pass-tabs + steps playhead → **0 errors**; before the fix it threw `kids is not iterable`.