### PR TITLE
✨ feat(timeline): resize a bare loop's displayed span (set-length) (#662)

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -214,6 +214,12 @@ export interface FullSongTimelineProps {
  *  extensible later via #487. A real arrangement already defines its own span. */
 const MIN_BARE_SPAN = 4
 
+/** The smallest span a user may SHRINK a bare loop to by dragging its edge
+ *  (#662). Two cycles keeps Split possible (a split needs ≥ 2 to yield two
+ *  non-empty arms). Once the user has resized, this clamp — not `MIN_BARE_SPAN`
+ *  — is the floor, so a tight 2-bar working area is reachable. */
+const MIN_BARE_SPLIT_SPAN = 2
+
 /** The natural display span: one loop period, or the analyzed horizon. ≥ 1. */
 function naturalSpan(analysis: SongAnalysis | null): number {
   if (!analysis) return 1
@@ -223,10 +229,24 @@ function naturalSpan(analysis: SongAnalysis | null): number {
 /** Display span in cycles. The natural span, but a pure bare loop is floored to
  *  `MIN_BARE_SPAN` so its single implicit clip is splittable (#489 D3). A real
  *  arrangement keeps its own length — flooring a period-2 arrange to 4 would paint
- *  empty bars past the last arm. ≥ 1. */
-function displaySpan(analysis: SongAnalysis | null, bareSong: boolean): number {
+ *  empty bars past the last arm. ≥ 1.
+ *
+ *  `bareSpanOverride` is the user's resized span (#662, option B): a view-only
+ *  preference that grows/shrinks the displayed bars with NO code write-back. When
+ *  set it REPLACES the `MIN_BARE_SPAN` floor with the shrinkable `MIN_BARE_SPLIT_SPAN`
+ *  clamp (so a 2-bar working area is reachable), but never drops below the true
+ *  content period (`natural`) — you can't show fewer bars than one full loop. */
+function displaySpan(
+  analysis: SongAnalysis | null,
+  bareSong: boolean,
+  bareSpanOverride?: number | null,
+): number {
   const natural = naturalSpan(analysis)
-  return bareSong ? Math.max(MIN_BARE_SPAN, natural) : natural
+  if (!bareSong) return natural
+  if (bareSpanOverride != null) {
+    return Math.max(MIN_BARE_SPLIT_SPAN, natural, Math.round(bareSpanOverride))
+  }
+  return Math.max(MIN_BARE_SPAN, natural)
 }
 
 /** Cycles of empty timeline kept PAST the dragged edge while EXTENDING the last
@@ -256,11 +276,24 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     }>
     return !evs.some((e) => typeof e.armIndex === 'number')
   }, [props.ir, natCycles])
+  // The user's resized display span for a pure bare loop (#662, option B). A
+  // VIEW-ONLY preference — dragging the bare clip's right edge grows/shrinks the
+  // bars shown with NO code write-back (the source `s("bd*4")` stays byte-identical;
+  // only Split/Delete write code). Seeded from the persisted camera so a reload
+  // restores it; persisted on change below. `null` = use the default floor. Ignored
+  // for a non-bare song (displaySpan gates on `bareSong`).
+  const [bareSpanOverride, setBareSpanOverride] = useState<number | null>(() => {
+    const c = loadTimelineCamera()
+    return c && typeof c.bareSpan === 'number' && Number.isFinite(c.bareSpan) ? c.bareSpan : null
+  })
+  const bareSpanOverrideRef = useRef<number | null>(bareSpanOverride)
+  bareSpanOverrideRef.current = bareSpanOverride
   // The TRUE content length — the rest span; also the playhead loop-wrap, the
   // note-mark collection window, and the bare-track implicit clip's end. The bare
-  // floor (#489) is folded in HERE so the clip extents use the floored span while
-  // the extend-drag (#487) layers a transient viewport span on top.
-  const loopCycles = displaySpan(analysis, bareSong)
+  // floor (#489) and the user's resize override (#662) are folded in HERE so the
+  // clip extents use the chosen span while the extend-drag (#487) layers a
+  // transient viewport span on top.
+  const loopCycles = displaySpan(analysis, bareSong, bareSpanOverride)
   // While EXTENDING the last clip, the visual span temporarily grows past the
   // content so there's empty timeline to drag into (#487). null at rest →
   // displayCycles == loopCycles (no permanent blank). `contentWidth` scales with
@@ -651,8 +684,14 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
   // (#501/U4). Global, best-effort; fires on each change — these are user
   // gestures (zoom button/wheel, expand toggle), not per-frame churn.
   useEffect(() => {
-    saveTimelineCamera({ zoom, expanded: [...expanded] })
-  }, [zoom, expanded])
+    saveTimelineCamera({
+      zoom,
+      expanded: [...expanded],
+      // #662 — the bare-loop resize is camera state too: omit when unset (null)
+      // so a never-resized song keeps its default floor on reload.
+      ...(bareSpanOverride != null ? { bareSpan: bareSpanOverride } : {}),
+    })
+  }, [zoom, expanded, bareSpanOverride])
 
   // Toggle a lane's expansion and bind it into the Pattern panel. Binding fires
   // on every activation (expand OR collapse) — clicking a lane selects it.
@@ -847,7 +886,11 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
       let best: NonNullable<ReturnType<typeof clipAtCycle>> | null = null
       let bestDist = CLIP_EDGE_GRIP_PX
       for (const clip of lane.clips) {
-        if (clip.armIndex < 0) continue // implicit/bare clip: not trimmable
+        // The implicit/bare clip's edge is grabbable ONLY in a pure bare song
+        // (#662 resize = set display span). A bare LANE inside a multitrack song
+        // (bareSong === false) has its span pinned by the other tracks — that
+        // harder case is deferred, so its edge stays inert.
+        if (clip.armIndex < 0 && !bareSong) continue
         const dist = Math.abs(contentX - songCycleToX(clip.endCycle, displayCycles, cw))
         if (dist <= bestDist) {
           best = clip
@@ -856,7 +899,7 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
       }
       return best ? { lane, clip: best } : null
     },
-    [onTrimClip, displayCycles, dragAwareContentWidth],
+    [onTrimClip, bareSong, displayCycles, dragAwareContentWidth],
   )
 
   // Apply an extend at a given clientX: map the cursor to a whole-cycle weight at
@@ -873,7 +916,11 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
       const ppc = restPxPerCycle(rect.width)
       if (ppc <= 0) return
       const contentX = clientX - rect.left + scrollLeftRef.current
-      const newEnd = Math.max(drag.startCycle + 1, Math.round(contentX / ppc))
+      // A bare resize (#662, armIndex < 0) clamps to MIN_BARE_SPLIT_SPAN so the
+      // loop never shrinks below a splittable 2 bars; a real arm keeps its ≥ 1
+      // cycle weight (startCycle + 1). Bare startCycle is 0, so newEnd === span.
+      const floor = drag.armIndex < 0 ? MIN_BARE_SPLIT_SPAN : drag.startCycle + 1
+      const newEnd = Math.max(floor, Math.round(contentX / ppc))
       drag.weight = newEnd - drag.startCycle
       const needed = Math.max(loopCyclesRef.current, newEnd + EXTEND_MARGIN_CYCLES)
       if (dragSpanRef.current == null || needed > dragSpanRef.current) {
@@ -1087,11 +1134,20 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
         /* best-effort */
       }
       if (commit && drag.weight !== drag.origWeight) {
-        onTrimClip?.({
-          sourceOffset: drag.sourceOffset,
-          armIndex: drag.armIndex,
-          weight: drag.weight,
-        })
+        if (drag.armIndex < 0) {
+          // #662 — a bare resize sets the DISPLAY span only (option B): persist
+          // the chosen bar count, write NO code. `drag.weight` is the new span
+          // (bare startCycle is 0). The override flows into `displaySpan`, and
+          // thence into the bare clip's `endCycle` — so a later Split/Delete
+          // operates at this granularity for free (they read the clip width).
+          setBareSpanOverride(drag.weight)
+        } else {
+          onTrimClip?.({
+            sourceOffset: drag.sourceOffset,
+            armIndex: drag.armIndex,
+            weight: drag.weight,
+          })
+        }
       }
     },
     [onTrimClip, stopExtendAutoScroll],

--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -286,8 +286,6 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     const c = loadTimelineCamera()
     return c && typeof c.bareSpan === 'number' && Number.isFinite(c.bareSpan) ? c.bareSpan : null
   })
