### PR TITLE
🐛 fix(timeline): scale a single-voice expanded lane with the sub-row setting (#647)

### DIFF
--- a/packages/app/src/components/musicalTimeline/__tests__/laneLayout.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/laneLayout.test.ts
@@ -104,11 +104,21 @@ describe('computeLaneLayout — per-voice sub-rows (#424)', () => {
     expect(sub[1]).toMatchObject({ voiceKey: 'square', label: 'square', melodic: true })
   })
 
-  it('keeps a single-voice expanded lane as ONE band (no sub-rows)', () => {
+  it('keeps a single MELODIC voice as ONE band that SCALES with the sub-row setting (#647)', () => {
     const layout = computeLaneLayout(drums, new Set(['lead']), 22, 96, 20)
-    const lead = layout.boxes[1]
-    expect(lead.height).toBe(96) // expandedHeight single band
+    const lead = layout.boxes[1] // voices: [square (melodic)]
+    expect(lead.height).toBe(80) // 4 melodic rows × 20, NOT the fixed 96 band
     expect(lead.subRows).toBeUndefined()
+    // …and it tracks the slider: a bigger sub-row → a taller band.
+    const taller = computeLaneLayout(drums, new Set(['lead']), 22, 96, 40)
+    expect(taller.boxes[1].height).toBe(160) // 4 × 40
+  })
+
+  it('gives a single PERCUSSIVE voice a single baseline row that scales (#647)', () => {
+    const perc = [{ laneKey: 'kick', voices: [v('bd')] }] // not melodic
+    const layout = computeLaneLayout(perc, new Set(['kick']), 22, 96, 20)
+    expect(layout.boxes[0].height).toBe(20) // 1 × subRowHeight
+    expect(layout.boxes[0].subRows).toBeUndefined()
   })
 
   it('does not split a COLLAPSED multi-voice lane', () => {

--- a/packages/app/src/components/musicalTimeline/laneLayout.ts
+++ b/packages/app/src/components/musicalTimeline/laneLayout.ts
@@ -22,6 +22,14 @@
  *  expanded lane keeps the full `expandedHeight` single band instead. */
 export const SUB_ROW_HEIGHT = 22
 
+/** A lone MELODIC voice expands to a pitch band this many sub-rows tall (#647).
+ *  A single melodic lane is a mini pianoroll — it needs vertical room for the
+ *  pitch spread — so it stays taller than a single drum baseline. Expressed in
+ *  sub-rows (not a fixed px) so it SCALES with the sub-row size setting like
+ *  every multi-voice lane, instead of being pinned to a constant that ignored
+ *  the setting. A lone percussive voice gets a single baseline row. */
+export const MELODIC_SINGLE_VOICE_ROWS = 4
+
 /** One voice sub-row inside an expanded multi-voice lane (#424). Absolute `top`
  *  in the SAME content space as `LaneBox.top`, so the draw, the gutter labels,
  *  and (future) hit-tests all read one geometry — no drift (PV120). */
@@ -96,9 +104,7 @@ export function computeLaneLayout(
     const isExpanded = expanded.has(lane.laneKey)
     const voices = lane.voices ?? []
     // An expanded lane with ≥2 voices splits into per-voice sub-rows (#424);
-    // its height grows with the voice count. A single-voice (or no-voice)
-    // expanded lane keeps the single `expandedHeight` band — same display as
-    // before this feature (melodic pitch spread, drums on one baseline).
+    // its height grows with the voice count.
     if (isExpanded && voices.length >= 2 && sub > 0) {
       const subRows: SubRowBox[] = voices.map((v, i) => ({
         voiceKey: v.key,
@@ -112,6 +118,21 @@ export function computeLaneLayout(
       top += height
       return box
     }
+    // A single-voice expanded lane stays ONE band (no per-voice sub-rows) but
+    // its height now SCALES with the sub-row setting too (#647), instead of a
+    // fixed `expandedHeight` constant that ignored it. Melodic → a tall pitch
+    // band (MELODIC_SINGLE_VOICE_ROWS rows, for the pianoroll spread);
+    // percussive → a single baseline row. So every expanded lane — 1 voice or
+    // many — responds to the same density slider.
+    if (isExpanded && voices.length === 1 && sub > 0) {
+      const rows = voices[0].melodic ? MELODIC_SINGLE_VOICE_ROWS : 1
+      const height = rows * sub
+      const box: LaneBox = { laneKey: lane.laneKey, top, height, expanded: true }
+      top += height
+      return box
+    }
+    // Collapsed lanes, and the degenerate no-voice / sub=0 expanded fallback,
+    // use the plain row / `expandedHeight` band.
     const height = isExpanded ? big : base
     const box: LaneBox = { laneKey: lane.laneKey, top, height, expanded: isExpanded }
     top += height

--- a/packages/app/tests/full-song-single-voice-expand-scale.spec.ts
+++ b/packages/app/tests/full-song-single-voice-expand-scale.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Full-song view: a single-voice expanded lane scales with the Timeline sub-row
+ * setting, like multi-voice lanes (#647).
+ *
+ * Bug: `computeLaneLayout` only scaled lanes with >= 2 voices; a single-voice
+ * lane expanded to a fixed `EXPANDED_ROW_HEIGHT` (96px) that ignored the
+ * setting. So a lone melodic lane (e.g. `$: note(...)`) stayed frozen at 96 while
+ * its neighbours grew/shrank with the slider — "really small" at a high setting.
+ *
+ * Fix: a single MELODIC voice → 4 × subRowHeight (a tall, scaling pitch band);
+ * a single PERCUSSIVE voice → 1 × subRowHeight. Guard: the melodic lane's
+ * expanded height tracks the slider and equals 4 × the setting.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+const MELODIC_ROWS = 4
+// d1 = 2-voice stack, d2 = single melodic note pattern, d3 = 3-voice drum stack.
+const CODE = `setcps(130/240)
+
+$: stack(
+  note("c4 e4 g4 b4").s("sawtooth").gain(0.3),
+  note("e3 g3 b3 e4").s("sine").gain(0.15)
+).viz("pianoroll")
+
+$: note("<c2 [g2 c2] f2 [g2 eb2]>").s("square").gain(0.4).viz("pitchwheel")
+
+$: stack(
+  s("hh*8").gain(0.3),
+  s("bd [~ bd] ~ bd").gain(0.5),
+  s("~ sd ~ [sd cp]").gain(0.4)
+).viz("wordfall")
+`
+
+async function bootAt(page: Page, subRow: number) {
+  // A tall viewport + tall drawer so the fully-expanded song (up to ~480px at the
+  // max sub-row) FITS without vertical overflow — otherwise the gutter rows get
+  // squished (the separate #645 gutter-collapse bug, not yet on this base) and
+  // the measured height under-reads the true layout height.
+  await page.setViewportSize({ width: 1280, height: 1100 })
+  await page.addInitScript(
+    ([sub]: string[]) => {
+      try {
+        window.localStorage.setItem('stave:bottomPanel.height', '860')
+        window.localStorage.setItem('stave:bottomPanel.open', 'true')
+        window.localStorage.setItem('stave:bottomPanel.activeTabId', 'musical-timeline')
+        window.localStorage.setItem('stave:musicalTimeline.subRowHeight', sub)
+      } catch {}
+    },
+    [String(subRow)],
+  )
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => (((window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco?.editor?.getEditors?.()?.length) ?? 0) > 0,
+    { timeout: 20_000 },
+  )
+  await page.evaluate((c) => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string; setValue?: (v: string) => void } | null; focus: () => void }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const ed = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    ed?.focus()
+    ed?.getModel()?.setValue?.(c)
+  }, CODE)
+  await page.waitForTimeout(500)
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1500)
+}
+
+async function heightsByLane(page: Page): Promise<Record<string, number>> {
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+  const expanders = page.locator('[data-full-song-lane-expand]')
+  const n = await expanders.count()
+  for (let i = 0; i < n; i++) { await expanders.nth(i).click({ force: true }); await page.waitForTimeout(120) }
+  await page.waitForTimeout(300)
+  return await page.evaluate(() => {
+    const out: Record<string, number> = {}
+    for (const l of Array.from(document.querySelectorAll('[data-full-song="lane-labels"] [data-full-song-lane]')) as HTMLElement[]) {
+      const k = l.getAttribute('data-full-song-lane')
+      if (k) out[k] = Math.round(l.getBoundingClientRect().height)
+    }
+    return out
+  })
+}
+
+test('#647 — a single melodic lane scales with the sub-row setting (small slider)', async ({ page }) => {
+  await bootAt(page, 12)
+  const h = await heightsByLane(page)
+  // d2 is the lone melodic lane → 4 × 12 = 48 (was frozen at 96).
+  expect(h.d2).toBe(MELODIC_ROWS * 12)
+})
+
+test('#647 — the same melodic lane grows with the setting (large slider)', async ({ page }) => {
+  await bootAt(page, 48)
+  const h = await heightsByLane(page)
+  // 4 × 48 = 192 — it MOVED with the slider instead of staying 96.
+  expect(h.d2).toBe(MELODIC_ROWS * 48)
+  // d1 (2 voices) and d3 (multi-voice) scale too — all expanded lanes respond.
+  expect(h.d1).toBe(2 * 48)
+})


### PR DESCRIPTION
## Summary

An expanded Song Timeline lane should respond to the **Timeline sub-row** size setting (Settings, 12–48px). Multi-voice lanes do (`voices × subRowHeight`), but a **single-voice lane** took the other branch and expanded to a hard-coded `EXPANDED_ROW_HEIGHT = 96px` that ignored the setting. So a lone melodic lane (e.g. `$: note(...)`) stayed frozen at 96 while its neighbours scaled — at a high setting it looked "really small" and never moved with the slider.

### Observed (expand all lanes, vary the slider)
```
subRow=12 → d1(2v)=24  d2(1 melodic)=96  d3(4v)=48
subRow=48 → d1(2v)=96  d2(1 melodic)=96  d3(4v)=192   ← d2 frozen
```

### Fix
A single-voice expanded lane now scales like the rest, while a melodic one keeps the room its pitch spread needs:
- **single MELODIC voice** → `MELODIC_SINGLE_VOICE_ROWS (4) × subRowHeight` — a tall, scaling pianoroll band (default 18 → 72px; range 48–192).
- **single PERCUSSIVE voice** → `1 × subRowHeight` — one baseline, like a drum row.
- Still rendered as ONE band (no per-voice sub-rows); only the height changes.

`EXPANDED_ROW_HEIGHT` remains only as the degenerate no-voice fallback.

## Test plan

- [x] In-browser observation: d2 now tracks the slider (**48 @ subRow=12, 192 @ subRow=48**) and renders a legible pitch spread (screenshot)
- [x] `laneLayout` unit tests updated (melodic single → 4×sub and scales; percussive single → 1×sub) — vitest **601 passed**
- [x] New e2e `full-song-single-voice-expand-scale.spec.ts` — asserts the melodic lane's expanded height equals `4 × setting` and moves with it
- [x] `tsc` clean · `eslint` clean
- [x] full-song e2e suite green (2 known P193 flakes, both pass solo)

closes #647

Base is `studio_v0.2.0` — the issue auto-closes at the studio→main merge.