### PR TITLE
✨ feat(timeline): vertical scrollbar so short drawers can scroll to hidden lanes (#655)

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -302,11 +302,21 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     return c && Number.isFinite(c.zoom) ? clampRestoreZoom(c.zoom) : MIN_ZOOM
   })
   const [scrollLeft, setScrollLeft] = useState(0)
+  // Vertical camera (#655) — the SAME pattern as scrollLeft, for the other axis.
+  // When the lanes overflow a short drawer, the grid scrolls Y natively
+  // (`overflowY: auto`); `scrollTop` mirrors that offset so the label gutter can
+  // translate in lockstep and the Y hit-tests can map client→content space.
+  const [scrollTop, setScrollTop] = useState(0)
   const [units, setUnits] = useState<RulerUnits>('cycles')
   const zoomRef = useRef(zoom)
   zoomRef.current = zoom
   const scrollLeftRef = useRef(scrollLeft)
   scrollLeftRef.current = scrollLeft
+  const scrollTopRef = useRef(scrollTop)
+  scrollTopRef.current = scrollTop
+  // The gutter's inner (translated) row stack — synced imperatively in the scroll
+  // handler so it tracks the grid's native vertical scroll with no React-commit lag.
+  const gutterInnerRef = useRef<HTMLDivElement | null>(null)
   const areaWidthRef = useRef(areaWidth)
   areaWidthRef.current = areaWidth
 
@@ -424,6 +434,13 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     const sl = e.currentTarget.scrollLeft
     scrollLeftRef.current = sl
     setScrollLeft((prev) => (prev === sl ? prev : sl))
