### PR TITLE
🐛 Key live-timeline rows by $: ordinal, not source offset (#483)

### DIFF
--- a/packages/app/src/components/MusicalTimeline.tsx
+++ b/packages/app/src/components/MusicalTimeline.tsx
@@ -266,24 +266,37 @@ function formatNoteTooltip(event: IREvent, fallbackTrackId: string): string {
  */
 function collectTopLevelSlots(
   node: PatternIR,
-): { slotKey: string; displayLabel: string }[] {
-  const summarize = (t: PatternIR): { slotKey: string; displayLabel: string } => {
+): { slotKey: string; displayLabel: string; pos: number | undefined }[] {
+  const summarize = (
+    t: PatternIR,
+    ordinal: number,
+  ): { slotKey: string; displayLabel: string; pos: number | undefined } => {
     const outer = t as Extract<PatternIR, { tag: 'Track' }>
     const pos = outer.loc?.[0]?.start
-    const slotKey = pos !== undefined ? `$${pos}` : outer.trackId
+    // Row identity is the `$:` ORDINAL (its index among the top-level `$:`
+    // tracks, in source order), NOT the source character offset (#483). A
+    // char-offset key churns whenever text ABOVE a track changes length:
+    // editing one track's content shifted the next track's offset, so its
+    // slotKey flipped and the old key lingered in `hasHadEventsRef` as a
+    // stale raw-`$N` ghost row. The ordinal is invariant under content edits
+    // and `.p()` renames; it only changes when `$:` lines are added, removed,
+    // or reordered — which is a genuine track-identity change. `pos` is still
+    // returned so events (which carry `dollarPos`) can be mapped to the slot.
+    const slotKey = `$${ordinal}`
     // Peek one level for a `.p()`-wrapped inner Track; that name becomes
     // the row label.
     const body = outer.body
     if (body.tag === 'Track' && body.userMethod === 'p') {
-      return { slotKey, displayLabel: body.trackId }
+      return { slotKey, displayLabel: body.trackId, pos }
     }
-    return { slotKey, displayLabel: outer.trackId }
+    return { slotKey, displayLabel: outer.trackId, pos }
   }
-  if (node.tag === 'Track') return [summarize(node)]
+  if (node.tag === 'Track') return [summarize(node, 0)]
   if (node.tag === 'Stack') {
-    const out: { slotKey: string; displayLabel: string }[] = []
+    const out: { slotKey: string; displayLabel: string; pos: number | undefined }[] = []
+    let ordinal = 0
     for (const child of node.tracks) {
-      if (child.tag === 'Track') out.push(summarize(child))
+      if (child.tag === 'Track') out.push(summarize(child, ordinal++))
     }
     return out
   }
@@ -291,12 +304,21 @@ function collectTopLevelSlots(
 }
 
 /** Compute the slot key for an event-derived group. The first event's
- *  `dollarPos` is the canonical identity; falling back to trackId
- *  matches the pre-`dollarPos` behavior for hand-built fixtures. */
-function groupSlotKey(group: { trackId: string; events: readonly IREvent[] }): string {
-  const first = group.events[0]
-  const pos = first?.dollarPos
-  return pos !== undefined ? `$${pos}` : group.trackId
+ *  `dollarPos` (source offset of its `$:` line) is mapped to the matching
+ *  IR slot's ORDINAL via `posToOrdinal` (#483), so the event side and the IR
+ *  side agree on the same stable key. Falls back to `trackId` for hand-built
+ *  fixtures or events with no matching `$:` slot (no `dollarPos`, or a
+ *  position the IR walk didn't surface). */
+function groupSlotKey(
+  group: { trackId: string; events: readonly IREvent[] },
+  posToOrdinal: ReadonlyMap<number, string>,
+): string {
+  const pos = group.events[0]?.dollarPos
+  if (pos !== undefined) {
+    const ordinalKey = posToOrdinal.get(pos)
+    if (ordinalKey !== undefined) return ordinalKey
+  }
+  return group.trackId
 }
 
 /**
@@ -725,6 +747,11 @@ export function MusicalTimeline(
   // entirely on stop+play. Cleared alongside slotMapRef on file switch
   // and on the transport-stop edge.
   const hasHadEventsRef = useRef<Set<string>>(new Set())
+  // #483 — last-seen display label per slotKey, so a reserved (ghosted) slot
+  // whose track is no longer in the IR (commented `$:` line) shows its last
+  // known orbit/`.p()` name instead of the raw internal slot key. Reset
+  // alongside slotMapRef/hasHadEventsRef on file switch + transport edge.
+  const slotLabelRef = useRef<Map<string, string>>(new Map())
 
   // File-switch reset: run BEFORE slot-map derivation so the new file's
   // tracks claim slots starting from 0 instead of inheriting the prior
@@ -732,6 +759,7 @@ export function MusicalTimeline(
   if (snapshot && snapshot.source !== lastSourceRef.current) {
     slotMapRef.current = new Map()
     hasHadEventsRef.current = new Set()
+    slotLabelRef.current = new Map()
     lastSourceRef.current = snapshot.source
   }
 
@@ -751,6 +779,7 @@ export function MusicalTimeline(
   if (prevCycleNullRef.current !== cycleIsNull) {
     slotMapRef.current = new Map()
     hasHadEventsRef.current = new Set()
+    slotLabelRef.current = new Map()
   }
   prevCycleNullRef.current = cycleIsNull
 
@@ -771,9 +800,16 @@ export function MusicalTimeline(
   // direct Track children. Nested `.p()` Tracks are inside those bodies
   // and contribute their NAME as a display label, not a separate slot.
   const irSlots = snapshot?.ir ? collectTopLevelSlots(snapshot.ir) : []
+  // #483 — map each `$:` track's source offset to its ordinal slotKey so the
+  // event groups (which carry `dollarPos`) resolve to the SAME stable key the
+  // IR walk assigned. Built fresh each render from the current IR.
+  const posToOrdinal = new Map<number, string>()
+  for (const s of irSlots) {
+    if (s.pos !== undefined) posToOrdinal.set(s.pos, s.slotKey)
+  }
   const groupBySlotKey = new Map<string, { displayLabel: string; events: readonly IREvent[] }>()
   for (const g of groups) {
-    const key = groupSlotKey(g)
+    const key = groupSlotKey(g, posToOrdinal)
     // Events from a `.p()`-wrapped Track carry the INNER trackId (the
     // user's chosen name). For events from a plain `$:` line, trackId
     // is the synthetic `d{N}`. Either way it's the right display label.
@@ -793,10 +829,14 @@ export function MusicalTimeline(
   for (const [key, { displayLabel }] of groupBySlotKey) {
     slotDisplay.set(key, displayLabel)
   }
+  // #483 — remember each slot's current label so a later ghost render (slot
+  // reserved but gone from the IR) shows the last known orbit/`.p()` name, not
+  // the raw ordinal key. Reset with the slot map on file switch + transport edge.
+  for (const [key, label] of slotDisplay) slotLabelRef.current.set(key, label)
 
   const currentSlotKeys = [
     ...irSlots.map((s) => s.slotKey),
-    ...groups.map(groupSlotKey),
+    ...groups.map((g) => groupSlotKey(g, posToOrdinal)),
   ]
   slotMapRef.current = stableTrackOrder(slotMapRef.current, currentSlotKeys)
   const slotMap = slotMapRef.current
@@ -805,16 +845,16 @@ export function MusicalTimeline(
   // entered into the set on a prior render with events; subsequent
   // event-less renders keep the row visible because its slot is still
   // in the set. Cleared on transport transitions + file switch.
-  for (const g of groups) hasHadEventsRef.current.add(groupSlotKey(g))
+  for (const g of groups) hasHadEventsRef.current.add(groupSlotKey(g, posToOrdinal))
 
   // Filter to slot keys that have ever produced events this session.
-  // Display label is read from `slotDisplay` so the chrome shows the
-  // inner `.p()` name when present, falling back to the outer `d{N}`.
+  // Display label is read from `slotDisplay` (live IR/event label), then the
+  // remembered label for a ghost slot, never the raw internal slotKey (#483).
   const orderedTracks = Array.from(slotMap.entries())
     .sort(([, a], [, b]) => a - b)
     .filter(([slotKey]) => hasHadEventsRef.current.has(slotKey))
     .map(([slotKey]) => ({
-      trackId: slotDisplay.get(slotKey) ?? slotKey,
+      trackId: slotDisplay.get(slotKey) ?? slotLabelRef.current.get(slotKey) ?? slotKey,
       events: groupBySlotKey.get(slotKey)?.events ?? [],
     }))
 

--- a/packages/app/tests/musical-timeline-slot-stability.spec.ts
+++ b/packages/app/tests/musical-timeline-slot-stability.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * MusicalTimeline slot-key stability (#483) — Playwright observation.
+ *
+ * Bug: the Live-view timeline keyed each `$:` track's row by the SOURCE
+ * CHARACTER OFFSET of its `$:` line. Editing one track's content changed the
+ * length of its line, which shifted the character offset of every line BELOW
+ * it — so those tracks' slot keys churned, and the stale keys lingered in the
+ * session's `hasHadEvents` set as junk ghost rows labelled with the raw `$N`
+ * internal key.
+ *
+ * Fix: key rows by the `$:` ORDINAL (index among the top-level `$:` tracks),
+ * which is invariant under content edits and `.p()` renames. Reserved ghost
+ * rows show their last-known orbit/`.p()` label, never the raw key.
+ *
+ * Repro (verified in the real browser): `$: s("bd*4")\n$: s("hh*8")` → rows
+ * `d1`/`d2`. Editing line 1 to `s("bd*16")` (a longer line) used to spawn a
+ * stale third row labelled `$13`; it must now stay exactly `d1`/`d2`.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+async function bootShell(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('stave:bottomPanel.height', '320')
+      localStorage.setItem('stave:bottomPanel.open', 'true')
+      localStorage.setItem('stave:bottomPanel.activeTabId', 'musical-timeline')
+    } catch {
+      /* ignore */
+    }
+  })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 15_000 })
+  await page.locator('.monaco-editor').waitFor({ timeout: 15_000 })
+}
+
+async function setCode(page: Page, code: string): Promise<void> {
+  const ok = await page.evaluate((c) => {
+    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+    const eds = (monaco?.editor?.getEditors?.() ?? []) as Array<{
+      getModel: () => { getLanguageId?: () => string; setValue: (s: string) => void } | null
+      focus: () => void
+    }>
+    const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    if (!t) return false
+    t.getModel()?.setValue(c)
+    t.focus()
+    return true
+  }, code)
+  expect(ok).toBe(true)
+  await page.waitForTimeout(150)
+}
+
+async function evalStrudel(page: Page): Promise<void> {
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(2000)
+}
+
+async function stopStrudel(page: Page): Promise<void> {
+  await page.keyboard.press(`${MOD}+.`)
+  await page.waitForTimeout(400)
+}
+
+/** Ordered row labels (the `data-musical-timeline-track-label` attribute). */
+function rowLabels(page: Page): Promise<(string | null)[]> {
+  return page
+    .locator('[data-musical-timeline-track-label]')
+    .evaluateAll((els) => els.map((el) => el.getAttribute('data-musical-timeline-track-label')))
+}
+
+test('editing one track’s content does NOT spawn a stale ghost row (#483)', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await bootShell(page)
+  await setCode(page, '$: s("bd*4")\n$: s("hh*8")')
+  await evalStrudel(page)
+  await expect(page.locator('[data-musical-timeline-track-row]')).toHaveCount(2, { timeout: 6000 })
+  expect(await rowLabels(page)).toEqual(['d1', 'd2'])
+
+  // Edit line 1 to a LONGER line while playing — this shifts line 2's source
+  // offset. With the old char-offset keying this spawned a stale `$N` ghost row.
+  await setCode(page, '$: s("bd*16")\n$: s("hh*8")')
+  await evalStrudel(page)
+  await page.waitForTimeout(400)
+
+  // Still exactly two rows, same labels — no churn, no raw-key ghost.
+  await expect(page.locator('[data-musical-timeline-track-row]')).toHaveCount(2)
+  expect(await rowLabels(page)).toEqual(['d1', 'd2'])
+  // No row label is a raw internal slot key (`$` followed by digits).
+  for (const label of await rowLabels(page)) {
+    expect(label, `raw slot-key leaked as a row label: ${label}`).not.toMatch(/^\$\d+$/)
+  }
+
+  // Edit line 1 again to a SHORTER line — still stable.
+  await setCode(page, '$: s("bd")\n$: s("hh*8")')
+  await evalStrudel(page)
+  await page.waitForTimeout(400)
+  await expect(page.locator('[data-musical-timeline-track-row]')).toHaveCount(2)
+  expect(await rowLabels(page)).toEqual(['d1', 'd2'])
+
+  await stopStrudel(page)
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})
+
+test('reserved/ghost rows never show a raw $N slot key after a structural edit (#483)', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await bootShell(page)
+  await setCode(page, '$: s("bd*4")\n$: s("hh*8")\n$: s("cp*2")')
+  await evalStrudel(page)
+  await expect(page.locator('[data-musical-timeline-track-row]')).toHaveCount(3, { timeout: 6000 })
+  expect(await rowLabels(page)).toEqual(['d1', 'd2', 'd3'])
+
+  // Comment the MIDDLE track and re-eval. A structural edit can leave a
+  // RESERVED (ghost) row whose track is no longer in the IR. The #483 fix
+  // guarantees that row shows its last-known orbit label (e.g. `d2`), NEVER
+  // the raw internal slot key (`$13` etc.). The exact row COUNT after a
+  // structural reshuffle of ordinals is out of scope here (tracked in #485).
+  await setCode(page, '$: s("bd*4")\n// $: s("hh*8")\n$: s("cp*2")')
+  await evalStrudel(page)
+  await page.waitForTimeout(400)
+
+  const labels = await rowLabels(page)
+  expect(labels.length).toBeGreaterThan(0)
+  for (const label of labels) {
+    expect(label, `raw slot-key leaked as a row label: ${label}`).not.toMatch(/^\$\d+$/)
+  }
+  // The live bd track is always present and orbit-labelled.
+  expect(labels).toContain('d1')
+
+  await stopStrudel(page)
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})


