### PR TITLE
✨ Toasts: cap visible toasts at 3 (#565)

### DIFF
--- a/packages/app/src/dialogs/__tests__/host.test.ts
+++ b/packages/app/src/dialogs/__tests__/host.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { showToast, getToasts, dismissToast } from "../host";
+
+beforeEach(() => {
+  // Module-level state — drain any toasts left by a previous test.
+  for (const t of getToasts()) dismissToast(t.id);
+});
+
+describe("showToast — visible cap (#565)", () => {
+  it("keeps at most 3 toasts, dropping the oldest", () => {
+    showToast("a");
+    showToast("b");
+    showToast("c");
+    showToast("d");
+    showToast("e");
+    const visible = getToasts();
+    expect(visible).toHaveLength(3);
+    // newest three retained, oldest (a, b) dropped
+    expect(visible.map((t) => t.message)).toEqual(["c", "d", "e"]);
+  });
+
+  it("coalesces an identical message instead of consuming a slot", () => {
+    showToast("dup");
+    showToast("dup");
+    showToast("dup");
+    const visible = getToasts();
+    expect(visible).toHaveLength(1);
+    expect(visible[0].count).toBe(3);
+  });
+
+  it("a repeat of a still-visible message does not evict others under the cap", () => {
+    showToast("x");
+    showToast("y");
+    showToast("x"); // bumps x's count, stays 2 toasts
+    const visible = getToasts();
+    expect(visible).toHaveLength(2);
+    expect(visible.map((t) => t.message)).toEqual(["x", "y"]);
+    expect(visible.find((t) => t.message === "x")?.count).toBe(2);
+  });
+
+  it("dismissToast removes a specific toast", () => {
+    showToast("one");
+    showToast("two");
+    const id = getToasts()[0].id;
+    dismissToast(id);
+    expect(getToasts().map((t) => t.message)).toEqual(["two"]);
+  });
+});

--- a/packages/app/src/dialogs/host.ts
+++ b/packages/app/src/dialogs/host.ts
@@ -42,6 +42,14 @@ export interface ToastState {
 
 type Listener = () => void;
 
+/**
+ * Most toasts visible at once. A burst of DISTINCT errors (the dedupe below
+ * only collapses identical ones) would otherwise stack without bound and cover
+ * the screen; cap the display and drop the oldest. Persistent surfaces (Console
+ * panel + status-bar LED) still keep every entry — this cap is display-only.
+ */
+const MAX_VISIBLE_TOASTS = 3;
+
 let dialog: DialogState | null = null;
 let toasts: ToastState[] = [];
 const listeners = new Set<Listener>();
@@ -151,7 +159,10 @@ export function showToast(message: string, level: "info" | "error" = "info", ttl
     expiresAt: Date.now() + ttlMs,
     count: 1,
   };
-  toasts = [...toasts, t];
+  // Append, then keep only the newest MAX_VISIBLE_TOASTS — a burst of distinct
+  // errors drops the oldest rather than covering the screen. Dropped toasts are
+  // simply forgotten; their pending cleanup no-ops (id no longer found).
+  toasts = [...toasts, t].slice(-MAX_VISIBLE_TOASTS);
   notify();
   scheduleToastCleanup(t.id);
 }


### PR DESCRIPTION
Closes #565. Part of EPIC #535 (Diagnostics & Console v2). Complements #563/#564; base `studio_v0.2.0`, independent (only `dialogs/host.ts` + a new test).

## Problem

`showToast` already dedupes an identical `(message, level)` into one counted toast, but **distinct** messages still stack without bound — a burst of different errors can cover the screen.

## Fix

Cap simultaneously-visible toasts at **3** in `dialogs/host.ts`. A genuinely new toast appends then trims to the newest 3 (`.slice(-MAX_VISIBLE_TOASTS)`), dropping the oldest; the dedupe path is untouched (it bumps an existing toast, never grows the list). Display-only — the Console panel + status-bar LED still keep every entry. `DialogHost` renders `getToasts()` verbatim, so the cap reaches the screen.

## Test plan
- Unit (`dialogs/__tests__/host.test.ts`, +4): 5 distinct → 3 kept (newest); identical repeats → 1 toast `count: 3`; a repeat under the cap doesn't evict siblings; `dismissToast` works. app vitest **575**, app typecheck clean.
- Render path verified by source: `DialogHost` maps `getToasts()` and re-renders on notify.

## Note
Verified via unit tests + render-path source check rather than a visual capture — reliably producing 5 *distinct* toasts headlessly is fiddly, and the cap is a pure `.slice(-3)`.