### PR TITLE
✨ Perf overlay: copy the snapshot as JSON (#729)

### DIFF
--- a/packages/app/src/components/PerfOverlay.tsx
+++ b/packages/app/src/components/PerfOverlay.tsx
@@ -40,6 +40,8 @@ export function PerfOverlay() {
   );
 
   const [snap, setSnap] = useState<PerfSnapshot | null>(null);
+  // Brief "copied" affordance on the copy button; auto-clears after a beat.
+  const [copied, setCopied] = useState(false);
 
   // Poll the snapshot only while enabled. setState lives in the timer callback
   // (not the effect body), so it doesn't trigger cascading renders. The first
@@ -49,6 +51,23 @@ export function PerfOverlay() {
     const id = setInterval(() => setSnap(perf.snapshot()), REFRESH_MS);
     return () => clearInterval(id);
   }, [enabled]);
+
+  // Copy the live snapshot as formatted JSON for pasting into a bug report.
+  // Reads the freshest snapshot at click time (not the 5Hz-lagging `snap`) so
+  // the copied numbers match the instant the user clicked. Clipboard can reject
+  // (permissions / insecure context) — swallow and skip the "copied" flash.
+  const copySnapshot = (): void => {
+    const json = JSON.stringify(perf.snapshot(), null, 2);
+    void navigator.clipboard
+      ?.writeText(json)
+      .then(() => {
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1200);
+      })
+      .catch(() => {
+        /* clipboard unavailable — no-op */
+      });
+  };
 
   // When disabled we render nothing regardless of any stale snapshot.
   if (!enabled || !snap) return null;
@@ -65,15 +84,26 @@ export function PerfOverlay() {
     <div style={styles.panel} role="status" aria-label="Performance overlay">
       <div style={styles.header}>
         <span>⚡ perf</span>
-        <button
-          type="button"
-          onClick={() => setPerfEnabled(false)}
-          style={styles.close}
-          aria-label="Close performance overlay"
-          title="Close (Alt+P)"
-        >
-          ×
-        </button>
+        <div style={styles.actions}>
+          <button
+            type="button"
+            onClick={copySnapshot}
+            style={styles.action}
+            aria-label="Copy performance snapshot as JSON"
+            title={copied ? "Copied!" : "Copy snapshot (JSON)"}
+          >
+            {copied ? "✓" : "⧉"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setPerfEnabled(false)}
+            style={styles.action}
+            aria-label="Close performance overlay"
+            title="Close (Alt+P)"
+          >
+            ×
+          </button>
+        </div>
       </div>
 
       <div style={styles.row}>
@@ -157,7 +187,8 @@ const styles: Record<string, React.CSSProperties> = {
     marginBottom: 4,
     color: "#ffd479",
   },
-  close: {
+  actions: { display: "flex", alignItems: "center", gap: 2 },
+  action: {
     background: "none",
     border: "none",
     color: "#9aa5b1",

--- a/packages/app/tests/perf-profiler.spec.ts
+++ b/packages/app/tests/perf-profiler.spec.ts
@@ -115,4 +115,31 @@ test.describe('Phase perf — profiler produces real per-frame data (#228)', () 
     expect(snap.longtasks).toHaveProperty('count')
     expect(snap.longtasks).toHaveProperty('maxMs')
   })
+
+  test('the header copy button copies the live snapshot as JSON to the clipboard (#729)', async ({
+    page,
+    context,
+  }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+
+    // Drive a little so the snapshot has real content, then let a frame land.
+    await setCode(page, '$: s("bd*4").bank("RolandTR909")._pianoroll()')
+    await runCode(page)
+
+    // The overlay auto-renders when perf is enabled. Copy button sits beside close.
+    const copyBtn = page.locator('[aria-label="Copy performance snapshot as JSON"]')
+    await expect(copyBtn).toBeVisible({ timeout: 6000 })
+    await copyBtn.click()
+
+    // Read the clipboard back — the REAL artifact, not the button's icon flip.
+    const text = await page.evaluate(() => navigator.clipboard.readText())
+    const parsed = JSON.parse(text) as Record<string, unknown>
+    // Shape of a PerfSnapshot — proves it's the snapshot, not some other payload.
+    expect(parsed).toHaveProperty('frames')
+    expect(parsed).toHaveProperty('sections')
+    expect(parsed).toHaveProperty('enabled', true)
+
+    // The button flips to a ✓ acknowledgement.
+    await expect(copyBtn).toHaveText('✓')
+  })
 })


### PR DESCRIPTION
Closes #729.

## What
Adds a **copy button** to the performance HUD (`PerfOverlay`, Alt+P) header, beside the `×` close button. It copies the current `perf.snapshot()` as formatted JSON to the clipboard and briefly flips to a ✓.

Before, the live diagnostics (fps / frame p95 / drops, section p50·p95, longtasks, viz counts, trigger rate) had to be retyped by hand to share in a bug report.

## Notes
- Reads the snapshot **at click time** (not the 5Hz-lagging render state), so the copied numbers match the instant you clicked.
- Clipboard rejection (permissions / insecure context) is swallowed — no "copied" flash, no throw.
- The close `style` was renamed to a shared `action`; the two buttons sit in an `actions` flex group.

## Test plan
- **New e2e** (`perf-profiler.spec.ts`) enables the profiler, clicks the copy button, **reads the clipboard back**, and asserts a real `PerfSnapshot` shape (`frames`/`sections`/`enabled:true`) + the ✓ flip — driven through the real overlay on a restarted server.
- `tsc` clean on the changed files.
- The pre-existing heavy-patch test's `hasBusSection` failure reproduces identically on clean `studio_v0.2.0` (a headless viz-bus env flake) — unrelated to this change.

App-only — no editor dist change.