-  const bareSpanOverrideRef = useRef<number | null>(bareSpanOverride)
-  bareSpanOverrideRef.current = bareSpanOverride
   // The TRUE content length — the rest span; also the playhead loop-wrap, the
   // note-mark collection window, and the bare-track implicit clip's end. The bare
   // floor (#489) and the user's resize override (#662) are folded in HERE so the

--- a/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
+++ b/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
@@ -775,3 +775,130 @@ describe('FullSongTimeline — NESTED combinator arm binds the OUTER arrange (#4
     expect(onTrimClip).toHaveBeenCalledWith({ sourceOffset: 0, armIndex: 0, weight: 1 })
   })
 })
+
+describe('FullSongTimeline — resize a bare loop (#662, set display span; option B = no write-back)', () => {
+  const settle = () => act(async () => { await Promise.resolve() })
+
+  // A PURE bare song mirroring `$: s("bd*4")`: one lane, content period 1 cycle
+  // (the pattern tiles every cycle). So the natural floor is 1 and the user can
+  // shrink the DISPLAY span down to the MIN_BARE_SPLIT_SPAN clamp (2). The fixture
+  // analysis used by the trim tests has period 4 — too coarse to exercise shrink.
+  const bareAnalysis: SongAnalysis = {
+    periodCycles: 1,
+    horizonCycles: 1,
+    reachedCap: false,
+    lanes: [{ laneKey: 'bd', onsetsByCycle: [4] }],
+    sections: [{ startCycle: 0, endCycle: 1, laneKeys: ['bd'] }],
+  }
+
+  // This test env ships a `window.localStorage` whose methods are non-functional,
+  // so install a real Map-backed Storage (mirrors timelineCameraPersistence.test)
+  // — the bare span override round-trips through it. Fresh per test → isolation.
+  let originalStorage: PropertyDescriptor | undefined
+  beforeEach(() => {
+    originalStorage = Object.getOwnPropertyDescriptor(window, 'localStorage')
+    const map = new Map<string, string>()
+    Object.defineProperty(window, 'localStorage', {
+      configurable: true,
+      writable: true,
+      value: {
+        get length() { return map.size },
+        clear: () => map.clear(),
+        getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+        key: (i: number) => Array.from(map.keys())[i] ?? null,
+        removeItem: (k: string) => map.delete(k),
+        setItem: (k: string, v: string) => { map.set(k, String(v)) },
+      } as Storage,
+    })
+  })
+  afterEach(() => {
+    if (originalStorage) Object.defineProperty(window, 'localStorage', originalStorage)
+  })
+
+  // BARE_EVENTS (no armIndex) → one implicit clip per lane spanning [0, displaySpan).
+  // `onTrimClip` is wired so the edge hit-test runs — but a bare resize must NEVER
+  // call it (option B writes no code). `onSplitClip` lets the split-at-span test
+  // observe the chosen granularity flowing through.
+  function renderBareResizable() {
+    const onTrimClip = vi.fn()
+    const onSplitClip = vi.fn()
+    const utils = renderFull({ analysis: bareAnalysis, ir: { bare: true } as never, onTrimClip, onSplitClip })
+    const grid = utils.container.querySelector('[data-full-song="grid"]') as HTMLElement
+    grid.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 800, height: 48, right: 800, bottom: 48, x: 0, y: 0, toJSON: () => ({}) }) as DOMRect
+    return { ...utils, grid, onTrimClip, onSplitClip }
+  }
+
+  const majors = (c: HTMLElement) => c.querySelectorAll('[data-full-song-tick="major"]').length
+
+  it('drags the bare clip’s right edge to EXTEND the span — grows bars, writes NO code', async () => {
+    const { grid, container, onTrimClip } = renderBareResizable()
+    await settle()
+    // At rest the bare loop is floored to MIN_BARE_SPAN (4) → 4 major ticks; its
+    // single implicit clip’s right edge sits at the song end (cycle 4 → x=800).
+    expect(majors(container as unknown as HTMLElement)).toBe(4)
+    // Grab the bare edge (x=798, 2px inside) in the bd row (y≈10) and drag RIGHT to
+    // a content-x mapping to cycle 6 (1200px at the constant 200px/cycle).
+    fireEvent.pointerDown(grid, { clientX: 798, clientY: 10, pointerId: 1 })
+    fireEvent.pointerMove(grid, { clientX: 1200, clientY: 10, pointerId: 1 })
+    // Mid-drag the transient extend room is real timeline: max(4, 6 + MARGIN 2) = 8.
+    expect(majors(container as unknown as HTMLElement)).toBe(8)
+    fireEvent.pointerUp(grid, { clientX: 1200, clientY: 10, pointerId: 1 })
+    // On release the OVERRIDE persists (unlike #487 real-trim, which collapses the
+    // room): displaySpan = max(2, natural 1, override 6) = 6 → 6 majors that STAY.
+    expect(majors(container as unknown as HTMLElement)).toBe(6)
+    // Option B observation gate: NO code write-back — the set-weight handler is
+    // never called. Only Split/Delete (separate gestures) write code.
+    expect(onTrimClip).not.toHaveBeenCalled()
+  })
+
+  it('drags the edge LEFT to shrink — clamped at MIN_BARE_SPLIT_SPAN (2) so Split stays possible', async () => {
+    const { grid, container, onTrimClip } = renderBareResizable()
+    await settle()
+    expect(majors(container as unknown as HTMLElement)).toBe(4)
+    // Grab the edge (cycle 4 → x=798) and drag hard LEFT past cycle 0 (x=0). The
+    // bare clamp floors the span at 2 — never below a splittable 2 bars.
+    fireEvent.pointerDown(grid, { clientX: 798, clientY: 10, pointerId: 1 })
+    fireEvent.pointerMove(grid, { clientX: 0, clientY: 10, pointerId: 1 })
+    fireEvent.pointerUp(grid, { clientX: 0, clientY: 10, pointerId: 1 })
+    // displaySpan = max(2, natural 1, override 2) = 2 → 2 majors.
+    expect(majors(container as unknown as HTMLElement)).toBe(2)
+    expect(onTrimClip).not.toHaveBeenCalled()
+  })
+
+  it('persists the resized span to the camera and restores it on a fresh mount (reload)', async () => {
+    const first = renderBareResizable()
+    await settle()
+    fireEvent.pointerDown(first.grid, { clientX: 798, clientY: 10, pointerId: 1 })
+    fireEvent.pointerMove(first.grid, { clientX: 1200, clientY: 10, pointerId: 1 })
+    fireEvent.pointerUp(first.grid, { clientX: 1200, clientY: 10, pointerId: 1 })
+    expect(majors(first.container as unknown as HTMLElement)).toBe(6)
+    // The override landed in the persisted camera under `bareSpan`.
+    const cam = JSON.parse(window.localStorage.getItem('stave:timelineCamera') ?? '{}')
+    expect(cam.bareSpan).toBe(6)
+    cleanup()
+    // A fresh mount (a reload) seeds the override from the camera → 6 bars with NO
+    // drag. This is the "persists across reload" guarantee at the unit level.
+    const second = renderBareResizable()
+    await settle()
+    expect(majors(second.container as unknown as HTMLElement)).toBe(6)
+  })
+
+  it('after extending to 6, selecting the bare clip + S splits at the CHOSEN span (6), not the floor (4)', async () => {
+    const { grid, onSplitClip } = renderBareResizable()
+    await settle()
+    // Extend to 6 bars.
+    fireEvent.pointerDown(grid, { clientX: 798, clientY: 10, pointerId: 1 })
+    fireEvent.pointerMove(grid, { clientX: 1200, clientY: 10, pointerId: 1 })
+    fireEvent.pointerUp(grid, { clientX: 1200, clientY: 10, pointerId: 1 })
+    // Select the bare clip (a click that does NOT travel) in the bd row.
+    fireEvent.pointerDown(grid, { clientX: 200, clientY: 10, pointerId: 1 })
+    fireEvent.pointerUp(grid, { clientX: 200, clientY: 10, pointerId: 1 })
+    // `S` materializes the combinator at the bare clip’s width — now 6, the chosen
+    // span — so split → arrange([3, pat], [3, pat]). The span flows through the
+    // clip’s endCycle (= displaySpan) for free, no serializer change (#662).
+    fireEvent.keyDown(grid, { key: 's' })
+    expect(onSplitClip).toHaveBeenCalledTimes(1)
+    expect(onSplitClip.mock.calls[0][0]).toMatchObject({ armIndex: -1, firstWeight: 3, span: 6 })
+  })
+})