+    // Vertical (#655): mirror the grid's native Y-scroll into `scrollTop` so the
+    // Y hit-tests can map client→content, and translate the gutter rows in the
+    // SAME frame (imperative — no React-commit lag against the native scroll).
+    const st = e.currentTarget.scrollTop
+    scrollTopRef.current = st
+    if (gutterInnerRef.current) gutterInnerRef.current.style.transform = `translateY(${-st}px)`
+    setScrollTop((prev) => (prev === st ? prev : st))
     // A scroll we didn't write (> 1px from our last programmatic value) is a
     // user drag/wheel-pan → suspend follow briefly so it doesn't fight them.
     if (Math.abs(sl - programmaticScrollRef.current) > 1) {
@@ -653,9 +670,10 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     (clientY: number) => {
       const el = areaRef.current
       if (!el) return
-      // The grid is full-height (vertical scroll lives on the parent body, which
-      // moves the grid's rect), so content-Y is just clientY minus the rect top.
-      const contentY = clientY - el.getBoundingClientRect().top
+      // content-Y = client-Y minus the grid's top, PLUS the grid's vertical scroll
+      // (#655) — the exact mirror of the content-X math (`+ scrollLeft`). The grid
+      // scrolls Y in place (it doesn't move its own rect), so the offset is needed.
+      const contentY = clientY - el.getBoundingClientRect().top + scrollTopRef.current
       const laneKey = laneAtY(layoutRef.current, contentY)
       if (laneKey != null) activateLane(laneKey)
     },
@@ -671,7 +689,7 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
       if (!onSelectLane) return
       const el = areaRef.current
       if (!el) return
-      const laneKey = laneAtY(layoutRef.current, clientY - el.getBoundingClientRect().top)
+      const laneKey = laneAtY(layoutRef.current, clientY - el.getBoundingClientRect().top + scrollTopRef.current)
       if (laneKey == null) return
       const lane = sceneRef.current.lanes.find((l) => l.laneKey === laneKey)
       const offset = lane?.labelOffset ?? lane?.sourceOffset ?? null
@@ -775,7 +793,7 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
       const rect = el.getBoundingClientRect()
       const cw = dragAwareContentWidth(rect.width)
       const contentX = clientX - rect.left + scrollLeftRef.current
-      const laneKey = laneAtY(layoutRef.current, clientY - rect.top)
+      const laneKey = laneAtY(layoutRef.current, clientY - rect.top + scrollTopRef.current)
       if (laneKey == null) return null
       const lane = sceneRef.current.lanes.find((l) => l.laneKey === laneKey)
       if (!lane) return null
@@ -812,7 +830,7 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
       const rect = el.getBoundingClientRect()
       const cw = dragAwareContentWidth(rect.width)
       const contentX = clientX - rect.left + scrollLeftRef.current
-      const laneKey = laneAtY(layoutRef.current, clientY - rect.top)
+      const laneKey = laneAtY(layoutRef.current, clientY - rect.top + scrollTopRef.current)
       if (laneKey == null) return null
       const lane = sceneRef.current.lanes.find((l) => l.laneKey === laneKey)
       if (!lane) return null
@@ -1340,7 +1358,23 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
           {layout.boxes.length === 0 ? (
             <div style={styles.emptyLabel}>No song to map yet — press play.</div>
           ) : (
-            layout.boxes.map((box) => {
+            <div
+              ref={gutterInnerRef}
+              data-full-song="lane-labels-inner"
+              style={{
+                display: 'flex',
+                flexDirection: 'column' as const,
+                // Keep the true total height (don't let the flex gutter squish the
+                // stack to its own height — the #645 squish, one level up).
+                flexShrink: 0,
+                // #655 — the gutter rows ride the grid's native vertical scroll. The
+                // transform is set imperatively in handleGridScroll (lag-free); this
+                // style keeps it correct across unrelated re-renders.
+                transform: `translateY(${-scrollTop}px)`,
+                willChange: 'transform',
+              }}
+            >
+            {layout.boxes.map((box) => {
               // An expanded multi-voice lane (#424) shows its identity on sub-row
               // 0 (`laneKey · voice0`, like the live monitor) and an indented
               // label per remaining voice, positioned from the SAME layout so
@@ -1502,7 +1536,8 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
                   ))}
                 </div>
               )
-            })
+            })}
+            </div>
           )}
         </div>
         {colorPickerLane && onSetTrackColor && (
@@ -1908,7 +1943,13 @@ const styles = {
     minWidth: 200,
     position: 'relative' as const,
     overflowX: 'auto' as const,
-    overflowY: 'hidden' as const,
+    // #655 — the grid is the vertical scrollport too (it already is the horizontal
+    // one). Its content is the full-`totalHeight` canvas, so `scrollHeight` already
+    // exceeds the viewport when lanes overflow a short drawer; `auto` surfaces a
+    // native Y-scrollbar that scrolls the canvas + marks. The label gutter is
+    // translated in lockstep from `handleGridScroll` (it keeps `overflow: clip`, so
+    // no #645 focus-drift). Both scrollbars stay pinned at the visible grid edges.
+    overflowY: 'auto' as const,
     background: 'var(--bg-input, #0f0f1a)',
     cursor: 'pointer' as const,
     // #651 — the grid is focusable (`tabIndex=0`) so it can route the clip-op

--- a/packages/app/tests/full-song-vertical-scroll.spec.ts
+++ b/packages/app/tests/full-song-vertical-scroll.spec.ts
@@ -1,0 +1,122 @@
+/**
+ * Full-song view: when the lanes overflow a short drawer, the grid must expose a
+ * vertical scrollbar and the label gutter must scroll in lockstep (#655).
+ *
+ * Bug: `#645` made both columns CLIP consistently (gutter `overflow: clip`, grid
+ * `overflowY: hidden`) — which fixed the collapse mismatch but left the lower rows
+ * unreachable: there was no way to scroll down to them.
+ *
+ * Fix: the grid is the vertical scrollport too (`overflowY: auto`) — its content is
+ * the full-`totalHeight` canvas, so `scrollHeight` already exceeds the viewport. The
+ * gutter rows are translated by `-scrollTop` in lockstep (kept `overflow: clip`, so
+ * no `#645` focus-drift), and the Y hit-tests add `scrollTop` (mirror of the X math).
+ *
+ * Guard (screenshot-free): at a short drawer the grid scrolls vertically; scrolling
+ * it translates the gutter inner row-stack by the SAME offset (lockstep); and a lane
+ * label that was below the fold becomes visible after scrolling to the bottom.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const K = {
+  height: 'stave:bottomPanel.height',
+  open: 'stave:bottomPanel.open',
+  activeTabId: 'stave:bottomPanel.activeTabId',
+}
+// Four lanes — even collapsed they exceed the short drawer's body height, so the
+// vertical overflow (and thus the scrollbar) is exercised without expanding.
+const CODE = `setcps(130/240)
+
+$: note("c4 e4 g4 b4").s("sawtooth").gain(0.3).viz("pianoroll")
+
+$: note("<c2 g2 f2 eb2>").s("square").gain(0.4).viz("pitchwheel")
+
+$: stack(
+  s("hh*8").gain(0.3),
+  s("bd [~ bd] ~ bd").gain(0.5)
+).viz("wordfall")
+
+$: s("cp*4").gain(0.35).viz("spectrum")
+`
+
+async function boot(page: Page, height: number) {
+  await page.addInitScript(
+    ([h, o, a, hv]: string[]) => {
+      try {
+        window.localStorage.setItem(h, hv)
+        window.localStorage.setItem(o, 'true')
+        window.localStorage.setItem(a, 'musical-timeline')
+      } catch {}
+    },
+    [K.height, K.open, K.activeTabId, String(height)],
+  )
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => (((window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco?.editor?.getEditors?.()?.length) ?? 0) > 0,
+    { timeout: 20_000 },
+  )
+  await page.evaluate((code) => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string; setValue?: (v: string) => void } | null; focus: () => void }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const ed = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    ed?.focus()
+    ed?.getModel()?.setValue?.(code)
+  }, CODE)
+  await page.waitForTimeout(500)
+  await page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string } | null; focus: () => void }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const ed = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    ed?.focus()
+  })
+  await page.keyboard.press(process.platform === 'darwin' ? 'Meta+Enter' : 'Control+Enter')
+  await page.waitForTimeout(1500)
+}
+
+test('#655 — a short drawer scrolls vertically; the gutter tracks the grid in lockstep', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(`console.error: ${m.text()}`) })
+
+  await boot(page, 120) // short — the lanes overflow the body height
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+
+  const grid = page.locator('[data-full-song="grid"]')
+  const inner = page.locator('[data-full-song="lane-labels-inner"]')
+
+  // 1) The grid now has a real vertical overflow (the precondition for a scrollbar).
+  const pre = await grid.evaluate((el) => ({ sh: el.scrollHeight, ch: el.clientHeight, st: el.scrollTop }))
+  expect(pre.sh, 'lanes should overflow the short drawer').toBeGreaterThan(pre.ch)
+  expect(pre.st).toBe(0)
+
+  // The last lane's gutter label starts below the fold (clipped by the short body).
+  const last = page.locator('[data-full-song-lane]').last()
+  const gridBox0 = (await grid.boundingBox())!
+  const lastBox0 = (await last.boundingBox())!
+  expect(lastBox0.y, 'last lane should start below the visible grid bottom').toBeGreaterThan(gridBox0.y + gridBox0.height - 4)
+
+  // 2) Scroll the grid to the bottom → the gutter inner stack translates by the
+  //    SAME offset (lockstep), driven by handleGridScroll.
+  const target = pre.sh - pre.ch
+  await grid.evaluate((el, top) => { el.scrollTop = top }, target)
+  await page.waitForTimeout(120)
+
+  const after = await grid.evaluate((el) => el.scrollTop)
+  expect(after).toBeCloseTo(target, 0)
+
+  // translateY(-after) — read back as a matrix (m41 == -after) or a translateY().
+  const dy = await inner.evaluate((el) => {
+    const t = getComputedStyle(el).transform
+    if (!t || t === 'none') return 0
+    const m = new DOMMatrixReadOnly(t)
+    return m.m42 // vertical translate
+  })
+  expect(dy, 'gutter inner tracks the grid scrollTop in lockstep').toBeCloseTo(-after, 0)
+
+  // 3) After scrolling to the bottom, the previously-clipped last lane label is now
+  //    within the visible grid band (the reveal the user asked for).
+  const gridBox1 = (await grid.boundingBox())!
+  const lastBox1 = (await last.boundingBox())!
+  expect(lastBox1.y).toBeGreaterThanOrEqual(gridBox1.y - 1)
+  expect(lastBox1.y + lastBox1.height).toBeLessThanOrEqual(gridBox1.y + gridBox1.height + 1)
+
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})


### PR DESCRIPTION
## What

When the Timeline (Song view) bottom panel is short and a song has more lanes than fit, the lower rows were **clipped and unreachable**. This adds a vertical scrollbar so you can scroll down to them.

| before | after |
|--------|-------|
| short drawer → lower lanes clipped, no way to reach them | grid scrolls vertically; gutter labels track in lockstep; hidden lanes revealed |

## Root cause

`#645` made both columns clip consistently (gutter `overflow: clip`, grid `overflowY: hidden`). The `body` row has `overflow: auto`, but its default `align-items: stretch` clamps both columns to the body height and their own clip/hidden swallow the excess — so `body` never overflows and no scrollbar appears. The original `#422` design *intended* vertical scroll (the canvas is `position: sticky; left: 0` — left-only — drawn at full `totalHeight`), but that path was lost.

## Fix

Make the grid the vertical scrollport too, mirroring the existing **horizontal** camera:

- **`grid.overflowY: auto`** — `grid.scrollHeight` is already `totalHeight` (the canvas), so a native Y-scrollbar scrolls the canvas + marks overlay for free (no canvas change). Both scrollbars stay pinned at the visible grid edges.
- **Gutter lockstep** — the label rows are translated by `-scrollTop` from `handleGridScroll` (imperative → no commit-lag; state-backed → survives re-renders). Keeps `overflow: clip`, so no `#645` focus-drift; the inner stack gets `flex-shrink: 0` to avoid a squish one level up.
- **Y hit-tests** — the four grid Y hit-tests add `scrollTop` (`clientY - rect.top + scrollTop`), the exact mirror of the content-X math (`+ scrollLeft`), so lane select / expand / clip ops stay correct after scrolling.

## Test plan

- `tsc` clean
- 206 app unit tests (incl. 40 `FullSongTimeline`)
- **new** `full-song-vertical-scroll.spec.ts` — at a short drawer the grid overflows, scrolling translates the gutter inner stack by the same offset (lockstep), and the previously-clipped last lane is revealed
- 17 related full-song e2e green (canvas, select-jump, clip-ops-e2e, arrange move/trim, expand-bind, single-voice-expand, clip-keys-focus)
- **Observed in the browser**: short drawer scrolls vertically; gutter tracks the grid in lockstep; the hidden lane is revealed; lane hit-tests after scrolling resolve to the correct lane

## Known minor limitations (documented, low severity)

- If lanes are removed *while scrolled to the bottom*, the gutter transform can be briefly stale until the next scroll (canvas/marks stay correct via native scroll; self-heals). No vertical re-clamp effect added, to keep the change tight.
- Classic (non-overlay) scrollbars only: the far-right clip X hit-test could be off by the scrollbar width when the Y-bar shows — a pre-existing `rect.width` pattern; moot on macOS overlay scrollbars.

closes #655