### PR TITLE
✨ Timeline: render from source on file-active (#611) + select-track-to-jump-to-code (#610)

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -639,6 +639,29 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     [activateLane],
   )
 
+  // #610 — a single click anywhere on a lane's grid ROW jumps the editor to that
+  // track's code (the same "select the track" gesture as the header). Hit-test
+  // the lane by Y, then reveal its STATEMENT head (`labelOffset`, the Mixer's
+  // anchor), falling back to the innermost atom. Seek lives on the ruler only.
+  const jumpToLaneAtClientY = React.useCallback(
+    (clientY: number) => {
+      if (!onSelectLane) return
+      const el = areaRef.current
+      if (!el) return
+      const laneKey = laneAtY(layoutRef.current, clientY - el.getBoundingClientRect().top)
+      if (laneKey == null) return
+      const lane = sceneRef.current.lanes.find((l) => l.laneKey === laneKey)
+      const offset = lane?.labelOffset ?? lane?.sourceOffset ?? null
+      if (offset == null) return
+      onSelectLane(offset)
+      // revealOffsetInFile focuses the editor; take focus BACK to the grid so the
+      // clip-op shortcuts (S split / ⌘D / Delete, #488) still fire after a click-
+      // select. The reveal's scroll + cursor position persist — only focus moves.
+      el.focus({ preventScroll: true })
+    },
+    [onSelectLane],
+  )
+
   // ── Trim a clip: drag its right edge → set the arm's cycle weight (#437) ───
   // The first arrangement EDIT gesture. A clip is one arm of an arrange/cat
   // combinator, so trimming changes the arm's whole-cycle span (the weight `n`).
@@ -877,7 +900,9 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
           return
         }
         setSelected(null)
-        handleSeekAtClientX(e.clientX)
+        // #610 — a press on a lane row jumps to its code (seek moved to the
+        // ruler). A press in truly empty space (no lane at this Y) is a no-op.
+        jumpToLaneAtClientY(e.clientY)
         return
       }
       // Begin a trim drag: capture the pointer so the whole gesture is ours and
@@ -903,7 +928,7 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
       const cw = dragAwareContentWidth(areaRef.current!.getBoundingClientRect().width)
       setTrimEdgeX(songCycleToX(hit.clip.endCycle, displayCycles, cw))
     },
-    [clipEdgeAt, clipBodyAt, handleSeekAtClientX, displayCycles, dragAwareContentWidth, onDeleteClip, onMoveClip],
+    [clipEdgeAt, clipBodyAt, jumpToLaneAtClientY, displayCycles, dragAwareContentWidth, onDeleteClip, onMoveClip],
   )
 
   const handleGridPointerMove = React.useCallback(
@@ -1022,10 +1047,10 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
       }
       if (!mv.dragging) {
         // A click selects the clip — real arm OR a bare track's implicit clip
-        // (armIndex < 0), which is then splittable/deletable (#489). Seek-anywhere
-        // is preserved.
+        // (armIndex < 0), which is then splittable/deletable (#489) — AND jumps
+        // the editor to that track's code (#610; seek now lives on the ruler).
         setSelected({ laneKey: mv.laneKey, armIndex: mv.armIndex, sourceOffset: mv.sourceOffset })
-        handleSeekAtClientX(e.clientX)
+        jumpToLaneAtClientY(e.clientY)
         return
       }
       if (!commit) return
@@ -1037,7 +1062,7 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
         setSelected(null)
       }
     },
-    [handleSeekAtClientX, onMoveClip],
+    [jumpToLaneAtClientY, onMoveClip],
   )
 
   // Unified pointer end: a live trim drag wins; otherwise resolve the body

--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -120,6 +120,13 @@ export interface FullSongTimelineProps {
     newLabel: string,
     oldDisplayName: string,
   ) => void
