### PR TITLE
🐛 Song timeline: pin expanded voice sub-row order across clip reorders (#480)

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -31,6 +31,11 @@ import {
 } from '@stave/editor'
 import { paletteForTrack, trackIndexOf } from './musicalTimeline/colors'
 import { buildTimelineScene, clipAtCycle } from './musicalTimeline/timelineScene'
+import {
+  applyStableVoiceOrder,
+  EMPTY_VOICE_ORDER,
+  type VoiceOrderByLane,
+} from './musicalTimeline/stableVoiceOrder'
 import { collectNoteMarks } from './musicalTimeline/timelineMarks'
 import { computeLaneLayout, laneAtY, type LaneLayout } from './musicalTimeline/laneLayout'
 import { SongTimelineCanvas } from './SongTimelineCanvas'
@@ -375,7 +380,19 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
   // collect + build run only when the analysis or IR changes — NOT on scroll or
   // zoom (those only move the shared transform the canvas already redraws against).
   const marks = useMemo(() => collectNoteMarks(props.ir ?? null, displayCycles), [props.ir, displayCycles])
-  const scene = useMemo(() => buildTimelineScene(analysis, marks), [analysis, marks])
+  // Per-lane voice sub-row order is pinned first-seen across re-evals (#480) so
+  // reordering clips in time doesn't reshuffle the instrument rows — the SAME
+  // first-seen stability `stableTrackOrder` gives the top-level lanes, one level
+  // down. The previous order rides in a ref and is threaded back each rebuild
+  // (mirrors MusicalTimeline's `slotMapRef`). Recomputed only when the analysis
+  // or marks change (NOT on scroll/zoom), and idempotent on a no-op re-eval.
+  const voiceOrderRef = useRef<VoiceOrderByLane>(EMPTY_VOICE_ORDER)
+  const scene = useMemo(() => {
+    const raw = buildTimelineScene(analysis, marks)
+    const { scene: ordered, order } = applyStableVoiceOrder(raw, voiceOrderRef.current)
+    voiceOrderRef.current = order
+    return ordered
+  }, [analysis, marks])
 
   // ── Expand + bind (#422) ─────────────────────────────────────────────────
   // Click/expand a lane → accordion it taller (read-only note detail) AND bind

--- a/packages/app/src/components/musicalTimeline/__tests__/stableVoiceOrder.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/stableVoiceOrder.test.ts
@@ -1,0 +1,111 @@
+/**
+ * stableVoiceOrder (#480) — per-lane voice sub-rows keep their first-seen slot
+ * across re-evals, so reordering CLIPS in time doesn't reshuffle the instrument
+ * TRACKS. Mirrors stableTrackOrder one level down.
+ */
+import { describe, it, expect } from 'vitest'
+import type { SongAnalysis } from '@stave/editor'
+import { buildTimelineScene, type SceneNote, type CollectedMarks } from '../timelineScene'
+import { applyStableVoiceOrder, EMPTY_VOICE_ORDER } from '../stableVoiceOrder'
+
+const analysis: SongAnalysis = {
+  periodCycles: 8,
+  horizonCycles: 8,
+  reachedCap: false,
+  lanes: [{ laneKey: 'drums', onsetsByCycle: [1, 1, 1, 1, 1, 1, 1, 1] }],
+  sections: [],
+}
+
+function marks(drums: SceneNote[]): CollectedMarks {
+  return {
+    marksByLane: new Map([['drums', drums]]),
+    sourceByLane: new Map(),
+    arrangeByLane: new Map(),
+    clipsByLane: new Map(),
+    capped: false,
+  }
+}
+
+const note = (cycle: number, voice: string): SceneNote => ({
+  cycle,
+  end: cycle + 0.5,
+  pitch: null,
+  gain: 1,
+  voice,
+})
+
+// The #480 repro: `arrange([2, s('bd*4')], [2, s('hh*8')], …)`. bd's first mark
+// is at cycle 0, hh's at cycle 2 → groupVoices yields [bd, hh].
+const beforeSwap = marks([note(0, 'bd'), note(2, 'hh'), note(4, 'sn')])
+// After swapping the first two arms: hh now leads (cycle 0), bd at 2. groupVoices
+// alone would yield [hh, bd, sn] — the reshuffle this fix prevents.
+const afterSwap = marks([note(0, 'hh'), note(2, 'bd'), note(4, 'sn')])
+
+const voiceKeys = (scene: ReturnType<typeof buildTimelineScene>) =>
+  scene.lanes[0].voices.map((v) => v.key)
+
+describe('applyStableVoiceOrder (#480)', () => {
+  it('groupVoices reshuffles on clip swap — the bug being fixed', () => {
+    // Establishes the precondition: without the stable pass, the raw scene's
+    // voice order DOES flip when clips are reordered.
+    expect(voiceKeys(buildTimelineScene(analysis, beforeSwap))).toEqual(['bd', 'hh', 'sn'])
+    expect(voiceKeys(buildTimelineScene(analysis, afterSwap))).toEqual(['hh', 'bd', 'sn'])
+  })
+
+  it('pins voice order across a clip swap (drag or code-edit)', () => {
+    const first = applyStableVoiceOrder(buildTimelineScene(analysis, beforeSwap), EMPTY_VOICE_ORDER)
+    expect(voiceKeys(first.scene)).toEqual(['bd', 'hh', 'sn'])
+
+    // Re-eval after the swap, threading the pinned order back.
+    const second = applyStableVoiceOrder(buildTimelineScene(analysis, afterSwap), first.order)
+    expect(voiceKeys(second.scene)).toEqual(['bd', 'hh', 'sn']) // UNCHANGED rows
+  })
+
+  it('reflects the swapped CONTENT while holding the row order', () => {
+    const first = applyStableVoiceOrder(buildTimelineScene(analysis, beforeSwap), EMPTY_VOICE_ORDER)
+    const second = applyStableVoiceOrder(buildTimelineScene(analysis, afterSwap), first.order)
+    const bd = second.scene.lanes[0].voices.find((v) => v.key === 'bd')!
+    const hh = second.scene.lanes[0].voices.find((v) => v.key === 'hh')!
+    // Rows held, but the marks moved: after the swap hh leads in time, bd follows.
+    const lane = second.scene.lanes[0]
+    expect(lane.notes.find((n) => n.voice === 'hh')!.cycle).toBe(0)
+    expect(lane.notes.find((n) => n.voice === 'bd')!.cycle).toBe(2)
+    expect(bd.key).toBe('bd')
+    expect(hh.key).toBe('hh')
+  })
+
+  it('appends a genuinely new voice at the end (not alphabetical)', () => {
+    const first = applyStableVoiceOrder(buildTimelineScene(analysis, beforeSwap), EMPTY_VOICE_ORDER)
+    // Add 'cp' (alphabetically before sn/hh) — it must land LAST, not sorted in.
+    const withNew = marks([note(0, 'bd'), note(1, 'cp'), note(2, 'hh'), note(4, 'sn')])
+    const second = applyStableVoiceOrder(buildTimelineScene(analysis, withNew), first.order)
+    expect(voiceKeys(second.scene)).toEqual(['bd', 'hh', 'sn', 'cp'])
+  })
+
+  it('keeps a vanished voice reserved so re-adding returns it to its slot', () => {
+    const first = applyStableVoiceOrder(buildTimelineScene(analysis, beforeSwap), EMPTY_VOICE_ORDER)
+    // hh disappears this eval.
+    const without = marks([note(0, 'bd'), note(4, 'sn')])
+    const second = applyStableVoiceOrder(buildTimelineScene(analysis, without), first.order)
+    expect(voiceKeys(second.scene)).toEqual(['bd', 'sn'])
+    // hh comes back — it returns to its original slot (between bd and sn), not the end.
+    const third = applyStableVoiceOrder(buildTimelineScene(analysis, beforeSwap), second.order)
+    expect(voiceKeys(third.scene)).toEqual(['bd', 'hh', 'sn'])
+  })
+
+  it('returns the same scene identity on a no-op re-eval (no churn)', () => {
+    const built = buildTimelineScene(analysis, beforeSwap)
+    const first = applyStableVoiceOrder(built, EMPTY_VOICE_ORDER)
+    // Stable already → identity preserved so downstream useMemos don't recompute.
+    const again = applyStableVoiceOrder(first.scene, first.order)
+    expect(again.scene).toBe(first.scene)
+  })
+
+  it('leaves single-voice lanes untouched', () => {
+    const single = marks([note(0, 'bd'), note(1, 'bd')])
+    const built = buildTimelineScene(analysis, single)
+    const out = applyStableVoiceOrder(built, EMPTY_VOICE_ORDER)
+    expect(out.scene).toBe(built) // no reorder, same identity
+    expect(voiceKeys(out.scene)).toEqual(['bd'])
+  })
+})

--- a/packages/app/src/components/musicalTimeline/stableVoiceOrder.ts
+++ b/packages/app/src/components/musicalTimeline/stableVoiceOrder.ts
@@ -1,0 +1,71 @@
+/**
+ * stableVoiceOrder — pin each lane's per-voice sub-row order across re-evals
+ * (#480).
+ *
+ * `groupVoices` (timelineScene) emits a lane's voices in FIRST-APPEARANCE-IN-TIME
+ * order — the order their first mark is seen while walking the marks. Reordering
+ * clips in time (drag or code-edit) changes who appears first, so the voice rows
+ * reshuffle even though the marks are correct. For a DAW that's wrong: reordering
+ * CLIPS must not move TRACKS.
+ *
+ * Top-level lanes already get first-seen-stable ordering from `stableTrackOrder`
+ * (D-04). This applies the SAME treatment one level down — PER LANE, keyed on the
+ * voice partition key (`SceneVoice.key`). A voice keeps its slot once seen; a
+ * genuinely new voice appends at the end (NOT alphabetical — musical-intent
+ * order is preserved, just frozen). Because it reuses `stableTrackOrder`, a voice
+ * that vanishes from one eval keeps its slot reserved, so removing then re-adding
+ * it within a session returns it to its original row.
+ *
+ * PURE — no React, no canvas. The caller (FullSongTimeline) holds the previous
+ * order in a ref and threads it back, mirroring MusicalTimeline's `slotMapRef`.
+ *
+ * Per-lane keying matters: the same sample name (e.g. `bd`) can appear in two
+ * different lanes; each lane owns an independent voice-order map so their slots
+ * never collide.
+ */
+
+import { stableTrackOrder } from './stableTrackOrder'
+import type { TimelineScene } from './timelineScene'
+
+/** laneKey → (voiceKey → pinned slot). Held in a ref by the component and
+ *  threaded back each re-eval so the ordering persists within a session. */
+export type VoiceOrderByLane = ReadonlyMap<string, ReadonlyMap<string, number>>
+
+/** A shared empty starting point (first build of a session). */
+export const EMPTY_VOICE_ORDER: VoiceOrderByLane = new Map()
+
+/**
+ * Reorder every lane's `voices` array by a stable, first-seen slot map and
+ * return BOTH the reordered scene and the updated order map (the caller writes
+ * the latter back to its ref). Lanes with fewer than two voices are returned
+ * untouched (nothing to reorder, and they render as a single band anyway), but
+ * their slot map is still advanced so a later-appearing second voice pins
+ * correctly. Lane order itself is never changed here — that stays `analyzeSong`'s
+ * first-seen order (already stable).
+ */
+export function applyStableVoiceOrder(
+  scene: TimelineScene,
+  prev: VoiceOrderByLane,
+): { scene: TimelineScene; order: VoiceOrderByLane } {
+  const order = new Map<string, ReadonlyMap<string, number>>()
+  let changed = false
+  const lanes = scene.lanes.map((lane) => {
+    const prevForLane = prev.get(lane.laneKey) ?? new Map<string, number>()
+    const slots = stableTrackOrder(
+      prevForLane,
+      lane.voices.map((v) => v.key),
+    )
+    order.set(lane.laneKey, slots)
+    if (lane.voices.length < 2) return lane
+    const sorted = [...lane.voices].sort(
+      (a, b) => (slots.get(a.key) ?? 0) - (slots.get(b.key) ?? 0),
+    )
+    // Preserve the lane object identity when the order is already stable so
+    // downstream `useMemo`s keyed on `scene.lanes` don't churn on no-op re-evals.
+    const moved = sorted.some((v, i) => v.key !== lane.voices[i].key)
+    if (!moved) return lane
+    changed = true
+    return { ...lane, voices: sorted }
+  })
+  return { scene: changed ? { ...scene, lanes } : scene, order }
+}

--- a/packages/app/tests/full-song-voice-order-stable.spec.ts
+++ b/packages/app/tests/full-song-voice-order-stable.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * Full-song view: expanded per-voice sub-rows keep a STABLE row order when clips
+ * are reordered (#480) — Playwright observation (AnviDev observe gate, P195).
+ *
+ * The bug: `groupVoices` orders a lane's voice sub-rows by first-appearance-in-
+ * time, so reordering the clips reshuffled the instrument rows even though the
+ * marks were correct. For a DAW that's wrong — reordering CLIPS must not move
+ * TRACKS. The fix pins each voice's row first-seen (stableVoiceOrder), mirroring
+ * the top-level lane stability.
+ *
+ * Repro (verified in the real browser): `arrange([2, s("bd*4")], [2, s("hh*8")],
+ * [4, s("bd sn bd sn")])` is ONE lane (`d1`) with three voices — header `d1 · bd`
+ * and indented sub-labels `[hh, sn]`. Swapping the first two arms (code-edit OR
+ * drag) must leave that row order [bd, hh, sn] UNCHANGED while the per-voice mark
+ * content moves (bd's hits slide later; hh's slide earlier) — proving the rows
+ * held WITHOUT freezing the timeline.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+const ORIG = 'arrange([2, s("bd*4")], [2, s("hh*8")], [4, s("bd sn bd sn")])'
+const SWAPPED = 'arrange([2, s("hh*8")], [2, s("bd*4")], [4, s("bd sn bd sn")])'
+
+async function bootShell(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('stave:bottomPanel.height', '360')
+      localStorage.setItem('stave:bottomPanel.open', 'true')
+      localStorage.setItem('stave:bottomPanel.activeTabId', 'musical-timeline')
+    } catch {
+      /* ignore */
+    }
+  })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => ((window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco?.editor?.getEditors?.()?.length ?? 0) > 0,
+    { timeout: 20_000 },
+  )
+}
+
+async function focusStrudel(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string } | null; focus: () => void }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    t?.focus()
+  })
+}
+
+async function setSongAndEval(page: Page, code: string): Promise<void> {
+  await focusStrudel(page)
+  await page.locator('.monaco-editor').first().click()
+  await page.keyboard.press(`${MOD}+A`)
+  await page.keyboard.press('Backspace')
+  await page.keyboard.type(code, { delay: 6 })
+  await page.waitForTimeout(400)
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1800)
+}
+
+async function reEval(page: Page): Promise<void> {
+  await focusStrudel(page)
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1800)
+}
+
+async function openSongView(page: Page): Promise<void> {
+  await page.locator('[data-musical-timeline="view-toggle"]').click()
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+  await page.locator('[data-full-song-canvas]').waitFor({ timeout: 10_000 })
+  await page.waitForTimeout(400)
+}
+
+/** The FULL ordered voice keys of a lane: header voice 0 (parsed from
+ *  `laneKey · voice0`) followed by the indented `data-full-song-voice` sub-rows.
+ *  This is the exact top-to-bottom row order the user sees. */
+async function voiceOrder(page: Page, laneKey: string): Promise<string[]> {
+  const lane = page.locator(`[data-full-song-lane="${laneKey}"]`)
+  const header = (await lane.locator('span').last().textContent()) ?? ''
+  const voice0 = header.includes('·') ? header.split('·').pop()!.trim() : header.trim()
+  const subs = await lane.locator('[data-full-song-voice]').evaluateAll((els) =>
+    els.map((e) => e.getAttribute('data-full-song-voice') ?? ''),
+  )
+  return [voice0, ...subs]
+}
+
+/** A pixel fingerprint of the canvas — changes iff the drawn scene changed.
+ *  The playhead is a DOM overlay (not on the canvas), so a diff here means the
+ *  note CONTENT moved, not animation. */
+async function canvasFingerprint(page: Page): Promise<string> {
+  return page.locator('[data-full-song-canvas]').evaluate((el) => (el as HTMLCanvasElement).toDataURL())
+}
+
+async function expandLane(page: Page, laneKey: string): Promise<void> {
+  const caret = page.locator(`[data-full-song-lane-expand="${laneKey}"]`)
+  if ((await caret.getAttribute('aria-pressed')) !== 'true') {
+    await caret.click()
+    await page.waitForTimeout(200)
+  }
+}
+
+test('expanded voice rows hold their order across a CODE-EDIT clip swap (#480)', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await bootShell(page)
+  await setSongAndEval(page, ORIG)
+  await openSongView(page)
+  await expandLane(page, 'd1')
+
+  const before = await voiceOrder(page, 'd1')
+  expect(before, `expected the repro to split lane d1 into [bd, hh, sn]; saw ${JSON.stringify(before)}`).toEqual(['bd', 'hh', 'sn'])
+  const canvasBefore = await canvasFingerprint(page)
+  await page.screenshot({ path: 'test-results/full-song-voice-order-before.png' })
+
+  // Reorder the first two clips by editing the code, then re-eval.
+  await setSongAndEval(page, SWAPPED)
+  await page.waitForTimeout(300)
+
+  const after = await voiceOrder(page, 'd1')
+  // (1) Rows HELD — the swap did not move the tracks.
+  expect(after, `voice rows reshuffled on clip swap — saw ${JSON.stringify(after)}`).toEqual(['bd', 'hh', 'sn'])
+  // (2) Content MOVED — the canvas redrew (bd's hits slid later, hh's earlier);
+  //     proves the rows held WITHOUT freezing the timeline.
+  const canvasAfter = await canvasFingerprint(page)
+  expect(canvasAfter, 'canvas did not change — the swap was a no-op (frozen timeline)').not.toBe(canvasBefore)
+  await page.screenshot({ path: 'test-results/full-song-voice-order-after.png' })
+
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})
+
+test('expanded voice rows hold their order across a DRAG clip reorder (#480)', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await bootShell(page)
+  await setSongAndEval(page, ORIG)
+  await openSongView(page)
+  await expandLane(page, 'd1')
+
+  const before = await voiceOrder(page, 'd1')
+  expect(before).toEqual(['bd', 'hh', 'sn'])
+
+  // The song spans 8 cycles: arm 0 (bd) over [0,2) = x∈[0,0.25W), arm 1 (hh)
+  // over [2,4) = x∈[0.25W,0.5W). Grab arm 0's clip body at cycle ~1 (0.125W) and
+  // drag it into arm 1's span at cycle ~2.8 (0.35W) → reorderArm rewrites the
+  // source, swapping the first two arms.
+  const grid = page.locator('[data-full-song="grid"]')
+  const box = await grid.boundingBox()
+  if (!box) throw new Error('no grid box')
+  const y = box.y + 8
+  await page.mouse.move(box.x + box.width * 0.125, y)
+  await page.mouse.down()
+  await page.mouse.move(box.x + box.width * 0.25, y, { steps: 5 })
+  await page.mouse.move(box.x + box.width * 0.35, y, { steps: 5 })
+  await page.mouse.up()
+
+  // The write-back rewrites the code; re-eval to refresh the analyzed marks.
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string; getValue: () => string } | null }> } } }).monaco?.editor?.getEditors?.()) ?? []
+          const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+          return t?.getModel()?.getValue() ?? ''
+        }),
+      { timeout: 8_000 },
+    )
+    .toContain('s("hh*8")], [2, s("bd*4")')
+  await reEval(page)
+  await page.waitForTimeout(300)
+
+  const after = await voiceOrder(page, 'd1')
+  expect(after, `voice rows reshuffled after a drag reorder — saw ${JSON.stringify(after)}`).toEqual(['bd', 'hh', 'sn'])
+  await page.screenshot({ path: 'test-results/full-song-voice-order-drag.png' })
+
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})


