### PR TITLE
Lock `<…>` as an atomic bare clip (resolve #666)

### DIFF
--- a/packages/app/tests/full-song-cycle-bare-clip.spec.ts
+++ b/packages/app/tests/full-song-cycle-bare-clip.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * #666 (resolved as "already supported") — a whole-string `<a b c>` is ONE atomic
+ * bare clip; the existing bare clip ops (split #488, delete-gap #489) materialize
+ * it into `arrange` arms whose pattern is the WHOLE `<a b c>`, NOT a per-arm (a/b/c)
+ * decomposition. `<a b c>` behaves like any other clip on the Song Timeline.
+ *
+ * Regression lock: the arm content (`<a b c>`) is NEVER split apart by a clip op —
+ * per-note editing is the Pattern tab's job. Guards against re-introducing a
+ * per-arm `armIndex` decomposition of mini `<…>` in the collect walk.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+async function bootShell(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('stave:bottomPanel.height', '340')
+      localStorage.setItem('stave:bottomPanel.open', 'true')
+      localStorage.setItem('stave:bottomPanel.activeTabId', 'musical-timeline')
+    } catch {
+      /* ignore */
+    }
+  })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => ((window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco?.editor?.getEditors?.()?.length ?? 0) > 0,
+    { timeout: 20_000 },
+  )
+}
+
+async function typeSongAndEval(page: Page, code: string): Promise<void> {
+  await page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string } | null; focus: () => void }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    t?.focus()
+  })
+  await page.locator('.monaco-editor').first().click()
+  await page.keyboard.press(`${MOD}+A`)
+  await page.keyboard.press('Backspace')
+  await page.keyboard.type(code, { delay: 8 })
+  await page.waitForTimeout(400)
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(1800)
+}
+
+function strudelSource(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const eds = ((window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string; getValue: () => string } | null }> } } }).monaco?.editor?.getEditors?.()) ?? []
+    const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    return t?.getModel()?.getValue() ?? ''
+  })
+}
+
+async function selectFirstClip(page: Page) {
+  await page.locator('[data-full-song="root"]').waitFor({ timeout: 10_000 })
+  await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
+  await page.locator('[data-full-song-canvas]').waitFor({ timeout: 10_000 })
+  await page.waitForTimeout(400)
+  const grid = page.locator('[data-full-song="grid"]')
+  const box = await grid.boundingBox()
+  if (!box) throw new Error('no grid box')
+  await page.mouse.click(box.x + box.width * 0.25, box.y + 8)
+  await expect(page.locator('[data-full-song="clip-selection"]')).toBeVisible({ timeout: 5_000 })
+  return grid
+}
+
+test('a bare `<a b c>` clip splits into atomic arrange spans (whole pattern per arm, #666)', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(`console.error: ${m.text()}`) })
+
+  await bootShell(page)
+  await typeSongAndEval(page, 's("<a b c>")')
+  const grid = await selectFirstClip(page)
+
+  await grid.press('s')
+  // Split materializes the WHOLE `<a b c>` as two atomic 2-cycle-span arms — the
+  // same bare→arrange path uniform loops use, NOT a per-arm (a/b/c) decomposition.
+  await expect.poll(() => strudelSource(page), { timeout: 8_000 }).toBe(
+    'arrange([2, s("<a b c>")], [2, s("<a b c>")])',
+  )
+  expect(errors, `errors:\n${errors.join('\n')}`).toEqual([])
+})
+
+test('deleting a bar of a bare `<a b c>` clip carves a gap around the whole pattern (#666)', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(`console.error: ${m.text()}`) })
+
+  await bootShell(page)
+  await typeSongAndEval(page, 's("<a b c>")')
+  const grid = await selectFirstClip(page)
+
+  await grid.press('Delete')
+  // Delete carves a silent gap AROUND the whole `<a b c>` (bare→arrange #489),
+  // never touching the arms.
+  await expect.poll(() => strudelSource(page), { timeout: 8_000 }).toBe(
+    'arrange([1, s("<a b c>")], [1, silence], [2, s("<a b c>")])',
+  )
+  expect(errors, `errors:\n${errors.join('\n')}`).toEqual([])
+})


### PR DESCRIPTION
## Resolution: #666 was a category error — already supported

#666 proposed making a mini `<a b c>` slowcat "addressable" by splitting it into N per-arm timeline clips. That crosses the **Timeline↔Pattern layer boundary**:

- **`<a b c>`'s clip identity is the whole pattern** (one atomic block) — exactly like a bare loop or an `arrange` arm.
- Its **per-bar a/b/c content is the Pattern tab's job** (a whole-string `<…>` already opens the sequencer/piano-roll grid).

The atomic-clip workflow the issue actually wanted already ships via the bare→arrange path (#489/#488/#662). Verified in the browser on baseline studio:

| op | result |
|---|---|
| split `s("<a b c>")` | `arrange([2, s("<a b c>")], [2, s("<a b c>")])` |
| delete a span | `arrange([1, s("<a b c>")], [1, silence], [2, s("<a b c>")])` |

…and the arm-level ops then split/delete those spans further — all treating `<a b c>` as the atomic unit.

## What this PR does

**No product code.** A prototype that decomposed `<…>` per-arm (stamping `armIndex` in `collect.ts`) was built, observed to be the wrong layer, and reverted. This lands only a **regression lock**: `full-song-cycle-bare-clip.spec.ts` drives the existing bare ops on `s("<a b c>")` and asserts the whole pattern is arranged atomically (arms never split apart) — guarding against re-introducing the per-arm mistake.

## Test plan

- `pnpm exec playwright test full-song-cycle-bare-clip` — 2 tests green (split + delete exact-string assertions).

Closes #666