--- a/packages/app/src/components/musicalTimeline/timelineCameraPersistence.ts
+++ b/packages/app/src/components/musicalTimeline/timelineCameraPersistence.ts
@@ -23,10 +23,13 @@
 const STORAGE_KEY = 'stave:timelineCamera'
 
 /** The persisted shape. `zoom` is the raw multiplier (the caller clamps it to
- *  the live MIN/MAX range on read); `expanded` is the lane-key list. */
+ *  the live MIN/MAX range on read); `expanded` is the lane-key list; `bareSpan`
+ *  is the user's resized display span for a pure bare loop (#662 — how many bars
+ *  its single implicit clip shows), absent until the user drags the edge. */
 export interface TimelineCamera {
   readonly zoom: number
   readonly expanded: readonly string[]
+  readonly bareSpan?: number
 }
 
 /**
@@ -47,7 +50,13 @@ export function loadTimelineCamera(): TimelineCamera | null {
     const expanded = Array.isArray(parsed.expanded)
       ? parsed.expanded.filter((k): k is string => typeof k === 'string')
       : []
-    return { zoom, expanded }
+    // A finite, positive bare span survives; anything else is omitted (the
+    // caller re-applies its own floor/clamp on read, #662).
+    const bareSpan =
+      typeof parsed.bareSpan === 'number' && Number.isFinite(parsed.bareSpan) && parsed.bareSpan > 0
+        ? parsed.bareSpan
+        : undefined
+    return bareSpan != null ? { zoom, expanded, bareSpan } : { zoom, expanded }
   } catch {
     return null
   }
@@ -62,7 +71,13 @@ export function saveTimelineCamera(camera: TimelineCamera): void {
   try {
     window.localStorage.setItem(
       STORAGE_KEY,
-      JSON.stringify({ zoom: camera.zoom, expanded: [...camera.expanded] }),
+      JSON.stringify({
+        zoom: camera.zoom,
+        expanded: [...camera.expanded],
+        // Persist the bare-loop span only when set (#662) — omit the key
+        // otherwise so a song that was never resized stays at its default floor.
+        ...(camera.bareSpan != null ? { bareSpan: camera.bareSpan } : {}),
+      }),
     )
   } catch {
     /* best-effort persistence */