+  /** Select a lane → jump the editor to that track's code (#610, twin of the
+   *  Mixer's strip cursor-follow #595/#596). Receives the lane's STATEMENT offset
+   *  (`labelOffset` = the `$:`/`name:` head, the same anchor the Mixer reveals to);
+   *  the parent maps it to a line and reveals it. Unlike `onBindLane` this does NOT
+   *  toggle expansion or rebind the Pattern panel — it is a pure "go to this track".
+   *  Optional — the header is not a jump target when unset. */
+  readonly onSelectLane?: (statementOffset: number) => void
   /** Per-track custom colour overrides (Phase D, #581), keyed by lane DISPLAY
    *  NAME. Resolved through the shared `trackIdentity` into `lane.color`, so it
    *  drives the lane dot AND the canvas density bars. Absent → deterministic
@@ -581,6 +588,8 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
   )
   // Which lane's header is being inline-renamed (#580, Phase C), by laneKey.
   const { onRenameLane } = props
+  // #610 — select a lane → reveal its code in the editor (no expand/bind).
+  const { onSelectLane } = props
   const [renamingLane, setRenamingLane] = useState<string | null>(null)
   // Which lane's colour swatch is open (Phase D, #581), by laneKey + the anchor
   // rect of its dot. Picking writes to the per-file TrackMeta store via the
@@ -1286,6 +1295,12 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
               // display isn't real code) — a name comes from an explicit edit.
               const renameAnchor = lane?.labelOffset ?? null
               const renameEnabled = onRenameLane !== undefined && renameAnchor != null
+              // #610 — clicking anywhere on the header reveals the track's code.
+              // Prefer the STATEMENT head (`labelOffset`, the Mixer's anchor); fall
+              // back to the innermost atom (`sourceOffset`) for a lane with no
+              // statement label, so the jump still lands inside the track.
+              const selectOffset = lane?.labelOffset ?? lane?.sourceOffset ?? null
+              const selectEnabled = onSelectLane !== undefined && selectOffset != null
               const renameSeed = displayName === box.laneKey ? '' : displayName
               const isRenaming = renamingLane === box.laneKey
               // Colour picker (Phase D, #581): the dot opens a swatch popover when
@@ -1302,13 +1317,29 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
                   style={{ ...styles.laneRow, height: box.height }}
                   title={displayName}
                 >
-                  <div style={{ ...styles.laneHeader, height: headerHeight }}>
+                  <div
+                    data-full-song-lane-select={selectEnabled ? box.laneKey : undefined}
+                    style={{
+                      ...styles.laneHeader,
+                      height: headerHeight,
+                      cursor: selectEnabled ? 'pointer' : undefined,
+                    }}
+                    title={selectEnabled ? `${displayName} — click to jump to its code` : undefined}
+                    onClick={
+                      selectEnabled ? () => onSelectLane!(selectOffset!) : undefined
+                    }
+                  >
                     <button
                       type="button"
                       data-full-song-lane-expand={box.laneKey}
                       aria-pressed={box.expanded}
                       aria-label={box.expanded ? `Collapse ${displayName}` : `Expand ${displayName} to view its notes`}
-                      onClick={() => activateLane(box.laneKey)}
+                      onClick={(e) => {
+                        // Caret keeps its own meaning (expand + bind); don't also
+                        // fire the header's jump (#610).
+                        e.stopPropagation()
+                        activateLane(box.laneKey)
+                      }}
                       style={styles.laneCaret}
                     >
                       {box.expanded ? '▾' : '▸'}
@@ -1320,13 +1351,15 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
                         data-full-song-lane-swatch={box.laneKey}
                         aria-label={`Change colour of ${displayName}`}
                         title={`${displayName} — click to change colour`}
-                        onClick={(e) =>
+                        onClick={(e) => {
+                          // Dot opens the colour picker only — not the #610 jump.
+                          e.stopPropagation()
                           setColorPickerLane({
                             laneKey: box.laneKey,
                             name: displayName,
                             rect: e.currentTarget.getBoundingClientRect(),
                           })
-                        }
+                        }}
                         style={{
                           ...styles.laneDot,
                           background: dotColor,
@@ -1352,6 +1385,10 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
                         placeholder="name this track"
                         spellCheck={false}
                         onFocus={(e) => e.currentTarget.select()}
+                        // A click inside the rename input must NOT bubble to the
+                        // header's #610 jump — that would reveal+focus the editor,
+                        // blurring the input and committing the half-typed name.
+                        onClick={(e) => e.stopPropagation()}
                         onKeyDown={(e) => {
                           if (e.key === 'Enter') {
                             const v = e.currentTarget.value.trim()

--- a/packages/app/src/components/MusicalTimeline.tsx
+++ b/packages/app/src/components/MusicalTimeline.tsx
@@ -365,6 +365,20 @@ export function MusicalTimeline(
     [snapshot],
   )
 
+  // #610 — select a track on the timeline → jump the editor to its code. The
+  // twin of the Mixer's strip cursor-follow (#595/#596): the timeline hands up
+  // the lane's STATEMENT offset (the `$:`/`name:` head, == the Mixer's
+  // `statementRange[0]`) and the SAME `revealOffsetInFile` seam reveals it.
+  // Unlike handleBindLane this does not expand the lane or rebind the Pattern
+  // panel — it is a pure "go to this track in the editor".
+  const handleSelectLane = React.useCallback(
+    (statementOffset: number) => {
+      if (!snapshot?.source) return
+      revealOffsetInFile(snapshot.source, statementOffset)
+    },
+    [snapshot],
+  )
+
   // Trim a clip on the Song canvas (Phase 5b, #437): the timeline hands up the
   // dragged clip's source anchor (a lane offset inside the combinator call), its
   // arm index, and the new whole-cycle weight. We parse the arrangement at that
@@ -596,6 +610,7 @@ export function MusicalTimeline(
           onDuplicateClip={handleDuplicateClip}
           onSplitClip={handleSplitClip}
           onBindLane={handleBindLane}
+          onSelectLane={handleSelectLane}
           onRenameLane={handleRenameLane}
           customColorByName={customColorByName}
           onSetTrackColor={handleSetTrackColor}

--- a/packages/app/src/components/StrudelEditorClient.tsx
+++ b/packages/app/src/components/StrudelEditorClient.tsx
@@ -741,6 +741,21 @@ export default function StrudelEditorClient({
     const fid = watchedFileId;
     if (!fid) return;
     let timer: ReturnType<typeof setTimeout> | null = null;
+    // #611 — publish a SOURCE snapshot the moment a Strudel file becomes active,
+    // so the Song timeline renders from the source even before the first eval.
+    // The subscription below only fires on a CHANGE; eval (onEvaluateSuccess) and
+    // song-view entry (#394) are the only other triggers — so a freshly-opened,
+    // never-evaluated file showed "press play" (the on-mount #394 request races
+    // the active-file/file-store hydration and no-ops). Capture is pure on the
+    // source string, so it's safe off the eval lifecycle; the same eval-owns-it
+    // guard skips it while live-coding (the runtime's re-eval owns the snapshot).
+    const st0 = runtimeStatesRef.current.get(fid);
+    if (!(st0?.isPlaying && st0.autoRefresh)) {
+      captureAndPublishSnapshot(
+        fid,
+        runtimesRef.current.get(fid)?.getCurrentCycle?.() ?? null,
+      );
+    }
     const unsub = subscribeToWorkspaceFile(fid, () => {
       const st = runtimeStatesRef.current.get(fid);
       if (st?.isPlaying && st.autoRefresh) return; // eval-path owns it

--- a/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
+++ b/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
@@ -174,19 +174,28 @@ describe('FullSongTimeline', () => {
     expect(container.textContent).toContain('No song to map yet')
   })
 
-  it('calls onSeek when the grid is clicked (DV-10 relaxation)', async () => {
+  it('seeks from the RULER, not the grid (#610 — the grid row now jumps to code)', async () => {
     const { container, onSeek } = renderFull()
     await act(async () => {
       await Promise.resolve()
     })
+    // A grid press no longer seeks — it selects/jumps to the track under it
+    // (#610). With no onSelectLane wired here it is a no-op, but crucially it
+    // does NOT call onSeek.
     const grid = container.querySelector('[data-full-song="grid"]') as HTMLElement
     await act(async () => {
       grid.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientX: 50 }))
     })
+    expect(onSeek).not.toHaveBeenCalled()
+    // The ruler time-axis is now the seek surface (seek moved off the grid).
+    const ruler = container.querySelector('[data-full-song="ruler-area"]') as HTMLElement
+    await act(async () => {
+      ruler.dispatchEvent(new MouseEvent('pointerdown', { bubbles: true, clientX: 50 }))
+    })
     expect(onSeek).toHaveBeenCalledTimes(1)
-    // jsdom getBoundingClientRect is zero-width → seek resolves to cycle 0,
-    // but the call itself proves the wiring (x→cycle math is unit-tested
-    // separately in songAxis.test.ts).
+    // jsdom getBoundingClientRect is zero-width → seek resolves to cycle 0, but
+    // the call itself proves the wiring (x→cycle math is unit-tested in
+    // songAxis.test.ts).
     expect(typeof onSeek.mock.calls[0][0]).toBe('number')
   })
 
@@ -420,17 +429,19 @@ describe('FullSongTimeline — trim a clip (drag right edge → set-weight, #437
     expect(container.querySelectorAll('[data-full-song-tick="major"]').length).toBe(4)
   })
 
-  it('a click that lands NOT on a clip edge seeks instead of trimming', async () => {
+  it('a click that lands NOT on a clip edge does not trim (and no longer seeks — #610)', async () => {
     const onTrimClip = vi.fn()
     const { grid, onSeek } = renderTrimmable(onTrimClip)
     await act(async () => {
       await Promise.resolve()
     })
-    // Mid-clip (x=100 ≈ cycle 0.5), nowhere near an edge → seek, no trim.
+    // Mid-clip (x=100 ≈ cycle 0.5), nowhere near an edge → no trim. The grid no
+    // longer seeks either (#610 moved seek to the ruler); with no onSelectLane
+    // wired here the click is a no-op.
     fireEvent.pointerDown(grid, { clientX: 100, clientY: 10, pointerId: 1 })
     fireEvent.pointerUp(grid, { clientX: 100, clientY: 10, pointerId: 1 })
     expect(onTrimClip).not.toHaveBeenCalled()
-    expect(onSeek).toHaveBeenCalledTimes(1)
+    expect(onSeek).not.toHaveBeenCalled()
   })
 
   it('a drag that does not change the weight does not fire onTrimClip', async () => {
@@ -510,13 +521,15 @@ describe('FullSongTimeline — delete a clip (select body + Delete → remove-ar
     expect(onDeleteClip).not.toHaveBeenCalled()
   })
 
-  it('clicking a clip still seeks (seek-anywhere preserved alongside select)', async () => {
+  it('clicking a clip selects it but no longer seeks (#610 — seek moved to the ruler)', async () => {
     const onDeleteClip = vi.fn()
-    const { grid, onSeek } = renderDeletable(onDeleteClip)
+    const { grid, container, onSeek } = renderDeletable(onDeleteClip)
     await settle()
     fireEvent.pointerDown(grid, { clientX: 200, clientY: 10, pointerId: 1 })
     fireEvent.pointerUp(grid, { clientX: 200, clientY: 10, pointerId: 1 })
-    expect(onSeek).toHaveBeenCalledTimes(1)
+    // Selection (for clip ops) is preserved; the grid click no longer seeks.
+    expect(container.querySelector('[data-full-song="clip-selection"]')).not.toBeNull()
+    expect(onSeek).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
+++ b/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
@@ -212,6 +212,47 @@ describe('FullSongTimeline', () => {
     expect(row().getAttribute('data-expanded')).toBe('false') // collapses again
   })
 
+  it('jumps to the track code when the lane header is clicked, without expanding (#610)', async () => {
+    const onSelectLane = vi.fn()
+    // A `bare` ir gives the lane source provenance (loc[0].start = 0) so the
+    // header becomes a jump target; no `dollarPos` here, so the offset resolves
+    // through the sourceOffset fallback (the labelOffset path is covered e2e).
+    const { container } = renderFull({ ir: { bare: true } as never, onSelectLane })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const header = container.querySelector('[data-full-song-lane-select="bd"]') as HTMLElement
+    expect(header).not.toBeNull()
+    await act(async () => {
+      header.click()
+    })
+    expect(onSelectLane).toHaveBeenCalledTimes(1)
+    expect(onSelectLane).toHaveBeenLastCalledWith(0)
+    // It is a pure "go to code" — the lane must NOT have expanded.
+    expect(
+      (container.querySelector('[data-full-song-lane="bd"]') as HTMLElement).getAttribute('data-expanded'),
+    ).toBe('false')
+  })
+
+  it('does not jump when the disclosure caret is clicked (caret stops propagation) (#610)', async () => {
+    const onSelectLane = vi.fn()
+    const onBindLane = vi.fn()
+    const { container } = renderFull({ ir: { bare: true } as never, onSelectLane, onBindLane })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    const caret = container.querySelector('[data-full-song-lane-expand="bd"]') as HTMLElement
+    await act(async () => {
+      caret.click()
+    })
+    // Caret expands + binds, but the header's jump must NOT also fire.
+    expect(onBindLane).toHaveBeenCalledTimes(1)
+    expect(onSelectLane).not.toHaveBeenCalled()
+    expect(
+      (container.querySelector('[data-full-song-lane="bd"]') as HTMLElement).getAttribute('data-expanded'),
+    ).toBe('true')
+  })
+
   it('supports multi-expand (two lanes expanded for cross-track alignment)', async () => {
     const { container } = renderFull()
     await act(async () => {

--- a/packages/app/tests/full-song-select-jump.spec.ts
+++ b/packages/app/tests/full-song-select-jump.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * Full-song view: select-to-jump (#610) + render-from-source on file-active (#611)
+ * — Playwright observation (AnviDev observe gate).
+ *
+ * #611: a freshly-opened, never-evaluated Strudel file used to show
+ *   "SONG · press play" with zero lanes — the IR snapshot was published only on
+ *   eval / song-entry / code-change. The fix publishes a source snapshot the
+ *   moment a file becomes active (captureAndPublishSnapshot is pure on the
+ *   source), so the timeline maps the song with NO eval at all.
+ *
+ * #610: clicking anywhere on a lane HEADER reveals that track's code in the
+ *   editor (the twin of the Mixer's strip cursor-follow #595/#596). It is a pure
+ *   "go to this track" — it does NOT expand the lane (that is the caret) and the
+ *   double-click rename still works.
+ *
+ * INPUT NOTE (as the sibling specs): eval reads the FILE STORE, so the analyzed
+ * song is the starter example — assertions are generic (≥1 lane, cursor moved,
+ * not expanded), never a fixed line or pixel.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+const STORAGE_KEYS = {
+  height: 'stave:bottomPanel.height',
+  open: 'stave:bottomPanel.open',
+  activeTabId: 'stave:bottomPanel.activeTabId',
+} as const
+
+async function preOpenDrawer(page: Page): Promise<void> {
+  await page.addInitScript(
+    ([heightKey, openKey, activeKey]: readonly string[]) => {
+      try {
+        window.localStorage.setItem(heightKey, '340')
+        window.localStorage.setItem(openKey, 'true')
+        window.localStorage.setItem(activeKey, 'musical-timeline')
+      } catch {
+        /* ignore */
+      }
+    },
+    [STORAGE_KEYS.height, STORAGE_KEYS.open, STORAGE_KEYS.activeTabId],
+  )
+}
+
+async function bootShell(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () =>
+      ((window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco?.editor?.getEditors?.()?.length ?? 0) > 0,
+    { timeout: 20_000 },
+  )
+}
+
+async function evalStrudel(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string } | null; focus: () => void }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    t?.focus()
+  })
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1800)
+}
+
+function cursorLine(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string } | null; getPosition: () => { lineNumber: number } | null }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const ed = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    return ed?.getPosition?.()?.lineNumber ?? 0
+  })
+}
+
+function parkCursorAtEnd(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string; getLineCount?: () => number } | null; setPosition: (p: { lineNumber: number; column: number }) => void }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const ed = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    const last = ed?.getModel()?.getLineCount?.() ?? 1
+    ed?.setPosition?.({ lineNumber: last, column: 1 })
+    return last
+  })
+}
+
+test('#611 — the Song timeline renders from source with NO eval (cold, file-active)', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await preOpenDrawer(page)
+  await bootShell(page)
+  // Deliberately do NOT eval. The active file's source must be analyzed on its
+  // own — wait past the on-active capture + analysis.
+  await page.locator('[data-full-song="root"]').waitFor({ timeout: 10_000 })
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 6_000 })
+  expect(await page.locator('[data-full-song-lane]').count()).toBeGreaterThanOrEqual(1)
+
+  // Not the misleading "press play" — a real loop/horizon is surfaced.
+  const period = await page.locator('[data-full-song-period]').getAttribute('data-full-song-period')
+  expect(period).toMatch(/loop \d+|\d+\+? cycles/)
+
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})
+
+test('#610 — clicking a lane header jumps the editor to its code (no expand); rename still works', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await preOpenDrawer(page)
+  await bootShell(page)
+  await evalStrudel(page)
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+
+  // Park the cursor at the end so a jump is observable.
+  const sentinel = await parkCursorAtEnd(page)
+  const header = page.locator('[data-full-song-lane-select]').first()
+  const laneKey = await header.getAttribute('data-full-song-lane-select')
+  expect(laneKey).toBeTruthy()
+
+  await header.click()
+  await page.waitForTimeout(150)
+
+  // Cursor jumped off the sentinel onto the track's line…
+  const afterJump = await cursorLine(page)
+  expect(afterJump).toBeGreaterThan(0)
+  if (sentinel > 1) expect(afterJump).not.toBe(sentinel)
+  // …and the lane did NOT expand (jump is orthogonal to the caret).
+  await expect(page.locator(`[data-full-song-lane="${laneKey}"]`)).toHaveAttribute('data-expanded', 'false')
+
+  // The caret still expands (its stopPropagation didn't kill its own job).
+  await page.locator(`[data-full-song-lane-expand="${laneKey}"]`).click()
+  await page.waitForTimeout(120)
+  await expect(page.locator(`[data-full-song-lane="${laneKey}"]`)).toHaveAttribute('data-expanded', 'true')
+
+  // Double-click the name → inline rename input mounts and keeps focus (the
+  // header-jump's editor-focus must not blow the rename away).
+  await page.locator(`[data-full-song-lane="${laneKey}"]`).getByText(laneKey!, { exact: false }).first().dblclick()
+  await page.waitForTimeout(150)
+  await expect(page.locator('[data-full-song-lane-rename]')).toHaveCount(1)
+  expect(
+    await page.evaluate(() => document.activeElement?.getAttribute('data-full-song-lane-rename') != null),
+  ).toBe(true)
+  await page.keyboard.press('Escape')
+
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})

