### PR TITLE
💄 Toast accent edge straight, not curved (#699)

### DIFF
--- a/packages/app/src/components/DialogHost.tsx
+++ b/packages/app/src/components/DialogHost.tsx
@@ -219,7 +219,9 @@ const styles: Record<string, React.CSSProperties> = {
     background: "var(--bg-elevated)",
     border: "1px solid var(--border-strong)",
     borderLeft: "3px solid var(--accent)",
-    borderRadius: 4,
+    // Square off the left corners so the accent stripe runs as a straight
+    // vertical edge; keep the right corners rounded (#699).
+    borderRadius: "0 4px 4px 0",
     padding: "10px 14px",
     color: "var(--text-primary)",
     fontSize: 12,


### PR DESCRIPTION
## Summary
The toast accent stripe (`borderLeft: 3px solid var(--accent)`) was bending around the toast's uniform `borderRadius: 4` at the top-left/bottom-left corners, so the accent edge looked curved. Squared off only the left corners via the `0 4px 4px 0` shorthand — the accent now renders as a clean straight vertical bar, right corners still rounded.

Single-line CSS change in `DialogHost.tsx` `styles.toast`.

## Test plan
- Observed the **real mounted toast** (drove FileTree → Copy Path in the running app via Playwright): computed `borderTopLeftRadius`/`borderBottomLeftRadius` = `0px`, right corners `4px`, accent `borderLeft` 3px straight. Screenshot confirms a clean vertical accent edge.
- No unit/e2e spec asserts toast geometry (grep clean) — nothing to regenerate.

Part of EPIC #673 v0.2.0 pre-merge polish.
Closes #699