### PR TITLE
🙈 chore(app): hide the IR debugger tab from the left panel (keep the code)

### DIFF
--- a/packages/app/src/components/StaveApp.tsx
+++ b/packages/app/src/components/StaveApp.tsx
@@ -1031,7 +1031,7 @@ export function StaveApp({ initialProject }: StaveAppProps) {
       render: () => null,
     }));
     // IR debugger (IR Inspector) — hidden from the left activity bar until the
-    // full breakpoint-driven music debugger flow lands (#678). The panel, its
+    // full breakpoint-driven music debugger flow lands (re-enable: #680). The panel, its
     // render block below (`activePanelId === "ir-inspector"`), the engine
     // capture, and the breakpoint wiring are all intentionally KEPT intact;
     // only this tab registration is disabled so nothing surfaces in the UI.

--- a/packages/app/src/components/StaveApp.tsx
+++ b/packages/app/src/components/StaveApp.tsx
@@ -1030,13 +1030,21 @@ export function StaveApp({ initialProject }: StaveAppProps) {
       order: 50,
       render: () => null,
     }));
-    unregs.push(registerPanel({
-      id: "ir-inspector",
-      title: "IR Inspector",
-      icon: "inspect",
-      order: 60,
-      render: () => null,
-    }));
+    // IR debugger (IR Inspector) — hidden from the left activity bar until the
+    // full breakpoint-driven music debugger flow lands (#678). The panel, its
+    // render block below (`activePanelId === "ir-inspector"`), the engine
+    // capture, and the breakpoint wiring are all intentionally KEPT intact;
+    // only this tab registration is disabled so nothing surfaces in the UI.
+    // `activePanelId` is not persisted and can only reach "ir-inspector" via
+    // this (now-absent) tab button, so the render block is safely dormant.
+    // To restore: un-comment the registerPanel call below.
+    // unregs.push(registerPanel({
+    //   id: "ir-inspector",
+    //   title: "IR Inspector",
+    //   icon: "inspect",
+    //   order: 60,
+    //   render: () => null,
+    // }));
     return () => { for (const u of unregs) u(); };
   }, [activeProject, handleRenameActiveProject, openSnapshotPanel, handleShareProject]);
 


### PR DESCRIPTION
Part of #673 (v0.2.0 pre-merge polish). Closes #678.

## What
Hides the **IR Inspector / IR debugger** tab from the left activity bar — **UI only, no deletion**. The debugger isn't useful without the full breakpoint flow, but it's kept for the upcoming breakpoint-driven music debugger.

- Comment out only the `registerPanel({ id: "ir-inspector", ... })` call in `StaveApp.tsx`, with a restore note.
- **Everything else stays**: `IRInspectorPanel/Timeline/Chrome`, the `activePanelId === "ir-inspector"` render block, engine `irInspector.ts`/`timelineCapture.ts`, and `useBreakpoints.ts`.

## Why this is safe
`activePanelId` is not persisted (resets to `explorer` each session) and can only reach `"ir-inspector"` via the now-absent tab button — so the render block is **dormant, not dead**. To restore: un-comment the one call.

## Test plan
- ✅ App suite — 34 files / 605 tests (none asserted the tab's presence)
- ✅ `next build` — exit 0 (route table generated)
- 👀 :3000 — IR Inspector no longer in the left activity bar

_Note: unrelated — found & killed 12 stale `tsup --watch` zombies that were re-corrupting the tracked editor `dist`; restored dist to HEAD so this PR touches only `StaveApp.tsx`._