### PR TITLE
✨ feat(timeline): delete a bar of a bare loop carves a gap (#489)

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -161,10 +161,16 @@ export interface FullSongTimelineProps {
    *  source anchor + arm index; the parent parses the arrangement at the anchor
    *  and writes a surgical remove-arm edit. Optional — without it clips can't be
    *  selected/deleted. A combinator's SOLE remaining arm is not deletable
-   *  (a lane keeps ≥1 clip, PV122 #5); the serializer no-ops that case. */
+   *  (a lane keeps ≥1 clip, PV122 #5); the serializer no-ops that case.
+   *  #489 — for a bare track's implicit clip (`armIndex < 0`) Delete carves a
+   *  GAP at the SELECTED bar: `barIndex` is the clicked whole-cycle and `span`
+   *  the loop's floored display width, so the parent materializes
+   *  `arrange([…, pat], [1, silence], […, pat])`. Real arms ignore both. */
   readonly onDeleteClip?: (req: {
     sourceOffset: number | null
     armIndex: number
+    barIndex?: number
+    span?: number
   }) => void
   /** Move a clip by dragging its body horizontally (Phase 5c, #386). Only a REAL
    *  arrange/cat arm is movable: `reorder` swaps it to a new slot in the
@@ -738,6 +744,10 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     laneKey: string
     armIndex: number
     sourceOffset: number | null
+    // #489 — for a bare implicit clip (armIndex < 0), the whole-cycle the user
+    // clicked. Drives the 1-bar selection highlight + the Delete gap target.
+    // Undefined for real arms (their armIndex already addresses the clip).
+    barCycle?: number
   } | null>(null)
 
   // #649 — the clip-selection (`selected`) and the caret lane-selection
@@ -1108,7 +1118,21 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
         // A click selects the clip — real arm OR a bare track's implicit clip
         // (armIndex < 0), which is then splittable/deletable (#489) — AND jumps
         // the editor to that track's code (#610; seek now lives on the ruler).
-        setSelected({ laneKey: mv.laneKey, armIndex: mv.armIndex, sourceOffset: mv.sourceOffset })
+        // For a bare clip, record WHICH whole-cycle bar was clicked (the Delete
+        // gap target / 1-bar highlight); clamped to the clip's [start, end).
+        let barCycle: number | undefined
+        if (mv.armIndex < 0) {
+          const el = areaRef.current
+          if (el) {
+            const rect = el.getBoundingClientRect()
+            const cw = dragAwareContentWidth(rect.width)
+            const contentX = e.clientX - rect.left + scrollLeftRef.current
+            // Read the LIVE span via the ref (this fires imperatively on pointer-up).
+            const cyc = Math.floor(xToSongCycle(contentX, displayCyclesRef.current, cw))
+            barCycle = Math.max(mv.startCycle, Math.min(cyc, mv.endCycle - 1))
+          }
+        }
+        setSelected({ laneKey: mv.laneKey, armIndex: mv.armIndex, sourceOffset: mv.sourceOffset, barCycle })
         jumpToLaneAtClientY(e.clientY)
         return
       }
@@ -1121,7 +1145,7 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
         setSelected(null)
       }
     },
-    [jumpToLaneAtClientY, onMoveClip],
+    [jumpToLaneAtClientY, onMoveClip, dragAwareContentWidth],
   )
 
   // Unified pointer end: a live trim drag wins; otherwise resolve the body
@@ -1152,9 +1176,10 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
   const handleGridKeyDown = React.useCallback(
     (e: React.KeyboardEvent) => {
       if (!selected) return
-      // A bare track's implicit clip (armIndex < 0) supports only SPLIT — that
-      // materializes the combinator (#489). Deleting or duplicating the WHOLE
-      // uniform loop is out of scope (split first, then act on the pieces).
+      // A bare track's implicit clip (armIndex < 0) supports SPLIT and DELETE,
+      // both of which materialize the combinator (#489). DUPLICATE stays out of
+      // scope (cloning a uniform bar into arrange is audibly identical — a
+      // no-op the user can reach by split-then-edit).
       const bareClip = selected.armIndex < 0
       // ⌘/Ctrl-D duplicates the selected clip (insert a clone arm after it).
       if ((e.metaKey || e.ctrlKey) && (e.key === 'd' || e.key === 'D')) {
@@ -1167,9 +1192,25 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
         return
       }
       if (e.key === 'Delete' || e.key === 'Backspace') {
-        if (!onDeleteClip || bareClip) return
+        if (!onDeleteClip) return
         e.preventDefault()
-        onDeleteClip({ sourceOffset: selected.sourceOffset, armIndex: selected.armIndex })
+        if (bareClip) {
+          // #489 — silence the SELECTED bar of the bare loop (gap). Needs the
+          // clicked bar index + the loop's whole display span; the parent
+          // materializes arrange([…,pat],[1,silence],[…,pat]). Derive span from
+          // the live scene clip (its floored width, #489 D3).
+          const lane = sceneRef.current.lanes.find((l) => l.laneKey === selected.laneKey)
+          const clip = lane?.clips.find((c) => c.armIndex < 0)
+          if (!clip) return
+          onDeleteClip({
+            sourceOffset: selected.sourceOffset,
+            armIndex: selected.armIndex,
+            barIndex: selected.barCycle ?? clip.startCycle,
+            span: clip.endCycle - clip.startCycle,
+          })
+        } else {
+          onDeleteClip({ sourceOffset: selected.sourceOffset, armIndex: selected.armIndex })
+        }
         setSelected(null)
         return
       }
@@ -1206,8 +1247,13 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     const clip = lane?.clips.find((c) => c.armIndex === selected.armIndex)
     const box = layout.boxes.find((b) => b.laneKey === selected.laneKey)
     if (!lane || !clip || !box) return null
-    const left = songCycleToX(clip.startCycle, displayCycles, contentWidth)
-    const right = songCycleToX(clip.endCycle, displayCycles, contentWidth)
+    // #489 — a bare clip highlights only the SELECTED 1-cycle bar (what Delete
+    // silences), not the whole tiled loop; real arms highlight their full span.
+    const isBareBar = clip.armIndex < 0 && selected.barCycle != null
+    const startCycle = isBareBar ? (selected.barCycle as number) : clip.startCycle
+    const endCycle = isBareBar ? (selected.barCycle as number) + 1 : clip.endCycle
+    const left = songCycleToX(startCycle, displayCycles, contentWidth)
+    const right = songCycleToX(endCycle, displayCycles, contentWidth)
     return { left, width: Math.max(1, right - left), top: box.top, height: box.height }
   }, [selected, scene, layout, displayCycles, contentWidth])
 

--- a/packages/app/src/components/MusicalTimeline.tsx
+++ b/packages/app/src/components/MusicalTimeline.tsx
@@ -54,6 +54,7 @@ import {
   reorderArm,
   insertArm,
   splitArm,
+  materializeBareDelete,
   materializeBareSplit,
   detectPickControlAt,
   pickSetWeight,
@@ -436,7 +437,7 @@ export function MusicalTimeline(
   // track) is allowed. The debounced re-eval republishes the IR and the lane
   // re-derives. (`removeArm` stays in @stave/editor for a future ripple-delete.)
   const handleDeleteClip = React.useCallback(
-    (req: { sourceOffset: number | null; armIndex: number }) => {
+    (req: { sourceOffset: number | null; armIndex: number; barIndex?: number; span?: number }) => {
       if (!snapshot?.source || req.sourceOffset == null) return
       const call = detectArrangeAt(snapshot.code, req.sourceOffset)
       if (call) {
@@ -448,8 +449,23 @@ export function MusicalTimeline(
       }
       // #463 Stage 2 — pick* section clip.
       const ctl = detectPickControlAt(snapshot.code, req.sourceOffset)
-      if (!ctl || req.armIndex < 0 || req.armIndex >= ctl.arms.length) return
-      const edits = pickRemoveArm(snapshot.code, ctl, req.armIndex)
+      if (ctl) {
+        if (req.armIndex < 0 || req.armIndex >= ctl.arms.length) return
+        const edits = pickRemoveArm(snapshot.code, ctl, req.armIndex)
+        if (edits.length === 0) return
+        applyOffsetEditsToFile(snapshot.source, edits, 'arrange.structure', snapshot.code)
+        return
+      }
+      // #489 — bare loop: silence the SELECTED bar (gap) by materializing an
+      // arrange. detectBarePattern finds the pattern's range; materializeBareDelete
+      // rewrites `pat` → `arrange([lead, pat], [1, silence], [rest, pat])` at the
+      // clicked `barIndex` over the loop's `span`, keeping the bytes verbatim. The
+      // deliberate counterpart of split (#488 drag-to-wrap removal): silencing the
+      // SOLE bar would empty the track, which the serializer refuses (PV122 #5).
+      if (req.armIndex >= 0 || req.barIndex == null || req.span == null) return
+      const bare = detectBarePattern(snapshot.code, req.sourceOffset)
+      if (!bare) return
+      const edits = materializeBareDelete(snapshot.code, bare.patternRange, req.barIndex, req.span)
       if (edits.length === 0) return
       applyOffsetEditsToFile(snapshot.source, edits, 'arrange.structure', snapshot.code)
     },

--- a/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
+++ b/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
@@ -507,18 +507,22 @@ describe('FullSongTimeline — delete a clip (select body + Delete → remove-ar
     expect(onDeleteClip).not.toHaveBeenCalled()
   })
 
-  it('clicking the bare/implicit clip (hh lane) selects it, but Delete no-ops (#489)', async () => {
+  it('clicking the bare/implicit clip (hh lane) + Delete → gap at the clicked bar (#489)', async () => {
     const onDeleteClip = vi.fn()
     const { grid, container } = renderDeletable(onDeleteClip)
     await settle()
-    // hh row (y≈30) has only the implicit clip (armIndex −1). It IS selectable now
-    // (#489 — select → split), but deleting the WHOLE uniform loop is out of scope
-    // (split first), so Delete is a no-op for a bare clip.
+    // hh row (y≈30) has only the implicit clip (armIndex −1, span [0,4)). Clicking
+    // x≈200 (cycle 1) selects bar 1; Delete carves a GAP there — the parent
+    // materializes arrange([1,pat],[1,silence],[2,pat]) (#489). barIndex = the
+    // clicked whole-cycle, span = the bare clip's floored width.
     fireEvent.pointerDown(grid, { clientX: 200, clientY: 30, pointerId: 1 })
     fireEvent.pointerUp(grid, { clientX: 200, clientY: 30, pointerId: 1 })
     expect(container.querySelector('[data-full-song="clip-selection"]')).not.toBeNull()
     fireEvent.keyDown(grid, { key: 'Delete' })
-    expect(onDeleteClip).not.toHaveBeenCalled()
+    expect(onDeleteClip).toHaveBeenCalledTimes(1)
+    expect(onDeleteClip.mock.calls[0][0]).toMatchObject({ armIndex: -1, barIndex: 1, span: 4 })
+    // Selection clears after the delete fires.
+    expect(container.querySelector('[data-full-song="clip-selection"]')).toBeNull()
   })
 
   it('clicking a clip selects it but no longer seeks (#610 — seek moved to the ruler)', async () => {

--- a/packages/app/tests/full-song-bare-arrange.spec.ts
+++ b/packages/app/tests/full-song-bare-arrange.spec.ts
@@ -90,3 +90,36 @@ test('a bare loop is selectable and pressing S materializes the arrange', async 
   await page.screenshot({ path: 'test-results/bare-arrange.png' })
   expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
 })
+
+test('deleting a bar of a bare loop carves a GAP (#489) — materialize with silence', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await bootShell(page)
+  await typeSongAndEval(page, 's("bd*4")')
+
+  await page.locator('[data-full-song="root"]').waitFor({ timeout: 10_000 })
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+  await page.locator('[data-full-song-canvas]').waitFor({ timeout: 10_000 })
+  await page.waitForTimeout(400)
+
+  // The bare loop spans the floored 4-bar span. Click bar 1 (x ≈ 0.25·width → the
+  // [1,2) cycle) to select THAT bar, then Delete to silence it.
+  const grid = page.locator('[data-full-song="grid"]')
+  const box = await grid.boundingBox()
+  if (!box) throw new Error('no grid box')
+  await page.mouse.click(box.x + box.width * 0.25, box.y + 8)
+  await expect(page.locator('[data-full-song="clip-selection"]')).toBeVisible({ timeout: 5_000 })
+
+  // Delete carves a gap at bar 1: arrange([1,pat], [1, silence], [2,pat]) (#489).
+  await grid.press('Delete')
+  await expect.poll(() => strudelSource(page), { timeout: 8_000 }).toContain(
+    'arrange([1, s("bd*4")], [1, silence], [2, s("bd*4")])',
+  )
+
+  await page.screenshot({ path: 'test-results/bare-arrange-delete.png' })
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})


### PR DESCRIPTION
## Problem

A bare track loop (`$: s("bd*4")`) renders as **one implicit clip** spanning the floored display span (`MIN_BARE_SPAN = 4` bars). **Split** already materialized the `arrange` combinator, but **Delete was guarded out entirely** — the `materializeBareDelete` serializer existed and was unit-tested, yet nothing wired it. Selecting a bare loop and pressing Delete did nothing. The DAW model (#489) wants a deleted bar to leave a silent **gap** in place.

## Fix

Wire bare-clip Delete to the dormant serializer, **per-bar** (minimal model — Split unchanged):

- A bare clip's click-selection now records **which whole-cycle** was clicked (`selected.barCycle`), derived from the pointer X via the live span ref. The selection highlight shows just that **1-cycle bar** (what Delete silences), not the whole tiled loop.
- `handleGridKeyDown` Delete un-guards bare clips and forwards `barIndex` (the clicked bar) + `span` (the loop's floored width).
- `handleDeleteClip` routes a bare clip (`armIndex < 0`) through `detectBarePattern → materializeBareDelete` → `arrange([lead, pat], [1, silence], [rest, pat])`. Silencing the **sole** bar would empty the track and is refused by the serializer (a lane keeps ≥1 sounding clip, PV122 #5).

**Trim / Move / Duplicate stay unsupported on a bare loop by design** — they're semantic no-ops or redundant on a uniform infinite loop (Duplicate ≡ split-then-edit). This is the per-bar (minimal) option; the full per-bar-rendering model was considered and deferred.

## Test plan

- **Observed (real browser, Playwright)**: clicking bar 1 of `s("bd*4")` + Delete rewrites the source to `arrange([1, s("bd*4")], [1, silence], [2, s("bd*4")])` and the `d1` lane renders **content → gap → content** (screenshot `test-results/bare-arrange-delete.png`).
- New e2e case in `full-song-bare-arrange.spec.ts` (2 passing: split + delete).
- `FullSongTimeline` unit suite **40 green** — the stale `Delete no-ops (#489)` test is rewritten to assert the gap behavior (`{armIndex:-1, barIndex:1, span:4}`).
- App unit suite **601 green**; `tsc --noEmit` **0 errors**; lint **net −1 warning** (no new warnings).
- Serializer (`materializeBareDelete`) already unit-tested in `@stave/editor` (`arrange.test.ts` barIndex 0/2/3 + sole-bar refusal; `arrange-materialize-haps.test.ts` gap grounding). **App-only change** — no editor/dist rebuild.

Closes #489