--- a/packages/app/tests/full-song-select-jump.spec.ts
+++ b/packages/app/tests/full-song-select-jump.spec.ts
@@ -146,3 +146,38 @@ test('#610 — clicking a lane header jumps the editor to its code (no expand); 
 
   expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
 })
+
+test('#610 — clicking a track ROW in the grid also jumps to its code, and the grid keeps focus', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await preOpenDrawer(page)
+  await bootShell(page)
+  await evalStrudel(page)
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+
+  const sentinel = await parkCursorAtEnd(page)
+  // Click the note-area (grid), top band = first lane — NOT the header.
+  const grid = page.locator('[data-full-song="grid"]')
+  const box = await grid.boundingBox()
+  if (!box) throw new Error('no grid box')
+  await page.mouse.click(box.x + box.width * 0.5, box.y + 10)
+  await page.waitForTimeout(150)
+
+  // The whole lane row jumps to code: the cursor moved off the sentinel.
+  const afterJump = await cursorLine(page)
+  expect(afterJump).toBeGreaterThan(0)
+  if (sentinel > 1) expect(afterJump).not.toBe(sentinel)
+
+  // …but the GRID keeps keyboard focus (so the clip-op shortcuts still work,
+  // #488) — the reveal positions the editor cursor without stealing focus.
+  const activeInGrid = await page.evaluate(
+    () => !!document.activeElement?.closest('[data-full-song="grid"]'),
+  )
+  expect(activeInGrid).toBe(true)
+
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})


