### PR TITLE
🐛 fix(timeline): make the Song gutter labels collapse like the track rows (#645)

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -1771,6 +1771,14 @@ const styles = {
     borderRight: '1px solid var(--border-subtle, rgba(255,255,255,0.08))',
     display: 'flex',
     flexDirection: 'column' as const,
+    // #645 — clip the stacked label rows at the column box so they collapse
+    // exactly like the track rows on the right (which keep true heights and clip
+    // via the grid's `overflowY: hidden`). Use `clip`, NOT `hidden`: `hidden` is
+    // still a scroll CONTAINER, so focusing an expand button inside the gutter
+    // let the browser scroll it independently of the grid (gutter drifted ~111px
+    // out of alignment). `clip` is not a scrollport — the gutter can never gain
+    // its own scroll offset, so it stays pinned to the canvas rows.
+    overflow: 'clip' as const,
   },
   // Outer lane label box (relative so the per-voice sub-labels can absolutely
   // position against the lane top, lining up with the canvas sub-rows — #424).
@@ -1778,6 +1786,12 @@ const styles = {
     position: 'relative' as const,
     borderBottom: '1px solid var(--border-subtle, rgba(255,255,255,0.08))',
     overflow: 'hidden',
+    // #645 — keep each row at its `box.height`. As a flex-column child the row
+    // would otherwise SHRINK to fit a short gutter (default flex-shrink:1),
+    // squishing every lane while the grid clips — the mismatched collapse. With
+    // shrink off, the gutter honors the SAME lane heights the canvas draws, so
+    // both sides collapse and reveal identically.
+    flexShrink: 0,
   },
   // #641/#642 — caret-selected lane GUTTER: an accent fill + a 3px left accent
   // bar (inset box-shadow → no layout shift). Pairs with the full-width grid

--- a/packages/app/tests/full-song-gutter-collapse.spec.ts
+++ b/packages/app/tests/full-song-gutter-collapse.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * Full-song view: the gutter (lane labels) must collapse IDENTICALLY to the
+ * track-row canvas on the right (#645).
+ *
+ * Bug: the gutter is a flex column; its `laneRow` children had no
+ * `flex-shrink: 0`, so when the drawer was shrunk below the content height,
+ * flexbox SQUISHED every label row to fit (gutter `scrollHeight` clamped to the
+ * viewport) while the grid kept true lane heights and CLIPPED (`overflowY:
+ * hidden`, content stays at the real total). The two sides no longer lined up.
+ *
+ * Fix: `laneRow { flex-shrink: 0 }` (keep true heights) + gutter `overflow:
+ * clip` (clip like the grid, and — unlike `hidden` — NOT a scroll container, so
+ * focusing an expand button can't scroll the gutter out of step with the grid).
+ *
+ * Guard (the property a screenshot-free assertion can still verify): at a short
+ * drawer height where the lanes overflow, the gutter's content height equals the
+ * grid's content height, and the gutter has no independent scroll offset.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+const K = {
+  height: 'stave:bottomPanel.height',
+  open: 'stave:bottomPanel.open',
+  activeTabId: 'stave:bottomPanel.activeTabId',
+}
+// Three lanes — even collapsed they exceed the short drawer's body height, so
+// the collapse behaviour is exercised without needing to expand anything.
+const CODE = `setcps(130/240)
+
+$: note("c4 e4 g4 b4").s("sawtooth").gain(0.3).viz("pianoroll")
+
+$: note("<c2 g2 f2 eb2>").s("square").gain(0.4).viz("pitchwheel")
+
+$: stack(
+  s("hh*8").gain(0.3),
+  s("bd [~ bd] ~ bd").gain(0.5)
+).viz("wordfall")
+`
+
+async function boot(page: Page, height: number) {
+  await page.addInitScript(
+    ([h, o, a, hv]: string[]) => {
+      try {
+        window.localStorage.setItem(h, hv)
+        window.localStorage.setItem(o, 'true')
+        window.localStorage.setItem(a, 'musical-timeline')
+      } catch {}
+    },
+    [K.height, K.open, K.activeTabId, String(height)],
+  )
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => (((window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco?.editor?.getEditors?.()?.length) ?? 0) > 0,
+    { timeout: 20_000 },
+  )
+  await page.evaluate((code) => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string; setValue?: (v: string) => void } | null; focus: () => void }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const ed = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    ed?.focus()
+    ed?.getModel()?.setValue?.(code)
+  }, CODE)
+  await page.waitForTimeout(500)
+  await page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string } | null; focus: () => void }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const ed = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    ed?.focus()
+  })
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1500)
+}
+
+test('#645 — the gutter collapses identically to the track rows (no squish, no drift)', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(`console.error: ${m.text()}`) })
+
+  await boot(page, 150) // short — the body ends up well under the 3-lane content height
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+
+  const m = await page.evaluate(() => {
+    const labels = document.querySelector('[data-full-song="lane-labels"]') as HTMLElement | null
+    const grid = document.querySelector('[data-full-song="grid"]') as HTMLElement | null
+    return {
+      labelsScrollH: labels?.scrollHeight ?? -1,
+      labelsClientH: labels?.clientHeight ?? -1,
+      labelsScrollTop: labels?.scrollTop ?? -1,
+      gridScrollH: grid?.scrollHeight ?? -1,
+      gridScrollTop: grid?.scrollTop ?? -1,
+    }
+  })
+
+  // The scenario is only meaningful if the content actually overflows.
+  expect(m.gridScrollH).toBeGreaterThan(m.labelsClientH)
+  // The gutter keeps the SAME true content height as the grid (no squish): both
+  // honour the lane heights from LaneLayout.
+  expect(m.labelsScrollH).toBe(m.gridScrollH)
+  // …and the gutter is pinned to the grid — no independent scroll offset (the
+  // `overflow: clip` guarantee; `hidden` allowed a focus-driven drift).
+  expect(m.labelsScrollTop).toBe(0)
+  expect(m.gridScrollTop).toBe(0)
+
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})


