### PR TITLE
🐛 fix(app): keep the Find/Replace widget opaque over a viz backdrop

### DIFF
--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -171,11 +171,12 @@ body {
    - selection / highlight decorations which paint via background-color;
    - the text CARET (`.cursor`) — Monaco renders the caret bar AS its
      background-color, so blanking it makes the cursor invisible (#598);
-   - the floating popup widgets (suggest / hover / signature help) — their
-     readable opaque theme surface must survive over the viz, else the
-     IntelliSense docs box goes transparent and unreadable (#598). */
+   - the floating popup widgets (suggest / hover / signature help /
+     find-replace) — their readable opaque theme surface must survive over
+     the viz, else the widget (IntelliSense docs box, or the Cmd+F find
+     widget) goes transparent and unreadable (#598, #681). */
 [data-stave-code-panel][data-stave-backdrop="on"] .monaco-editor,
-[data-stave-code-panel][data-stave-backdrop="on"] .monaco-editor *:not(.selected-text):not(.selectionHighlight):not(.current-line-margin):not(.current-line):not(.minimap-slider-horizontal):not(.cursor):not(.suggest-widget):not(.suggest-widget *):not(.monaco-hover):not(.monaco-hover *):not(.parameter-hints-widget):not(.parameter-hints-widget *) {
+[data-stave-code-panel][data-stave-backdrop="on"] .monaco-editor *:not(.selected-text):not(.selectionHighlight):not(.current-line-margin):not(.current-line):not(.minimap-slider-horizontal):not(.cursor):not(.suggest-widget):not(.suggest-widget *):not(.monaco-hover):not(.monaco-hover *):not(.parameter-hints-widget):not(.parameter-hints-widget *):not(.find-widget):not(.find-widget *) {
   background-color: transparent !important;
 }
 


### PR DESCRIPTION
Part of #673 (v0.2.0 pre-merge polish). Closes #681.

## Problem
With a viz set as the editor background, opening Find/Replace (Cmd/Ctrl+F) rendered a **transparent** widget — the viz bled through and the find UI was unreadable.

## Root cause
`packages/app/src/app/globals.css:177-180`. The backdrop-transparency rule blanks the background of every `.monaco-editor` descendant *except* an allow-list of floating widgets (`:not(.suggest-widget):not(.monaco-hover):not(.parameter-hints-widget)…`, added under **#598** for exactly this symptom). The find widget renders as `.monaco-editor .find-widget` — the same class of floating widget — but was **missing from the allow-list**, so `background-color: transparent !important` stripped its opaque `editorWidget` surface.

## Fix
Add `:not(.find-widget):not(.find-widget *)` to the exclusion list, matching suggest/hover/params. One line.

## Observed (not inferred)
Probed the production build with the backdrop forced ON, reading computed `background-color`:

| Backdrop | `.find-widget` root | opaque layers |
|----------|--------------------|---------------|
| OFF | `rgb(15,15,30)` | 3 |
| ON (before fix) | `rgba(0,0,0,0)` | 0 |
| ON (after fix) | `rgb(15,15,30)` ✅ | 3 |

The widget now stays opaque over the viz, identical to the no-backdrop state.

- ✅ `next build` green
- ⚠️ The running dev server on :3000 caches CSS — a stale chunk still shows the old behavior until it recompiles/restarts; the fix is confirmed against a fresh production build.

_Pattern: this allow-list is fragile — every floating Monaco widget must be added (rename box, quick-input, context menu are candidates if the same symptom appears)._