--- a/packages/app/tests/full-song-bare-resize.spec.ts
+++ b/packages/app/tests/full-song-bare-resize.spec.ts
@@ -1,0 +1,207 @@
+/**
+ * Full-song view: RESIZE a bare loop's displayed span (set-length, #662) —
+ * Playwright observation (AnviDev observe gate).
+ *
+ * A bare loop (`$: s("bd*4")`, period 1) shows as ONE implicit clip floored to
+ * MIN_BARE_SPAN (4 bars). #662 lets the user drag its right edge to choose how
+ * many bars it shows — option B: a VIEW-ONLY display span (persisted to the
+ * timeline camera), with NO code write-back. The source stays byte-identical;
+ * only a real structural op (Split/Delete) writes code, now at the chosen span.
+ *
+ * The observation gate for option B is the byte-for-byte source check after a
+ * resize: the whole point is that dragging the edge mutates NO code. We TYPE the
+ * song (not setValue) so the onChange → file store → IR-snapshot path fires.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+const BARE_SONG = 's("bd*4")'
+
+async function bootShell(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('stave:bottomPanel.height', '340')
+      localStorage.setItem('stave:bottomPanel.open', 'true')
+      localStorage.setItem('stave:bottomPanel.activeTabId', 'musical-timeline')
+    } catch {
+      /* ignore */
+    }
+  })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await waitForMonaco(page)
+}
+
+async function waitForMonaco(page: Page): Promise<void> {
+  await page.waitForFunction(
+    () => ((window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco?.editor?.getEditors?.()?.length ?? 0) > 0,
+    { timeout: 20_000 },
+  )
+}
+
+async function typeSongAndEval(page: Page, code: string): Promise<void> {
+  await page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string } | null; focus: () => void }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    t?.focus()
+  })
+  await page.locator('.monaco-editor').first().click()
+  await page.keyboard.press(`${MOD}+A`)
+  await page.keyboard.press('Backspace')
+  await page.keyboard.type(code, { delay: 8 })
+  await page.waitForTimeout(400)
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1800)
+}
+
+function strudelSource(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string; getValue: () => string } | null }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    return t?.getModel()?.getValue() ?? ''
+  })
+}
+
+async function waitForSongView(page: Page): Promise<void> {
+  await page.locator('[data-full-song="root"]').waitFor({ timeout: 10_000 })
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+  await page.locator('[data-full-song-canvas]').waitFor({ timeout: 10_000 })
+  await page.waitForTimeout(400)
+}
+
+const majorCount = (page: Page): Promise<number> =>
+  page.locator('[data-full-song-tick="major"]').count()
+
+test('extending a bare loop’s edge grows the display span and writes NO code, persisting across reload (#662)', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await bootShell(page)
+  await typeSongAndEval(page, BARE_SONG)
+  await waitForSongView(page)
+
+  // At rest the bare loop is floored to 4 bars → 4 major ticks. The source is the
+  // bare pattern verbatim.
+  expect(await majorCount(page)).toBe(4)
+  expect((await strudelSource(page)).trim()).toBe(BARE_SONG)
+
+  // Grab the bare clip's right edge (the song end, at the wall) and HOLD in the
+  // right-edge band so the rAF auto-scroll pulls more empty timeline in and the
+  // edge follows — the same #487 mechanic, here growing the DISPLAY span.
+  const grid = page.locator('[data-full-song="grid"]')
+  const box = await grid.boundingBox()
+  if (!box) throw new Error('no grid box')
+  const bandX = box.x + box.width - 3
+  const y = box.y + 8
+  await page.mouse.move(box.x + box.width - 2, y)
+  await page.mouse.down()
+  for (let i = 0; i < 6; i++) {
+    await page.mouse.move(bandX, y)
+    await page.waitForTimeout(50)
+  }
+  await page.mouse.up()
+  await page.waitForTimeout(300)
+
+  // The display span GREW (more bars than the 4-bar floor)…
+  const grown = await majorCount(page)
+  expect(grown).toBeGreaterThan(4)
+  // …and the OBSERVATION GATE for option B: the source is byte-identical — the
+  // resize wrote no code. Only Split/Delete write code.
+  expect((await strudelSource(page)).trim()).toBe(BARE_SONG)
+
+  // Persist + reload: the camera carries the resized span across a fresh session.
+  await page.waitForTimeout(300)
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await waitForMonaco(page)
+  await typeSongAndEval(page, BARE_SONG)
+  await waitForSongView(page)
+
+  // The restored span matches the resized one (same override, same viewport).
+  expect(await majorCount(page)).toBe(grown)
+
+  await page.screenshot({ path: 'test-results/bare-resize-extend.png' })
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})
+
+test('shrinking a bare loop is clamped at 2 bars so Split stays possible (#662)', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await bootShell(page)
+  await typeSongAndEval(page, BARE_SONG)
+  await waitForSongView(page)
+  expect(await majorCount(page)).toBe(4)
+
+  // Drag the edge hard LEFT toward cycle 0. The bare clamp floors the span at 2 —
+  // never below a splittable 2 bars. In-viewport, so no auto-scroll needed.
+  const grid = page.locator('[data-full-song="grid"]')
+  const box = await grid.boundingBox()
+  if (!box) throw new Error('no grid box')
+  const y = box.y + 8
+  await page.mouse.move(box.x + box.width - 2, y)
+  await page.mouse.down()
+  await page.mouse.move(box.x + box.width * 0.4, y)
+  await page.mouse.move(box.x + 4, y)
+  await page.mouse.up()
+  await page.waitForTimeout(300)
+
+  // Clamped to 2 bars, and still no code write-back.
+  expect(await majorCount(page)).toBe(2)
+  expect((await strudelSource(page)).trim()).toBe(BARE_SONG)
+
+  await page.screenshot({ path: 'test-results/bare-resize-shrink.png' })
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})
+
+test('Split after an extend materializes the arrange at the CHOSEN span, not the 4-bar floor (#662)', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await bootShell(page)
+  await typeSongAndEval(page, BARE_SONG)
+  await waitForSongView(page)
+  expect(await majorCount(page)).toBe(4)
+
+  const grid = page.locator('[data-full-song="grid"]')
+  const box = await grid.boundingBox()
+  if (!box) throw new Error('no grid box')
+  const y = box.y + 8
+  // Extend the span past 4 bars (hold in the right-edge band).
+  await page.mouse.move(box.x + box.width - 2, y)
+  await page.mouse.down()
+  for (let i = 0; i < 6; i++) {
+    await page.mouse.move(box.x + box.width - 3, y)
+    await page.waitForTimeout(50)
+  }
+  await page.mouse.up()
+  await page.waitForTimeout(300)
+  const span = await majorCount(page)
+  expect(span).toBeGreaterThan(4)
+
+  // Select the bare clip (a click that doesn't drag) and Split it.
+  await page.mouse.click(box.x + box.width * 0.25, y)
+  await expect(page.locator('[data-full-song="clip-selection"]')).toBeVisible({ timeout: 5_000 })
+  await grid.press('s')
+
+  // The materialized arrange splits the CHOSEN span: two `s("bd*4")` arms whose
+  // weights sum to the resized bar count (> 4) — not the default floor of 4.
+  await expect.poll(() => strudelSource(page), { timeout: 8_000 }).toContain('arrange(')
+  const src = await strudelSource(page)
+  const arms = [...src.matchAll(/\[(\d+),\s*s\("bd\*4"\)\]/g)].map((m) => Number(m[1]))
+  expect(arms.length).toBe(2)
+  expect(arms[0] + arms[1]).toBe(span)
+  expect(arms[0] + arms[1]).toBeGreaterThan(4)
+
+  await page.screenshot({ path: 'test-results/bare-resize-split.png' })
+  expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
+})


