### PR TITLE
💄 fix(timeline): drop the grid focus ring that bordered the whole bars area (#651)

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -1879,6 +1879,13 @@ const styles = {
     overflowY: 'hidden' as const,
     background: 'var(--bg-input, #0f0f1a)',
     cursor: 'pointer' as const,
+    // #651 — the grid is focusable (`tabIndex=0`) so it can route the clip-op
+    // keys (S / ⌘D / Delete) to the selected clip, and selecting a row focuses it
+    // programmatically. Suppress the browser's default focus ring: it draws a
+    // border around the WHOLE bars area (a stray "selected box") that competes
+    // with the real lane band. Focus here is mouse-driven, not keyboard
+    // navigation, and the selection band / clip rect already indicate state.
+    outline: 'none' as const,
   },
   // Sticky viewport pin for the interactive marks (#506) — mirrors the base
   // canvas + live overlay (sticky left:0, marginTop:-height set inline). Children

--- a/packages/app/tests/full-song-grid-focus-outline.spec.ts
+++ b/packages/app/tests/full-song-grid-focus-outline.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Full-song view: selecting a row must NOT draw the browser focus ring around
+ * the bars area (#651).
+ *
+ * The grid is `tabIndex=0` so it can route clip-op keys to the selected clip,
+ * and selecting a row focuses it programmatically. The browser's default
+ * `outline: auto` then bordered the WHOLE grid — a stray box competing with the
+ * lane band. The grid style now sets `outline: none`; this guards it.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+const CODE = `setcps(130/240)
+
+$: stack(note("c4 e4 g4 b4").s("sawtooth"), note("e3 g3 b3 e4").s("sine")).viz("pianoroll")
+$: note("<c2 g2 f2 eb2>").s("square").viz("pitchwheel")
+$: stack(s("hh*8"), s("bd ~ bd ~")).viz("wordfall")
+`
+
+async function boot(page: Page) {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('stave:bottomPanel.height', '420')
+      localStorage.setItem('stave:bottomPanel.open', 'true')
+      localStorage.setItem('stave:bottomPanel.activeTabId', 'musical-timeline')
+    } catch {}
+  })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => (((window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco?.editor?.getEditors?.()?.length) ?? 0) > 0,
+    { timeout: 20_000 },
+  )
+  await page.evaluate((c) => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string; setValue?: (v: string) => void } | null; focus: () => void }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const ed = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    ed?.focus()
+    ed?.getModel()?.setValue?.(c)
+  }, CODE)
+  await page.waitForTimeout(500)
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1500)
+}
+
+test('#651 — selecting a row focuses the grid but draws no focus-ring outline', async ({ page }) => {
+  await boot(page)
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+
+  const grid = page.locator('[data-full-song="grid"]')
+  const gb = await grid.boundingBox()
+  if (!gb) throw new Error('no grid box')
+
+  // Click a lane ROW → selects it AND focuses the grid (so clip-op keys work).
+  await page.mouse.click(gb.x + 200, gb.y + 30)
+  await page.waitForTimeout(250)
+
+  const state = await page.evaluate(() => {
+    const g = document.querySelector('[data-full-song="grid"]') as HTMLElement
+    const cs = getComputedStyle(g)
+    return {
+      gridIsFocused: document.activeElement === g,
+      outlineStyle: cs.outlineStyle,
+      outlineWidth: cs.outlineWidth,
+    }
+  })
+
+  // The grid is the focus target (so the clip-op keys still route here)…
+  expect(state.gridIsFocused).toBe(true)
+  // …but the browser focus RING is suppressed — no border around the bars area.
+  expect(state.outlineStyle).toBe('none')
+})


### PR DESCRIPTION
## Summary

Selecting a lane row focuses the grid container (`data-full-song="grid"`, `tabIndex=0`) so the clip-op keys (S / ⌘D / Delete) route to the selected clip. The browser then painted its default `outline: auto 1px` focus ring around the **entire grid** — a purple border around the whole bars area (incl. the empty space below the lanes), reading as a stray "selected box" competing with the lane-selection band.

### Fix
`outline: none` on the grid. Focus here is mouse-driven (programmatic), not keyboard navigation, and the selection band / clip rect already indicate state — so the ring is noise. The grid stays focusable, so the clip-op keys keep working.

## Test plan

- [x] Focus probe: `activeElement` = the grid div, `outline: auto 1px rgb(153,200,255)` → now `none`
- [x] New e2e `full-song-grid-focus-outline.spec.ts` — selected-row grid is focused but `outlineStyle: none` (fails on old code)
- [x] Clip-op + select-jump e2es green (grid focus preserved — keys still route)
- [x] app vitest · `tsc` clean · `eslint` clean (1 pre-existing unrelated warning)

closes #651

Base is `studio_v0.2.0` — the issue auto-closes at the studio→main merge.