### PR TITLE
🐛 fix(timeline): span-preserving note-mark cap so dense clips don't truncate mid-song (#714)

### DIFF
--- a/packages/app/src/components/musicalTimeline/__tests__/downsampleMarks.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/downsampleMarks.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'vitest'
+import { downsampleMarksToCap, type SceneNote } from '../timelineScene'
+
+/** Build `perCycle` marks in each of `[0, cycles)` — cycle-ascending, the order
+ *  `collectNoteMarks` pushes them. Mirrors the #714 drum lane. */
+function denseLane(cycles: number, perCycle: number): SceneNote[] {
+  const out: SceneNote[] = []
+  for (let c = 0; c < cycles; c++) {
+    for (let k = 0; k < perCycle; k++) {
+      out.push({ cycle: c + k / perCycle, end: c + k / perCycle, pitch: null, gain: 1 })
+    }
+  }
+  return out
+}
+
+const lastCycle = (marks: readonly SceneNote[]): number =>
+  marks.reduce((m, n) => Math.max(m, n.cycle), -1)
+
+describe('downsampleMarksToCap — span-preserving note-mark cap (#714)', () => {
+  test('dense lane keeps its FULL extent, not just the first `cap` in cycle order', () => {
+    // The exact reported case: drum stack, 256 cycles × 35 onsets = 8960 marks.
+    const marks = denseLane(256, 35)
+    expect(marks.length).toBe(8960)
+
+    const { marks: out, capped } = downsampleMarksToCap(marks, 2000)
+
+    expect(capped).toBe(true)
+    // Budget preserved: never more than `cap` retained.
+    expect(out.length).toBeLessThanOrEqual(2000)
+    // First onset survives → clip starts at 0.
+    expect(out[0].cycle).toBe(0)
+    // THE REGRESSION: the OLD tail-drop stopped at cycle ~57 (2000 / 35). The
+    // downsample must reach the END of the song instead.
+    expect(lastCycle(out)).toBeGreaterThan(254)
+    // Definitely not the old truncation point.
+    expect(lastCycle(out)).toBeGreaterThan(57)
+    // Order preserved (monotonic non-decreasing in cycle).
+    for (let i = 1; i < out.length; i++) expect(out[i].cycle).toBeGreaterThanOrEqual(out[i - 1].cycle)
+  })
+
+  test('sparse lane (≤ cap) is returned untouched, same reference', () => {
+    const marks = denseLane(200, 2) // 400 marks < 2000
+    const { marks: out, capped } = downsampleMarksToCap(marks, 2000)
+    expect(capped).toBe(false)
+    expect(out).toBe(marks) // no copy
+    expect(lastCycle(out)).toBeGreaterThan(198)
+  })
+
+  test('output length never exceeds cap across a range of sizes', () => {
+    for (const len of [1999, 2000, 2001, 4000, 4001, 8960, 100000]) {
+      const marks = Array.from({ length: len }, (_, i) => ({
+        cycle: i, end: i, pitch: null, gain: 1,
+      })) as SceneNote[]
+      const { marks: out } = downsampleMarksToCap(marks, 2000)
+      expect(out.length).toBeLessThanOrEqual(2000)
+      expect(out[0].cycle).toBe(0)
+      // Last survivor within one stride of the true end (extent preserved).
+      const stride = Math.ceil(len / 2000)
+      expect(lastCycle(out)).toBeGreaterThanOrEqual(len - 1 - stride)
+    }
+  })
+
+  test('degenerate caps are safe', () => {
+    const marks = denseLane(10, 4)
+    expect(downsampleMarksToCap(marks, 0).marks).toBe(marks) // cap 0 → no-op
+    expect(downsampleMarksToCap([], 2000).marks).toEqual([]) // empty
+  })
+})

--- a/packages/app/src/components/musicalTimeline/timelineMarks.ts
+++ b/packages/app/src/components/musicalTimeline/timelineMarks.ts
@@ -12,7 +12,13 @@
 import type { PatternIR } from '@stave/editor'
 import { collectCycles, laneKeyOf } from '@stave/editor'
 import { extractPitch } from './pitch'
-import { EMPTY_MARKS, type CollectedMarks, type SceneClip, type SceneNote } from './timelineScene'
+import {
+  downsampleMarksToCap,
+  EMPTY_MARKS,
+  type CollectedMarks,
+  type SceneClip,
+  type SceneNote,
+} from './timelineScene'
 
 /** Per-lane mini-note-mark cap, so a long/dense song can't retain unbounded
  *  marks. Density (per-cycle counts) always covers the full span regardless. */
@@ -128,10 +134,9 @@ export function collectNoteMarks(
       arr = []
       marksByLane.set(key, arr)
     }
-    if (arr.length >= capPerLane) {
-      capped = true
-      continue
-    }
+    // Collect ALL marks here; the per-lane cap is applied AFTER the walk as a
+    // span-preserving downsample (see below). Capping in cycle order here would
+    // drop the tail and truncate a dense lane's clip mid-song (#714).
     const end = Number.isFinite(ev.end) && ev.end > cycle ? ev.end : cycle
     // `voice` = the sample name (`ev.s`), the per-voice partition key (#424). A
     // `$:` drum stack shares one lane key (`trackId`) but distinct `s` per voice,