### PR DESCRIPTION
## Problem

In an expanded Song-view lane, reordering clips in time **reshuffled the instrument sub-rows**. The marks were correct — only the row *order* was unstable. Swapping `arrange([2, s("bd*4")], [2, s("hh*8")], …)` made `hh` appear first, so `bd` and `hh` traded row positions. For a DAW that's wrong: reordering *clips* must not move *tracks*.

Top-level **lanes** already get first-seen stability from `stableTrackOrder`, but that was never applied one level down to the per-voice sub-rows.

## Root cause (confirmed by browser observation)

The issue body pointed at `layoutTrackRows.ts` (the live monitor), but driving the actual repro and dumping `[data-full-song-voice]` showed the reshuffling rows are the **Song-view canvas** lane voices — `groupVoices` in `timelineScene.ts`, which orders voices by **first-appearance-in-time** over the collected marks. Reorder the clips → who-plays-first changes → the rows re-sort.

## Fix

New pure helper `stableVoiceOrder.ts` reuses `stableTrackOrder` **per lane** (keyed on the voice partition key `s`):

- A voice keeps its slot the first time it's seen.
- A genuinely new voice appends at the **end** (musical-intent order frozen, not alphabetical).
- A vanished voice keeps its slot reserved, so removing then re-adding it returns it to its row.

`FullSongTimeline` threads the previous order through a ref (mirrors `MusicalTimeline`'s `slotMapRef`), recomputed only when the analysis/marks change, idempotent on a no-op re-eval, and lane-identity-preserving so downstream memos don't churn.

Binding (`activateLane` → `lane.sourceOffset`, keyed on laneKey) and clip ops (keyed on `armIndex`) don't depend on voice row order, so the reorder can't misroute them.

## Test plan

- **Unit** (`stableVoiceOrder.test.ts`, 7 tests) including a precondition test proving `groupVoices` *does* reshuffle without the fix (`[bd,hh,sn]` → `[hh,bd,sn]`), plus stable-across-swap, new-voice-appends, vanished-voice-reserved, no-op identity.
- **Real-browser e2e** (`full-song-voice-order-stable.spec.ts`): drives the exact repro, reorders the first two clips via **code-edit AND drag**, asserts `[data-full-song-voice]` order stays `[bd, hh, sn]` while the canvas fingerprint changes (content moved, not a frozen timeline). No console/page errors.
- Full app vitest suite: **577 passed**. App-side only — no editor dist rebuild.

closes #480