### PR DESCRIPTION
## Summary

Shrinking the Song Timeline tab vertically collapsed the **left gutter (lane labels)** differently from the **track-row canvas**: the grid kept each lane at its true height and clipped the overflow, while the gutter — a flex column whose rows lacked `flex-shrink: 0` — **squished** every label to fit. The two sides stopped lining up.

### Root cause
Both columns are fed the same lane heights from `LaneLayout`, but honored them differently:
- **grid**: fixed-height canvas + `overflowY: hidden` → keeps true heights, clips.
- **gutter**: `flex` column, `laneRow` children had no `flex-shrink: 0` → flexbox shrank them to fit a short column (`scrollHeight` clamped to the viewport).

### Fix (2 CSS properties)
- `laneRow { flex-shrink: 0 }` — rows keep their `box.height` instead of squishing.
- gutter `overflow: clip` — clips at the column box like the grid. Deliberately `clip`, not `hidden`: `hidden` is still a scroll container, so focusing an expand button inside the gutter let the browser scroll it ~111px out of step with the grid. `clip` is not a scrollport, so the gutter can never drift.

## Test plan

- [x] Playwright measure at a short drawer height: gutter and grid now report **identical content height** and **zero scroll offset** (before: gutter 39 vs grid 204)
- [x] New regression e2e `full-song-gutter-collapse.spec.ts` — asserts `gutter.scrollHeight == grid.scrollHeight` and both `scrollTop == 0` (fails on the old code)
- [x] app vitest **600 passed** · `tsc` clean · `eslint` clean (1 pre-existing unrelated warning)
- [x] full-song e2e suite green (1 known P193 GPU/settle flake, passes solo)
- [x] Screenshot: gutter starts at the top aligned with the rows and clips at the bottom

closes #645

Base is `studio_v0.2.0` — the issue auto-closes at the studio→main merge.