@@ -145,6 +150,18 @@ export function collectNoteMarks(
       gain: clamp01(ev.gain ?? 1),
       voice: ev.s ?? null,
     })
+  }
+  // Bound each lane to `capPerLane` marks by downsampling ACROSS its span (keep
+  // every Nth), not by dropping the tail. A dense lane (e.g. a drum stack at
+  // ~35 onsets/cycle) keeps its full clip extent with uniformly thinner ticks
+  // instead of being cut off at cycle ~57 (#714). Sparse lanes (≤ cap) are
+  // untouched (same array reference).
+  for (const [key, arr] of marksByLane) {
+    const ds = downsampleMarksToCap(arr, capPerLane)
+    if (ds.capped) {
+      marksByLane.set(key, ds.marks)
+      capped = true
+    }
   }
   // Run-length-encode each lane's per-cycle arm index into contiguous clips.
   // A change in arm index (or a silent cycle) closes the current clip; this

--- a/packages/app/src/components/musicalTimeline/timelineScene.ts
+++ b/packages/app/src/components/musicalTimeline/timelineScene.ts
@@ -47,6 +47,35 @@ export interface SceneNote {
   readonly voice?: string | null
 }
 
+/**
+ * Bound a lane's note-mark array to `cap` entries WITHOUT truncating its time
+ * extent. When a lane has more marks than `cap` (a dense track over a long
+ * span), keep every Nth mark (`stride = ceil(len / cap)`) so the survivors are
+ * spread evenly across the WHOLE span — the first mark and a mark within one
+ * stride of the last both survive, so the drawn clip still covers the track's
+ * true extent, just with uniformly thinner ticks. Output length is always
+ * `≤ cap`, so the retained-marks / per-frame-draw budget is unchanged.
+ *
+ * Replaces the earlier TAIL-DROP (keep the first `cap` in cycle order, discard
+ * the rest), which cut a dense lane's clip off partway through the song (#714):
+ * a ~35-onset/cycle drum stack hit the 2000 cap at cycle ~57, so its expanded
+ * voice bars stopped there while sparser tracks spanned the full timeline.
+ *
+ * `marks` is assumed in collection (≈ cycle-ascending) order — the order
+ * `collectNoteMarks` pushes them. Returns the SAME array reference (no copy)
+ * when already within `cap`. `capped` is true iff a downsample happened.
+ */
+export function downsampleMarksToCap(
+  marks: SceneNote[],
+  cap: number,
+): { marks: SceneNote[]; capped: boolean } {
+  if (cap <= 0 || marks.length <= cap) return { marks, capped: false }
+  const stride = Math.ceil(marks.length / cap)
+  const out: SceneNote[] = []
+  for (let i = 0; i < marks.length; i += stride) out.push(marks[i])
+  return { marks: out, capped: true }
+}
+
 /** One voice (distinct sample/instrument) within a lane — the sub-row model an
  *  EXPANDED lane splits into (#424). Mirrors the live view's leaf voices
  *  (`layoutTrackRows` `LeafLayout`), but partitioned by `s` rather than the


### PR DESCRIPTION
## What

Fixes the Song timeline truncating a dense track's expanded clips partway through the song. A drum `$: stack` (lane `d5`, voices `bd/hh/rim/cp/-`) had all five voice bars cut off at ~cycle 57 while the melodic tracks spanned the full timeline. Audio was unaffected — display-only.

## Root cause

`NOTE_MARK_CAP_PER_LANE = 2000` was enforced **in cycle order** (drop the tail). The drum lane emits ~35 onsets/cycle, so it hit 2000 marks at `2000 ÷ 35 ≈ cycle 57` and every later mark was discarded. A bare track's expanded bar *is* its marks, so the tail-drop truncated the visible extent. Data (IR → `collectCycles` → `analyzeSong`) was correct the whole song — only note-mark collection truncated.

## Fix

Replace the tail-drop with a **span-preserving downsample**: `collectNoteMarks` collects every mark, then bounds each lane to the cap by keeping every Nth (`stride = ceil(len/cap)`) across the whole span, via a new pure `downsampleMarksToCap` helper in the editor-free `timelineScene` module. Budget unchanged (≤ cap per lane); dense clips render full width with uniformly thinner ticks. Sparse lanes untouched.

## Test plan

- New `downsampleMarks.test.ts` (4 tests) reproduces the exact case: 256 cycles × 35 onsets → last visible cycle 255 (not 57), length ≤ 2000, order preserved, sparse lanes untouched, degenerate caps safe.
- Full timeline suite green: 337/337 (incl. `FullSongTimeline` 44, `FullSongTimeline.voices` 3).
- `next build` clean (TypeScript passes).
- Observed working in-app: the expanded drum voices now span the full timeline.

App-only change — no editor dist rebuild needed.

Follow-up #715 tracks making canvas mark cost O(visible) to drop the fixed cap entirely.

closes #714
