### PR TITLE
🐛 Bare clip isn't movable — drop the wrap-with-silence drag gesture (#488)

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -109,18 +109,18 @@ export interface FullSongTimelineProps {
     sourceOffset: number | null
     armIndex: number
   }) => void
-  /** Move a clip by dragging its body horizontally (Phase 5c, #386). Two shapes:
-   *   - `reorder`: the clip is a real arm — swap it to a new slot in the combinator
-   *     (`reorderArm(fromIndex → toIndex)`). Clip time-order = arm order (PV122 #1).
-   *   - `wrap`: the clip is a bare track's implicit clip — there is no combinator
-   *     yet, so the first placement WRAPS the pattern (§2.1 `wrapBare`):
-   *     `pattern → arrange([leadingWeight, silence], [patternWeight, pattern])`.
-   *   The parent resolves the anchor and writes the surgical edit. Optional —
-   *   without it clips can't be dragged (trim/select/delete still work). */
+  /** Move a clip by dragging its body horizontally (Phase 5c, #386). Only a REAL
+   *  arrange/cat arm is movable: `reorder` swaps it to a new slot in the
+   *  combinator (`reorderArm(fromIndex → toIndex)`). Clip time-order = arm order
+   *  (PV122 #1). A bare track's implicit clip (`armIndex < 0`) is NOT movable —
+   *  a uniform pattern tiles every cycle identically, so dragging it would swap
+   *  identical content (an identity); injecting a leading `silence` to "place" it
+   *  invents a gap the source never had (#488). Starting an arrangement from a
+   *  bare pattern is an explicit action (type `arrange(...)`), not a drag. The
+   *  parent resolves the anchor and writes the surgical edit. Optional — without
+   *  it clips can't be dragged (trim/select/delete still work). */
   readonly onMoveClip?: (
-    req:
-      | { kind: 'reorder'; sourceOffset: number | null; fromIndex: number; toIndex: number }
-      | { kind: 'wrap'; sourceOffset: number | null; leadingWeight: number; patternWeight: number },
+    req: { kind: 'reorder'; sourceOffset: number | null; fromIndex: number; toIndex: number },
   ) => void
   /** Duplicate a clip (Phase 5c, #386). Fired on ⌘/Ctrl-D with a clip selected:
    *  insert a verbatim clone of the arm right after it (`insertArm`). Receives the
@@ -480,7 +480,6 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     endCycle: number
     dragging: boolean
     toIndex: number // reorder target (real arm)
-    leadCycle: number // wrap lead (bare clip)
   } | null>(null)
   const [moveGhost, setMoveGhost] = useState<{
     left: number
@@ -490,10 +489,11 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
   } | null>(null)
 
   // Hit-test a clip BODY (not its edge) under a client point → { lane, clip },
-  // or null. Matches CONTAINMENT (`clipAtCycle`). `includeBare` keeps the bare
-  // implicit clip (armIndex < 0) — wanted for MOVE (wrap), not for select/delete.
+  // or null. Matches CONTAINMENT (`clipAtCycle`). A bare track's implicit clip
+  // (armIndex < 0) is NEVER returned — it isn't selectable, deletable, or movable
+  // (#488: a uniform pattern has no distinct clip to act on).
   const clipBodyAt = React.useCallback(
-    (clientX: number, clientY: number, includeBare = false) => {
+    (clientX: number, clientY: number) => {
       const el = areaRef.current
       if (!el) return null
       const rect = el.getBoundingClientRect()
@@ -505,7 +505,7 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
       if (!lane) return null
       const cyc = xToSongCycle(contentX, displayCycles, cw)
       const clip = clipAtCycle(lane, cyc)
-      if (!clip || (clip.armIndex < 0 && !includeBare)) return null
+      if (!clip || clip.armIndex < 0) return null
       return { lane, clip }
     },
     [displayCycles],
@@ -563,7 +563,7 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
         // resolves on pointer-up: a MOVE drag if the pointer travelled, else a
         // click (select + seek). A press off any clip clears selection + seeks.
         const interactive = !!(onDeleteClip || onMoveClip || onDuplicateClip || onSplitClip)
-        const body = interactive ? clipBodyAt(e.clientX, e.clientY, !!onMoveClip) : null
+        const body = interactive ? clipBodyAt(e.clientX, e.clientY) : null
         if (body) {
           e.preventDefault()
           try {
@@ -585,7 +585,6 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
             endCycle: body.clip.endCycle,
             dragging: false,
             toIndex: body.clip.armIndex,
-            leadCycle: body.clip.startCycle,
           }
           return
         }
@@ -635,8 +634,9 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
         return
       }
       // Move drag (Phase 5c): once the press travels past the threshold, preview
-      // the destination — a reorder slot for a real arm, or the wrap lead for a
-      // bare clip — and stash the target on the ref for commit.
+      // the reorder destination (the arm whose span the pointer falls in) and
+      // stash it on the ref for commit. Only real arms reach here — a bare clip
+      // can't start a move (clipBodyAt excludes it, #488).
       const mv = moveDragRef.current
       if (mv && e.pointerId === mv.pointerId) {
         if (!mv.dragging && Math.abs(e.clientX - mv.startClientX) < CLIP_MOVE_THRESHOLD_PX) return
@@ -644,32 +644,22 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
         const contentX = e.clientX - rect.left + scrollLeftRef.current
         const cyc = xToSongCycle(contentX, displayCycles, cw)
         const box = layoutRef.current.boxes.find((b) => b.laneKey === mv.laneKey)
-        if (mv.armIndex >= 0) {
-          const spans = armSpansNow()
-          let to = mv.armIndex
-          if (spans.length) {
-            const inSpan = spans.find((s) => cyc >= s.startCycle && cyc < s.endCycle)
-            to = inSpan
-              ? inSpan.armIndex
-              : cyc < spans[0].startCycle
-                ? spans[0].armIndex
-                : spans[spans.length - 1].armIndex
-          }
-          mv.toIndex = to
-          const tgt = spans.find((s) => s.armIndex === to)
-          if (box && tgt) {
-            const left = songCycleToX(tgt.startCycle, displayCycles, cw)
-            const right = songCycleToX(tgt.endCycle, displayCycles, cw)
-            setMoveGhost({ left, width: Math.max(2, right - left), top: box.top, height: box.height })
-          }
-        } else {
-          const lead = Math.max(0, Math.round(cyc))
-          mv.leadCycle = lead
-          if (box) {
-            const left = songCycleToX(lead, displayCycles, cw)
-            const right = songCycleToX(lead + 1, displayCycles, cw)
-            setMoveGhost({ left, width: Math.max(2, right - left), top: box.top, height: box.height })
-          }
+        const spans = armSpansNow()
+        let to = mv.armIndex
+        if (spans.length) {
+          const inSpan = spans.find((s) => cyc >= s.startCycle && cyc < s.endCycle)
+          to = inSpan
+            ? inSpan.armIndex
+            : cyc < spans[0].startCycle
+              ? spans[0].armIndex
+              : spans[spans.length - 1].armIndex
+        }
+        mv.toIndex = to
+        const tgt = spans.find((s) => s.armIndex === to)
+        if (box && tgt) {
+          const left = songCycleToX(tgt.startCycle, displayCycles, cw)
+          const right = songCycleToX(tgt.endCycle, displayCycles, cw)
+          setMoveGhost({ left, width: Math.max(2, right - left), top: box.top, height: box.height })
         }
         return
       }
@@ -677,7 +667,7 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
       // movable body. Direct style write (no React state) so hover never churns.
       el.style.cursor = clipEdgeAt(e.clientX, e.clientY)
         ? 'col-resize'
-        : onMoveClip && clipBodyAt(e.clientX, e.clientY, true)
+        : onMoveClip && clipBodyAt(e.clientX, e.clientY)
           ? 'grab'
           : ''
     },
@@ -729,16 +719,11 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
         return
       }
       if (!commit) return
-      if (mv.armIndex >= 0) {
-        if (mv.toIndex !== mv.armIndex) {
-          onMoveClip?.({ kind: 'reorder', sourceOffset: mv.sourceOffset, fromIndex: mv.armIndex, toIndex: mv.toIndex })
-          // The arm list reindexes after a reorder, so the held armIndex would
-          // now point at a different clip — clear it (matching DELETE).
-          setSelected(null)
-        }
-      } else if (mv.leadCycle > 0) {
-        onMoveClip?.({ kind: 'wrap', sourceOffset: mv.sourceOffset, leadingWeight: mv.leadCycle, patternWeight: 1 })
-        // §2.1 wrap rewrites the bare clip into an arrange() — drop the stale selection.
+      // Only real arms reach a move commit (bare clips never start one, #488).
+      if (mv.toIndex !== mv.armIndex) {
+        onMoveClip?.({ kind: 'reorder', sourceOffset: mv.sourceOffset, fromIndex: mv.armIndex, toIndex: mv.toIndex })
+        // The arm list reindexes after a reorder, so the held armIndex would
+        // now point at a different clip — clear it (matching DELETE).
         setSelected(null)
       }
     },

--- a/packages/app/src/components/MusicalTimeline.tsx
+++ b/packages/app/src/components/MusicalTimeline.tsx
@@ -51,12 +51,10 @@ import {
   revealOffsetInFile,
   applyOffsetEditsToFile,
   detectArrangeAt,
-  detectBarePattern,
   setWeight,
   removeArm,
   reorderArm,
   insertArm,
-  wrapBare,
   splitArm,
   detectPickControlAt,
   pickSetWeight,
@@ -1094,42 +1092,30 @@ export function MusicalTimeline(
     [snapshot],
   )
 
-  // Move a clip on the Song canvas (Phase 5c, #386): two shapes.
-  //  - `reorder`: the dragged clip is a real arm — swap it to a new slot in the
-  //    combinator (reorderArm fromIndex→toIndex). Clip time-order = arm order.
-  //  - `wrap`: the clip is a bare track's implicit clip — there is no combinator
-  //    yet, so we INTRODUCE one (§2.1): detectBarePattern finds the pattern's
-  //    range and wrapBare rewrites `pattern` → `arrange([lead, silence], [pw, pattern])`.
-  // Both parse against the SAME snapshot the offsets came from and route through
-  // the structural write-back; the debounced re-eval re-derives the clips.
+  // Move a clip on the Song canvas (Phase 5c, #386): `reorder` only — the dragged
+  // clip is a real arm, swapped to a new slot in the combinator (reorderArm
+  // fromIndex→toIndex). Clip time-order = arm order. A bare track's implicit clip
+  // is NOT movable (#488): a uniform pattern tiles every cycle identically, so a
+  // drag would swap identical content — injecting a leading `silence` to "place"
+  // it invents a gap the source never had. Parses against the SAME snapshot the
+  // offsets came from and routes through the structural write-back; the debounced
+  // re-eval re-derives the clips.
   const handleMoveClip = React.useCallback(
-    (
-      req:
-        | { kind: 'reorder'; sourceOffset: number | null; fromIndex: number; toIndex: number }
-        | { kind: 'wrap'; sourceOffset: number | null; leadingWeight: number; patternWeight: number },
-    ) => {
+    (req: { kind: 'reorder'; sourceOffset: number | null; fromIndex: number; toIndex: number }) => {
       if (!snapshot?.source || req.sourceOffset == null) return
-      if (req.kind === 'reorder') {
-        const call = detectArrangeAt(snapshot.code, req.sourceOffset)
-        if (call) {
-          const edits = reorderArm(snapshot.code, call, req.fromIndex, req.toIndex)
-          if (edits.length === 0) return
-          applyOffsetEditsToFile(snapshot.source, edits, 'arrange.structure', snapshot.code)
-          return
-        }
-        // #463 Stage 2 — reorder pick* control sections.
-        const ctl = detectPickControlAt(snapshot.code, req.sourceOffset)
-        if (!ctl) return
-        const edits = pickReorderArm(snapshot.code, ctl, req.fromIndex, req.toIndex)
+      const call = detectArrangeAt(snapshot.code, req.sourceOffset)
+      if (call) {
+        const edits = reorderArm(snapshot.code, call, req.fromIndex, req.toIndex)
         if (edits.length === 0) return
         applyOffsetEditsToFile(snapshot.source, edits, 'arrange.structure', snapshot.code)
-      } else {
-        const bare = detectBarePattern(snapshot.code, req.sourceOffset)
-        if (!bare) return
-        const edits = wrapBare(bare.patternRange, req.leadingWeight, req.patternWeight)
-        if (edits.length === 0) return
-        applyOffsetEditsToFile(snapshot.source, edits, 'arrange.structure', snapshot.code)
+        return
       }
+      // #463 Stage 2 — reorder pick* control sections.
+      const ctl = detectPickControlAt(snapshot.code, req.sourceOffset)
+      if (!ctl) return
+      const edits = pickReorderArm(snapshot.code, ctl, req.fromIndex, req.toIndex)
+      if (edits.length === 0) return
+      applyOffsetEditsToFile(snapshot.source, edits, 'arrange.structure', snapshot.code)
     },
     [snapshot],
   )

--- a/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
+++ b/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
@@ -32,7 +32,7 @@ const { TRIM_EVENTS, BARE_EVENTS, NESTED_EVENTS } = vi.hoisted(() => ({
   ],
   // A BARE track: events with NO armIndex → no clipsByLane entry → the scene
   // synthesises ONE implicit clip (armIndex −1) spanning the song. Used for the
-  // §2.1 wrap (move-on-a-bare-track) test.
+  // bare-clip-is-not-movable test (#488: dragging it must be a no-op).
   BARE_EVENTS: [
     { begin: 0, end: 1, s: 'bd', loc: [{ start: 0, end: 9 }] },
     { begin: 1, end: 2, s: 'bd', loc: [{ start: 0, end: 9 }] },
@@ -450,7 +450,7 @@ describe('FullSongTimeline — delete a clip (select body + Delete → remove-ar
   })
 })
 
-describe('FullSongTimeline — move a clip (drag body → reorder / §2.1 wrap, #386)', () => {
+describe('FullSongTimeline — move a clip (drag body → reorder; bare clip = no-op, #386/#488)', () => {
   // Reorder fixture: the same two-arm bd lane (arm 0 [0,2), arm 1 [2,4)) at
   // 200px/cycle. Dragging arm 0's body (x≈200) right into arm 1's span (x≈600 =
   // cycle 3) reorders it to slot 1.
@@ -519,20 +519,18 @@ describe('FullSongTimeline — move a clip (drag body → reorder / §2.1 wrap, 
     expect(container.querySelector('[data-full-song="clip-selection"]')).toBeNull()
   })
 
-  it('dragging a BARE track’s clip → onMoveClip wrap (§2.1, lead = drop cycle)', async () => {
+  it('dragging a BARE track’s clip is a no-op — onMoveClip never fires (#488)', async () => {
     const onMoveClip = vi.fn()
-    const { grid } = renderWrappable(onMoveClip)
+    const { grid, container } = renderWrappable(onMoveClip)
     await settle()
-    // The implicit clip spans [0,4); drag it to start at cycle 3.
+    // The implicit clip tiles [0,4) uniformly; dragging it must NOT introduce an
+    // arrange/silence (a uniform pattern has no distinct clip to move).
     fireEvent.pointerDown(grid, { clientX: 200, clientY: 10, pointerId: 1 })
     fireEvent.pointerMove(grid, { clientX: 600, clientY: 10, pointerId: 1 }) // cycle 3
     fireEvent.pointerUp(grid, { clientX: 600, clientY: 10, pointerId: 1 })
-    expect(onMoveClip).toHaveBeenCalledWith({
-      kind: 'wrap',
-      sourceOffset: 0,
-      leadingWeight: 3,
-      patternWeight: 1,
-    })
+    expect(onMoveClip).not.toHaveBeenCalled()
+    // A bare clip isn't selectable either — the press falls through to seek.
+    expect(container.querySelector('[data-full-song="clip-selection"]')).toBeNull()
   })
 })
 

--- a/packages/app/tests/full-song-arrange-move.spec.ts
+++ b/packages/app/tests/full-song-arrange-move.spec.ts
@@ -1,12 +1,13 @@
 /**
  * Full-song view: MOVE a clip by dragging its body (#386 / Phase 5c) —
- * Playwright observation (AnviDev observe gate). Two shapes:
- *   - reorder: drag a real arm's clip into another arm's time-span → reorderArm.
- *   - wrap (§2.1): drag a BARE track's clip → detectBarePattern + wrapBare
- *     INTRODUCES the combinator (`pattern → arrange([lead, silence], [1, pattern])`).
+ * Playwright observation (AnviDev observe gate).
+ *   - reorder: drag a REAL arm's clip into another arm's time-span → reorderArm.
+ *   - bare clip: NOT movable (#488). A uniform pattern tiles every cycle
+ *     identically, so a drag would swap identical content; injecting a leading
+ *     `silence` to "place" it invents a gap the source never had. The drag is a
+ *     no-op (the old wrap-to-arrange gesture was removed).
  *
- * Unit tests cover the substrate (editor arrange.test.ts: reorderArm,
- * detectBarePattern, wrapBare) and the gesture geometry (FullSongTimeline.test.tsx).
+ * Unit tests cover the reorder substrate (editor arrange.test.ts: reorderArm).
  * This drives the REAL app end-to-end.
  */
 import { test, expect, type Page } from '@playwright/test'