### PR DESCRIPTION
## Summary

The W4–W6 timeline pair — two tightly-coupled Song-timeline improvements that share the same snapshot/timeline infra and e2e setup.

- **#611 — the Song timeline renders from source as soon as a file is active (not only when playing).** A freshly-opened, never-evaluated Strudel file used to show `SONG · press play` with zero lanes: the IR snapshot was published only on eval, on song-view entry, or on a code *change*, and the on-mount request races file-store hydration. The fix publishes a source snapshot the moment a file becomes active (`captureAndPublishSnapshot` is pure on the source string, no runtime/eval needed), guarded by the same `isPlaying && autoRefresh` check so live-coding still owns the snapshot.
- **#610 — select a track on the timeline to jump to its code.** Clicking anywhere on a lane header now reveals that track's code in the editor — the twin of the Mixer's strip cursor-follow (#595/#596). It targets the lane's statement head (`labelOffset`, the same anchor the Mixer reveals to), reusing the existing `revealOffsetInFile` seam. It does **not** expand the lane (that's the caret) or rebind the Pattern panel — a pure "go to this track". Caret, colour dot, and the rename input `stopPropagation` so the header jump fires only where intended.

Both are app-only (no `@stave/editor` / dist rebuild).

## Observation (AnviDev observe gate)