### PR DESCRIPTION
## Problem

The Live-view timeline keyed each `$:` track's row by the **source character offset** of its `$:` line (`$` + `loc.start`). Editing one track's content changes that line's length, which shifts the character offset of every line **below** it — so those tracks' slot keys churned, and the stale keys lingered in the session's `hasHadEvents` set as **junk ghost rows labelled with the raw `$N` internal key**.

Found while re-grounding #477. Reproduced in the real browser:

```
$: s("bd*4")
$: s("hh*8")     → rows d1, d2  ✓
```
then editing line 1 to `s("bd*16")` (a longer line) →
```
rows: d1, $13 (stale empty ghost!), d2
```
Just changing a track's note count corrupts the timeline with a raw-`$13` junk row.

## Fix

Key rows by the **`$:` ordinal** (index among the top-level `$:` tracks, in source order) instead of the character offset. The ordinal is invariant under content edits and `.p()` renames; it only changes when `$:` lines are added/removed/reordered (a genuine identity change). Event groups (which carry `dollarPos`) map to the same ordinal via a per-render `pos → ordinal` table, so the IR side and event side agree on one stable key.

A new `slotLabelRef` remembers each slot's last-seen orbit/`.p()` label, so a reserved (ghosted) row shows that label — **never the raw key**. It resets with the slot map on file switch + transport edge.

## Verified by observation (real browser)

- Editing a track's content (`bd*4` → `bd*16` → `bd`) keeps the timeline at exactly `[d1, d2]` — no stale ghost, no raw key.
- Commenting a track keeps proper orbit labels, no raw `$N` leak.
- 570 app vitest tests green (incl. `MusicalTimeline.test.tsx`'s 51 slot tests — backward-compatible).

## Test plan

- New `tests/musical-timeline-slot-stability.spec.ts` (2 tests): content-edit-no-churn + no-raw-key-after-structural-edit. Green + deterministic across repeated solo runs.

## Scope / residual

This fixes the **dominant** cause (char-offset churn on content edits) and the raw-label leak. A **residual** remains: STRUCTURAL `$:` edits (add/remove/reorder/comment a line above others, and the bare→multi-`$:` transition) renumber ordinals and can show a transient duplicate/ghost row until stop+replay. That's a deeper positional-identity limitation, **pre-existing** (the bare→multi duplicate reproduces on the studio baseline, worse), and is tracked in **#485**.

closes #483