@@ -92,7 +93,7 @@ test('reorder: dragging arm 0’s clip into arm 1’s span swaps the arm order',
   expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
 })
 
-test('wrap (§2.1): dragging a bare track’s clip introduces the combinator', async ({ page }) => {
+test('a bare track’s clip is NOT movable — dragging it leaves the source untouched (#488)', async ({ page }) => {
   const errors: string[] = []
   page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
   page.on('console', (m) => {
@@ -100,25 +101,31 @@ test('wrap (§2.1): dragging a bare track’s clip introduces the combinator', a
   })
 
   await bootShell(page)
-  // A bare, multi-cycle track so there's room to drag the implicit clip right.
-  await typeSongAndEval(page, 's("bd hh cp sd").slow(4)')
+  // A bare, multi-cycle track. Its implicit clip tiles every cycle identically,
+  // so a drag would swap identical content (an identity); injecting a leading
+  // `silence` to "place" it would invent a gap the source never had (#488).
+  const SRC = 's("bd hh cp sd").slow(4)'
+  await typeSongAndEval(page, SRC)
   await openSongView(page)
 
   const grid = page.locator('[data-full-song="grid"]')
   const box = await grid.boundingBox()
   if (!box) throw new Error('no grid box')
   const y = box.y + 8
-  // Grab the implicit clip's body and drag it well to the right (later cycle) →
-  // wrapBare introduces `arrange([lead, silence], [1, …])`.
+  // Drag the implicit clip's body well to the right — this must NOT rewrite the
+  // pattern into an `arrange([…, silence], …)`.
   await page.mouse.move(box.x + box.width * 0.2, y)
   await page.mouse.down()
   await page.mouse.move(box.x + box.width * 0.5, y, { steps: 4 })
   await page.mouse.move(box.x + box.width * 0.7, y, { steps: 4 })
   await page.mouse.up()
 
-  await expect
-    .poll(() => strudelSource(page), { timeout: 8_000 })
-    .toMatch(/arrange\(\[\d+, silence\], \[1, s\("bd hh cp sd"\)\.slow\(4\)\]\)/)
-  await page.screenshot({ path: 'test-results/arrange-move-wrap.png' })
+  // Settle, then assert the source is byte-for-byte unchanged — no arrange, no silence.
+  await page.waitForTimeout(1000)
+  const after = await strudelSource(page)
+  expect(after).toBe(SRC)
+  expect(after).not.toContain('silence')
+  expect(after).not.toContain('arrange(')
+  await page.screenshot({ path: 'test-results/arrange-move-bare-noop.png' })
   expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
 })

--- a/packages/app/tests/full-song-clip-ops-e2e.spec.ts
+++ b/packages/app/tests/full-song-clip-ops-e2e.spec.ts
@@ -172,11 +172,12 @@ test.describe('full-song clip ops on a multi-track $: song', () => {
     expect(errors, errors.join('\n')).toEqual([])
   })
 
-  test('MOVE (wrap) — drag a BARE sibling track introduces a combinator (§2.1)', async ({ page }) => {
+  test('MOVE — dragging a BARE sibling track is a no-op (no combinator introduced) (#488)', async ({ page }) => {
     const errors = setup(page)
     await bootShell(page)
-    // sibling 2 (note(...).slow(2)) is a 2-cycle BARE track — room to drag its
-    // implicit clip right so wrapBare introduces arrange([lead, silence], [1, …]).
+    // sibling 2 (note(...).slow(2)) is a 2-cycle BARE track. Its implicit clip
+    // tiles every cycle identically, so dragging it must NOT rewrite it into an
+    // arrange([…, silence], …) — that would invent a gap the source never had.
     await typeSongAndEval(page, SONG)
     await openSongView(page)
 
@@ -193,15 +194,15 @@ test.describe('full-song clip ops on a multi-track $: song', () => {
     await page.mouse.move(box.x + box.width * 0.6, y, { steps: 4 })
     await page.mouse.up()
 
-    // The bare sibling line is rewritten into an arrange(...) with a leading
-    // silence; the arrange track + the OTHER sibling stay byte-identical.
-    await expect
-      .poll(() => strudelSource(page), { timeout: 8_000 })
-      .toMatch(/arrange\(\[\d+, silence\], \[1, note\("c2 eb2 g2 c3"\)\.s\("sawtooth"\)\.slow\(2\)\]\)/)
+    // The whole program is byte-identical — no silence, no new arrange, every
+    // track (the arrange + both siblings) untouched.
+    await page.waitForTimeout(1000)
     const src = await strudelSource(page)
+    expect(src, 'no leading silence introduced').not.toContain('silence')
+    expect(src, 'the bare sibling stays bare').toContain(SIB2)
     expect(src, 'the arrange track must be untouched').toContain(ARRANGE)
     expect(src, 'sibling 1 must be untouched').toContain(SIB1)
-    await page.screenshot({ path: 'test-results/clipop-move-wrap.png' })
+    await page.screenshot({ path: 'test-results/clipop-move-bare-noop.png' })
     expect(errors, errors.join('\n')).toEqual([])
   })
 


### PR DESCRIPTION
Closes #488.

## Problem
Dragging a bare track's implicit clip (e.g. `s("bd*4")`) rewrote it to `arrange([1, silence], [1, s("bd*4")])` — manufacturing a silent cycle and changing playback (the kick now plays every OTHER cycle). A bare pattern is CONTINUOUS — it tiles every cycle identically — so a drag swaps identical content (an identity) and should leave the music unchanged. The model treated the implicit clip as a finite, placeable thing and ran "introduce the combinator" (`wrapBare`) on a plain drag, conflating *move a uniform loop* (a no-op) with *carve a gap then play* (a deliberate action). `patternWeight` was also hardcoded to 1, shredding multi-cycle bare patterns.

## Fix
A bare implicit clip (`armIndex < 0`) is no longer a move target — `clipBodyAt` drops the `includeBare` escape hatch and the `kind: 'wrap'` request / ghost branch / `handleMoveClip` wrap case are removed. Dragging a bare clip falls through to seek. Real `arrange`/`cat` arms still reorder. `wrapBare`/`detectBarePattern` stay as `@stave/editor` library surface. App-only, no dist change.

## Test plan
- Flipped the two wrap e2e specs + the jsdom unit case to assert the bare drag is a no-op (source byte-identical, no `silence`, no new `arrange`).
- reorder / split / delete / duplicate / trim all still green.

Note: #489 (PR follows) is stacked on this branch and reframes the bare-loop interaction as select+split.