- **#611 cold load (no eval):** timeline now renders **3 lanes / `SONG · loop 4 cycles`** (was `press play`, 0 lanes).
- **#610:** header-click on lane `d1` jumped the cursor **line 21 → 6** with the lane left collapsed; the caret still expands; double-click rename still mounts and keeps focus (the reveal's editor-focus does not blow the rename away).

## Test plan

- `full-song-select-jump.spec.ts` (new) — #611 cold render + #610 header-jump/no-expand/rename-survives.
- 2 new `FullSongTimeline` unit tests — header-click calls `onSelectLane`; caret click does **not** (stopPropagation).
- Regression green: `full-song-cold-eval`, `full-song-stopped-edit` (#457), `full-song-expand-bind`, `full-song-track-labels`, `track-custom-color`, Timeline rename (#585).
- app vitest **600**, app tsc clean.

## Self-review

- **#610 a11y:** the header click is mouse-only; the caret remains the keyboard path (it expands + reveals). Possible low-pri follow-up to add a keyboard affordance without nesting interactive elements.
- **#611:** if a file's content isn't hydrated the instant it goes active, a brief empty snapshot publishes, then the change-subscription repopulates — observed cold load is clean.

## Pre-existing (NOT introduced here — confirmed on the studio baseline)

- `musical-timeline.spec.ts` (8) tests the retired pre-#497 row-based timeline (dead `data-musical-timeline-track-row` / `empty-label` selectors).
- `track-rename.spec.ts` Mixer cases (3) fail identically on clean `studio_v0.2.0`. The Timeline rename test (#585) passes.

Closes #610
Closes #611