### PR DESCRIPTION
## Summary

Drag a bare track loop's right edge to choose **how many bars it shows** — the DAW "resize a looped region" reflex, now available for bare loops (`s("bd*4")`).

Grounded last session as **option B** (DAW manuals + queried Strudel haps + 16-tune corpus, see #662): the resize is a **view-only display span** with **NO code write-back**. The source stays byte-identical; only a real structural op (Split/Delete) writes code — now at the chosen span, for free, since they read the clip width.

> **Stacked on #661** (`feat/489-bare-clip-delete`). Base retargets to `studio_v0.2.0` once #661 merges. The diff here is #662-only.

## What changed (all `packages/app`, app-only — no editor/serializer/dist change)

- **`timelineCameraPersistence`** — `TimelineCamera` gains `bareSpan`; persisted only when set, so a never-resized song keeps its default floor.
- **`displaySpan(analysis, bareSong, override?)`** — an override replaces the `MIN_BARE_SPAN` (4) floor with the shrinkable `MIN_BARE_SPLIT_SPAN` (2) clamp (so Split stays possible), never below the true content period.
- **`clipEdgeAt`** grabs the bare clip's edge **only in a pure bare song**; a bare lane inside a multitrack stays **deferred by design**.
- **`applyTrim`** clamps a bare drag's floor to 2; **`endTrimDrag`** routes a bare commit to a persistent span override, **never `onTrimClip`** (no write-back).
- The override flows into the bare clip's `endCycle` (= `displaySpan`), so **Split/Delete operate at the chosen span with no serializer change**.

## Test plan

- **Unit** (`FullSongTimeline.test.tsx`, +4): extend grows span + `onTrimClip` never fires; shrink clamps at 2; resize persists → fresh mount restores; Split uses the chosen span. **605 app tests green, tsc clean.**
- **e2e** (`full-song-bare-resize.spec.ts`, new — real browser, AnviDev observe gate):
  - extend → bars grow, **source byte-identical**, **persists across reload**
  - shrink → clamped at 2 bars, source byte-identical
  - Split after extending to 5 → materializes `arrange([2, s("bd*4")], [3, s("bd*4")])` (chosen span, not the 4-bar floor)
- **Observed** via screenshots; **#487 (real-clip extend) and #489 (bare split/delete) e2e unregressed.**

## Scope boundary

First cut targets the **pure bare song** (`s("bd*4")` alone). A bare lane inside a multitrack (span already pinned by other tracks) is deferred — the edge stays inert there by the `bareSong` gate.

Closes #662