### PR TITLE
🎨 Set-bg & backdrop polish: colour bar, focus frame, popover alignment

### DIFF
--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -174,9 +174,12 @@ body {
    - the floating popup widgets (suggest / hover / signature help /
      find-replace) — their readable opaque theme surface must survive over
      the viz, else the widget (IntelliSense docs box, or the Cmd+F find
-     widget) goes transparent and unreadable (#598, #681). */
+     widget) goes transparent and unreadable (#598, #681);
+   - the per-track colour-bar segments (`[data-track-colour-bar]`, #608) —
+     the stripe IS its background colour, and showing the track's identity
+     over the viz is the whole point, so blanking it defeats the bar (#721). */
 [data-stave-code-panel][data-stave-backdrop="on"] .monaco-editor,
-[data-stave-code-panel][data-stave-backdrop="on"] .monaco-editor *:not(.selected-text):not(.selectionHighlight):not(.current-line-margin):not(.current-line):not(.minimap-slider-horizontal):not(.cursor):not(.suggest-widget):not(.suggest-widget *):not(.monaco-hover):not(.monaco-hover *):not(.parameter-hints-widget):not(.parameter-hints-widget *):not(.find-widget):not(.find-widget *) {
+[data-stave-code-panel][data-stave-backdrop="on"] .monaco-editor *:not(.selected-text):not(.selectionHighlight):not(.current-line-margin):not(.current-line):not(.minimap-slider-horizontal):not(.cursor):not(.suggest-widget):not(.suggest-widget *):not(.monaco-hover):not(.monaco-hover *):not(.parameter-hints-widget):not(.parameter-hints-widget *):not(.find-widget):not(.find-widget *):not([data-track-colour-bar]) {
   background-color: transparent !important;
 }
 

--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -183,6 +183,16 @@ body {
   background-color: transparent !important;
 }
 
+/* Monaco paints a 1px focus outline (`--vscode-focusBorder`, ~#007fd4) on
+   `.monaco-editor` while focused. It's invisible against the opaque editor
+   surface, but with a backdrop on that surface goes transparent and the
+   outline reads as a blue frame around the whole code view (#723). Drop it
+   in backdrop mode; the caret still signals focus, and normal (non-backdrop)
+   focus indication is untouched. */
+[data-stave-code-panel][data-stave-backdrop="on"] .monaco-editor {
+  outline: none !important;
+}
+
 
 /* Viz chrome, runtime chrome, and tab bar sit inside the code
    panel. Make them semi-opaque so buttons stay legible while

--- a/packages/app/src/components/BackdropPopover.tsx
+++ b/packages/app/src/components/BackdropPopover.tsx
@@ -77,12 +77,14 @@ export function BackdropPopover(props: Props) {
   );
   const pinned = props.backgroundFileId != null;
 
-  // Position below the indicator, right-aligned to its right edge.
+  // Position below the indicator, LEFT-aligned to its left edge (#724) — opens
+  // down-and-right like a conventional dropdown. Clamp to the viewport so a
+  // button near the right edge doesn't push the popover off-screen.
   const left = Math.max(
     8,
     Math.min(
       window.innerWidth - 8 - 320,
-      props.anchorRect.right - 320,
+      props.anchorRect.left,
     ),
   );
   const top = props.anchorRect.bottom + 6;

--- a/packages/app/tests/editor-track-colour-bar.spec.ts
+++ b/packages/app/tests/editor-track-colour-bar.spec.ts
@@ -149,19 +149,25 @@ test('the colour bar keeps its colour when a background viz is active (#721)', a
   expect(before.length).toBe(3)
   for (const s of before) expect(s.bg).not.toBe('rgba(0, 0, 0, 0)')
 
-  // Turn the backdrop on (same attribute the "set as background" flow flips).
-  // The backdrop-transparency blanket in globals.css neutralises Monaco's
-  // opaque layers so the viz shows through; the colour-bar segments must be
-  // exempt (allowlist) or the stripe vanishes over the viz.
-  await page.evaluate(() => {
-    document
-      .querySelectorAll('[data-stave-code-panel]')
-      .forEach((p) => p.setAttribute('data-stave-backdrop', 'on'))
-  })
-  await page.waitForTimeout(200)
+  // Drive the REAL "set bg" flow (not a forced attribute): open the pattern
+  // chrome's bg dropdown and pick a viz, exactly as a user would. This mounts
+  // `[data-workspace-background]` and flips the panel to backdrop mode, engaging
+  // the transparency blanket in globals.css that neutralises Monaco's opaque
+  // layers. The colour-bar segments must be exempt (allowlist) or the stripe
+  // goes transparent (rgba(0,0,0,0)) and vanishes over the viz.
+  await page.locator('[data-testid="strudel-chrome-bg-toggle"]').click()
+  await page.locator('[data-testid="backdrop-popover"]').waitFor({ timeout: 5000 })
+  const picker = page.locator('[data-testid="backdrop-popover-picker"]')
+  const vizValue = await picker.locator('option').nth(1).getAttribute('value')
+  expect(vizValue).toBeTruthy()
+  await picker.selectOption(vizValue!)
+  await page.locator('[data-workspace-background]').waitFor({ timeout: 5000 })
+  await page.keyboard.press('Escape').catch(() => {})
+  await page.waitForTimeout(300)
 
   const after = await readSegments(page)
   expect(after.length).toBe(3)
+  // The regression: without the allowlist exemption these are all rgba(0,0,0,0).
   for (const s of after) expect(s.bg).not.toBe('rgba(0, 0, 0, 0)')
   // Colours are unchanged by the backdrop — byte-identical to before.
   expect(after.map((s) => s.bg)).toEqual(before.map((s) => s.bg))

--- a/packages/app/tests/editor-track-colour-bar.spec.ts
+++ b/packages/app/tests/editor-track-colour-bar.spec.ts
@@ -139,3 +139,30 @@ test('the colour bar stays continuous across a word-wrapped track', async ({ pag
   // The segment covers the whole wrapped block height (allow a few px slack).
   expect(Math.abs(probe.segHeight - probe.contentSpanPx)).toBeLessThanOrEqual(4)
 })
+
+test('the colour bar keeps its colour when a background viz is active (#721)', async ({ page }) => {
+  await boot(page)
+  await setCode(page, `bass: s("bd*4")\nlead: note("c e g")\n$: s("hh*8")`)
+
+  // Sanity: opaque colours before any backdrop.
+  const before = await readSegments(page)
+  expect(before.length).toBe(3)
+  for (const s of before) expect(s.bg).not.toBe('rgba(0, 0, 0, 0)')
+
+  // Turn the backdrop on (same attribute the "set as background" flow flips).
+  // The backdrop-transparency blanket in globals.css neutralises Monaco's
+  // opaque layers so the viz shows through; the colour-bar segments must be
+  // exempt (allowlist) or the stripe vanishes over the viz.
+  await page.evaluate(() => {
+    document
+      .querySelectorAll('[data-stave-code-panel]')
+      .forEach((p) => p.setAttribute('data-stave-backdrop', 'on'))
+  })
+  await page.waitForTimeout(200)
+
+  const after = await readSegments(page)
+  expect(after.length).toBe(3)
+  for (const s of after) expect(s.bg).not.toBe('rgba(0, 0, 0, 0)')
+  // Colours are unchanged by the backdrop — byte-identical to before.
+  expect(after.map((s) => s.bg)).toEqual(before.map((s) => s.bg))
+})

--- a/packages/app/tests/set-bg-on-pattern-bar.spec.ts
+++ b/packages/app/tests/set-bg-on-pattern-bar.spec.ts
@@ -107,3 +107,19 @@ test('no blue focus outline frames the editor when a backdrop is active (#723)',
   // blue frame — it must be suppressed in backdrop mode.
   expect(await editorOutline()).toBe('none')
 })
+
+test('the set-bg popover left-aligns to the button, opening down-and-right (#724)', async ({ page }) => {
+  const btn = page.locator('[data-testid="strudel-chrome-bg-toggle"]')
+  await btn.click()
+  await page.locator('[data-testid="backdrop-popover"]').waitFor()
+
+  const { buttonLeft, popoverLeft, popoverRight, buttonRight } = await page.evaluate(() => {
+    const b = document.querySelector('[data-testid="strudel-chrome-bg-toggle"]')!.getBoundingClientRect()
+    const p = document.querySelector('[data-testid="backdrop-popover"]')!.getBoundingClientRect()
+    return { buttonLeft: b.left, buttonRight: b.right, popoverLeft: p.left, popoverRight: p.right }
+  })
+  // Left edges aligned (allow a sub-pixel rounding slack), and the popover
+  // extends to the RIGHT of the button's left edge (down-and-right), not left.
+  expect(Math.abs(popoverLeft - buttonLeft)).toBeLessThanOrEqual(1)
+  expect(popoverRight).toBeGreaterThan(buttonRight)
+})

--- a/packages/app/tests/set-bg-on-pattern-bar.spec.ts
+++ b/packages/app/tests/set-bg-on-pattern-bar.spec.ts
@@ -81,3 +81,29 @@ test('backdrop is PER-TAB — switching tabs swaps/clears it, switching back res
   await expect(page.locator('[data-workspace-background]')).toHaveCount(1)
   await expect(btn).toHaveAttribute('data-pinned', 'true')
 })
+
+test('no blue focus outline frames the editor when a backdrop is active (#723)', async ({ page }) => {
+  const btn = page.locator('[data-testid="strudel-chrome-bg-toggle"]')
+
+  // Focus the editor first — the outline only computes while `.monaco-editor`
+  // is focused. Without a backdrop it's the usual 1px focus border.
+  await page.locator('.monaco-editor .view-lines').click()
+  const editorOutline = () =>
+    page.evaluate(() => {
+      const ed = document.querySelector('[data-stave-code-panel] .monaco-editor')
+      return getComputedStyle(ed as Element).outlineStyle
+    })
+  expect(await editorOutline()).not.toBe('none') // focus border present normally
+
+  // Pin a backdrop (real flow).
+  await btn.click()
+  const picker = page.locator('[data-testid="backdrop-popover-picker"]')
+  await picker.selectOption((await picker.locator('option').nth(1).getAttribute('value'))!)
+  await expect(page.locator('[data-workspace-background]')).toHaveCount(1)
+  await page.keyboard.press('Escape')
+  await page.locator('.monaco-editor .view-lines').click()
+
+  // Over the (now transparent) editor surface the focus outline would read as a
+  // blue frame — it must be suppressed in backdrop mode.
+  expect(await editorOutline()).toBe('none')
+})

--- a/packages/app/tests/set-bg-viz-file-outline.spec.ts
+++ b/packages/app/tests/set-bg-viz-file-outline.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * A viz file (.p5 / .hydra) set as its OWN group background must not frame its
+ * code view in a blue focus outline (#723, viz-file case). Setting the viz as
+ * backdrop flips its code panel to backdrop mode, so the Monaco surface goes
+ * transparent and the `.monaco-editor` focus outline (`--vscode-focusBorder`,
+ * ~#007fd4) — invisible against an opaque surface — would read as a blue frame.
+ * The globals.css rule that drops the outline in backdrop mode covers every
+ * `.monaco-editor` under the code panel, viz files included; this locks that.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+async function openVizFile(page: Page): Promise<void> {
+  await page.goto('/')
+  await page.locator('[data-workspace-shell="root"]').waitFor({ timeout: 15000 })
+  await page.locator('.monaco-editor').waitFor({ timeout: 15000 })
+  // Open a bundled .p5 preset via the file tree (bundled p5 fileIds contain "p5").
+  const item = page.locator('[data-file-tree-item*="p5"]').first()
+  await item.waitFor({ timeout: 10000 })
+  await item.dblclick()
+  await page.locator('[data-workspace-chrome="viz"]').first().waitFor({ timeout: 10000 })
+}
+
+const outlineStyle = (page: Page) =>
+  page.evaluate(() => {
+    const ed = document.querySelector('[data-stave-code-panel] .monaco-editor')
+    return getComputedStyle(ed as Element).outlineStyle
+  })
+
+test('no blue focus outline frames a viz file set as its own background (#723)', async ({ page }) => {
+  await openVizFile(page)
+
+  // Focus first — the outline only computes while `.monaco-editor` is focused.
+  // Without a backdrop it's the usual 1px focus border (present).
+  await page.locator('.monaco-editor .view-lines').first().click()
+  expect(await outlineStyle(page)).not.toBe('none')
+
+  // Set this viz file as the group backdrop (the real gesture the user reported).
+  await page.locator('[data-testid="viz-chrome-bg-toggle"]').first().click()
+  await page.waitForTimeout(400)
+  await expect(
+    page.locator('[data-stave-code-panel][data-stave-backdrop="on"]'),
+  ).toHaveCount(1)
+
+  // Re-focus over the now-transparent surface — the outline must be gone.
+  await page.locator('.monaco-editor .view-lines').first().click()
+  await page.waitForTimeout(150)
+  expect(await outlineStyle(page)).toBe('none')
+})


### PR DESCRIPTION
Closes #721, closes #723, closes #724. Three small set-bg / backdrop UX fixes in the code view (app-only).

## 1 — Track colour bar vanished over a background viz (#721)
The backdrop transparency blanket (`.monaco-editor * { background-color: transparent !important }`) was blanking the per-track colour-bar segments. Added `:not([data-track-colour-bar])` to its allowlist.

## 2 — Blue focus outline framed the editor under a backdrop (#723)
Monaco's editor focus outline (`.monaco-editor` → `outline: 1px solid rgb(0,127,212)`) reads as a blue rectangle once the editor surface goes transparent for the viz. Suppressed it in backdrop mode (`[data-stave-backdrop="on"] .monaco-editor { outline: none }`); normal focus indication unchanged.

## 3 — Set-bg popover left-aligns to its button (#724)
The dropdown opened right-aligned (`left = anchorRect.right - 320`), extending leftward. Changed to `left = anchorRect.left` so it opens down-and-right, left edge aligned to the button. Viewport clamps kept.

## Diagnosis note
My first pass on #721 verified with a *forced* `data-stave-backdrop` attribute rather than the real "set bg" flow, and reported against stale HMR CSS — so it looked fixed when it wasn't live. All three are now verified through the **real dropdown flow** and each regression test is proven **fail-without / pass-with** where applicable.

## Test plan
- `editor-track-colour-bar.spec.ts` (#721): real set-bg flow, segments stay opaque + byte-identical colour.
- `set-bg-on-pattern-bar.spec.ts` (#723): editor outline is the focus border normally, `none` once a backdrop is pinned.
- `set-bg-on-pattern-bar.spec.ts` (#724): popover left edge aligns to the button (±1px) and extends right.
- Observed all three live on :3000 (screenshots): colour bars visible over the viz; no blue frame; popover opens down-and-right (left 396 == button left 396). App `tsc` clean.

> A pre-existing test in the colour-bar spec ("continuous across a word-wrapped track") fails on clean studio too (±44px word-wrap pixel assertion) — unrelated; flagged for a separate issue.