### PR TITLE
✨ Move the CYCLES/BARS ruler toggle onto the editor pattern bar

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -34,6 +34,7 @@ import { SongTimelineLiveOverlay } from './SongTimelineLiveOverlay'
 import { paletteForTrack, trackIndexOf } from './musicalTimeline/colors'
 import { buildTimelineScene, clipAtCycle } from './musicalTimeline/timelineScene'
 import { TrackSwatchPopover } from './TrackSwatchPopover'
+import { useRulerUnits } from '../state/rulerUnits'
 import {
   applyStableVoiceOrder,
   EMPTY_VOICE_ORDER,
@@ -76,10 +77,6 @@ const CLIP_EDGE_GRIP_PX = 6
  *  click (select/seek). Below this it stays a click so seek-anywhere is intact. */
 const CLIP_MOVE_THRESHOLD_PX = 4
 const FONT_MONO = 'var(--font-mono), ui-monospace, monospace'
-
-/** Ruler units (#412). CYCLES = Strudel's native numbering; BARS = DAW
- *  convention (one cycle ≈ one bar) with quarter-cycle beat ticks. */
-type RulerUnits = 'cycles' | 'bars'
 
 export interface FullSongTimelineProps {
   /** Whole-song analysis, or null before the first analysis completes. */
@@ -349,7 +346,9 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
   // (`overflowY: auto`); `scrollTop` mirrors that offset so the label gutter can
   // translate in lockstep and the Y hit-tests can map client→content space.
   const [scrollTop, setScrollTop] = useState(0)
-  const [units, setUnits] = useState<RulerUnits>('cycles')
+  // Ruler units (#412 → #750). The toggle now lives on the editor pattern bar
+  // (StrudelEditorClient); this view just reads the shared store.
+  const units = useRulerUnits()
   const zoomRef = useRef(zoom)
   zoomRef.current = zoom
   const scrollLeftRef = useRef(scrollLeft)
@@ -1334,19 +1333,9 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
           surfaced via the data attribute below for Playwright observation. */}
       <div data-full-song-period={periodLabel} style={{ display: 'none' }} />
 
-      {/* Controls: units toggle (left) + zoom (right). Discoverable buttons over
-          shortcuts; ⌘/Ctrl+wheel also zooms. */}
+      {/* Controls: zoom cluster (right). The CYCLES/BARS units toggle moved to
+          the editor pattern bar (#750). ⌘/Ctrl+wheel also zooms. */}
       <div data-full-song="controls" style={styles.controls}>
-        <button
-          type="button"
-          data-full-song-units-toggle
-          data-units={units}
-          onClick={() => setUnits((u) => (u === 'cycles' ? 'bars' : 'cycles'))}
-          style={styles.unitsToggle}
-          title={units === 'cycles' ? 'Show bars & beats' : 'Show cycles'}
-        >
-          {units === 'cycles' ? 'CYCLES' : 'BARS'}
-        </button>
         <div style={styles.zoomCluster} data-full-song-zoom={zoomPercent}>
           <button
             type="button"
@@ -1802,7 +1791,7 @@ const styles = {
     minHeight: CONTROLS_HEIGHT,
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'space-between',
+    justifyContent: 'flex-end',
     gap: 8,
     padding: '0 8px',
     background: 'var(--bg-app, #090912)',

--- a/packages/app/src/components/RulerUnitsButton.tsx
+++ b/packages/app/src/components/RulerUnitsButton.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import React from "react";
+import { useRulerUnits, toggleRulerUnits } from "../state/rulerUnits";
+
+/**
+ * CYCLES / BARS units toggle (#750) for the editor pattern (Strudel) chrome
+ * bar. Moved off the Timeline controls — the Timeline ruler now reads the
+ * shared `rulerUnits` store this button writes. Styled to match the sibling
+ * SetBackdropButton chrome chip.
+ */
+export function RulerUnitsButton(): React.ReactElement {
+  const units = useRulerUnits();
+  const cycles = units === "cycles";
+  return (
+    <button
+      data-testid="strudel-chrome-units-toggle"
+      data-units={units}
+      onClick={() => toggleRulerUnits()}
+      title={cycles ? "Ruler: cycles — click for bars & beats" : "Ruler: bars & beats — click for cycles"}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        padding: "3px 8px",
+        borderRadius: 3,
+        fontSize: 10,
+        letterSpacing: "0.08em",
+        fontFamily: "var(--font-mono), ui-monospace, monospace",
+        cursor: "pointer",
+        userSelect: "none",
+        background: "none",
+        color: "var(--foreground-muted)",
+        border: "1px solid var(--border)",
+      }}
+    >
+      {cycles ? "CYCLES" : "BARS"}
+    </button>
+  );
+}

--- a/packages/app/src/components/StrudelEditorClient.tsx
+++ b/packages/app/src/components/StrudelEditorClient.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useVizRefWatcher } from "../useVizRefWatcher";
 import { promptAndCreateFile } from "../lib/newFile";
 import { BackdropPopover } from "./BackdropPopover";
+import { RulerUnitsButton } from "./RulerUnitsButton";
 import { PopoutPreviewController } from "./PopoutPreviewController";
 import { registerVizWorker } from "../visualizers/registerVizWorker";
 import {
@@ -1128,11 +1129,15 @@ export default function StrudelEditorClient({
       autoRefresh: state.autoRefresh,
       onToggleAutoRefresh: () => handleToggleAutoRefresh(tab.fileId),
       chromeExtras: (
-        <SetBackdropButton
-          pinned={tabBg != null}
-          fileName={backdropName(tabBg)}
-          onOpen={(rect) => setBgPopover({ rect, fileId: tab.fileId })}
-        />
+        <>
+          {/* #750 — ruler units toggle, moved off the Timeline controls. */}
+          <RulerUnitsButton />
+          <SetBackdropButton
+            pinned={tabBg != null}
+            fileName={backdropName(tabBg)}
+            onOpen={(rect) => setBgPopover({ rect, fileId: tab.fileId })}
+          />
+        </>
       ),
     };
     return runtimeProvider.renderChrome(ctx);

--- a/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
+++ b/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
@@ -13,6 +13,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import * as React from 'react'
 import { act, render, cleanup, fireEvent } from '@testing-library/react'
 import type { SongAnalysis } from '@stave/editor'
+import { setRulerUnits } from '../../state/rulerUnits'
 
 // FullSongTimeline now pulls the editor runtime (collectCycles/laneKeyOf, via
 // timelineMarks) into its import graph; the real module drags in a CJS dep
@@ -338,23 +339,24 @@ describe('FullSongTimeline', () => {
     expect(toggle.getAttribute('aria-pressed')).toBe('false')
   })
 
-  it('toggles CYCLES ↔ BARS and adds beat ticks in bars mode', async () => {
+  it('the ruler reflects the shared units store — bars adds beat ticks (#750)', async () => {
+    // The CYCLES/BARS toggle moved to the editor pattern bar; the ruler now
+    // reads the shared `rulerUnits` store. Drive the store directly.
+    setRulerUnits('cycles')
     const { container } = renderFull()
     await act(async () => {
       await Promise.resolve()
     })
-    const toggle = container.querySelector('[data-full-song-units-toggle]') as HTMLButtonElement
-    expect(toggle.textContent).toBe('CYCLES')
     // CYCLES: 4 major ticks (period 4 across 800px → 200px/cycle), no beats.
     expect(container.querySelectorAll('[data-full-song-tick="major"]').length).toBe(4)
     expect(container.querySelectorAll('[data-full-song-tick="beat"]').length).toBe(0)
     await act(async () => {
-      toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      setRulerUnits('bars')
     })
-    expect(toggle.textContent).toBe('BARS')
     // BARS: 4 majors + 4×3 interior beat ticks (200/4 = 50px/beat ≥ 14).
     expect(container.querySelectorAll('[data-full-song-tick="major"]').length).toBe(4)
     expect(container.querySelectorAll('[data-full-song-tick="beat"]').length).toBe(12)
+    setRulerUnits('cycles') // reset the module singleton for other tests
   })
 })
 

--- a/packages/app/src/components/__tests__/RulerUnitsButton.test.tsx
+++ b/packages/app/src/components/__tests__/RulerUnitsButton.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import React from "react";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { RulerUnitsButton } from "../RulerUnitsButton";
+import {
+  getRulerUnits,
+  setRulerUnits,
+  toggleRulerUnits,
+  subscribeRulerUnits,
+} from "../../state/rulerUnits";
+
+beforeEach(() => setRulerUnits("cycles"));
+afterEach(() => {
+  cleanup();
+  setRulerUnits("cycles");
+});
+
+describe("rulerUnits store", () => {
+  it("toggles and notifies subscribers", () => {
+    const cb = vi.fn();
+    const unsub = subscribeRulerUnits(cb);
+    expect(getRulerUnits()).toBe("cycles");
+    toggleRulerUnits();
+    expect(getRulerUnits()).toBe("bars");
+    expect(cb).toHaveBeenCalledTimes(1);
+    unsub();
+    toggleRulerUnits();
+    expect(cb).toHaveBeenCalledTimes(1); // unsubscribed
+  });
+
+  it("no-ops (no notify) when set to the current value", () => {
+    const cb = vi.fn();
+    subscribeRulerUnits(cb);
+    setRulerUnits("cycles"); // already cycles
+    expect(cb).not.toHaveBeenCalled();
+  });
+});
+
+describe("RulerUnitsButton", () => {
+  it("shows the current units and flips the shared store on click", () => {
+    render(<RulerUnitsButton />);
+    const btn = screen.getByTestId("strudel-chrome-units-toggle");
+    expect(btn.textContent).toBe("CYCLES");
+    fireEvent.click(btn);
+    expect(getRulerUnits()).toBe("bars");
+    expect(btn.textContent).toBe("BARS");
+  });
+
+  it("two instances stay in sync via the shared store", () => {
+    render(
+      <>
+        <RulerUnitsButton />
+        <RulerUnitsButton />
+      </>,
+    );
+    const btns = screen.getAllByTestId("strudel-chrome-units-toggle");
+    fireEvent.click(btns[0]);
+    expect(btns[0].textContent).toBe("BARS");
+    expect(btns[1].textContent).toBe("BARS"); // second reflects the shared change
+  });
+});

--- a/packages/app/src/state/rulerUnits.ts
+++ b/packages/app/src/state/rulerUnits.ts
@@ -1,0 +1,51 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+/**
+ * Shared ruler-units state (#750).
+ *
+ * CYCLES = Strudel's native cycle numbering; BARS = DAW convention (one
+ * cycle ≈ one bar) with quarter-cycle beat ticks (#412).
+ *
+ * The control that flips this lives on the editor pattern bar
+ * (StrudelEditorClient chrome), while the consumer — the Timeline ruler
+ * (FullSongTimeline) — lives in a different subtree. Their only common
+ * ancestor is StaveApp, so instead of threading the value through two large
+ * prop surfaces we keep it in this tiny external store (same shape as the
+ * commands/keybindings store). Both sides read via `useRulerUnits`; the
+ * pattern-bar button writes via `toggleRulerUnits`.
+ *
+ * In-session only (survives Timeline remounts, resets on reload) — matches
+ * the prior local-useState behaviour. Persistence, if wanted, is a later
+ * one-liner here.
+ */
+
+export type RulerUnits = "cycles" | "bars";
+
+let current: RulerUnits = "cycles";
+const listeners = new Set<() => void>();
+
+export function getRulerUnits(): RulerUnits {
+  return current;
+}
+
+export function setRulerUnits(next: RulerUnits): void {
+  if (next === current) return;
+  current = next;
+  for (const l of listeners) l();
+}
+
+export function toggleRulerUnits(): void {
+  setRulerUnits(current === "cycles" ? "bars" : "cycles");
+}
+
+export function subscribeRulerUnits(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => { listeners.delete(cb); };
+}
+
+/** React binding — re-renders the caller whenever the units change. */
+export function useRulerUnits(): RulerUnits {
+  return useSyncExternalStore(subscribeRulerUnits, getRulerUnits, getRulerUnits);
+}

--- a/packages/app/tests/full-song-zoom-ruler.spec.ts
+++ b/packages/app/tests/full-song-zoom-ruler.spec.ts
@@ -146,9 +146,11 @@ test('full-song view: zoom widens + scrolls, Fit refits, bars toggle adds beat t
   }
 
   // (5) Bars toggle adds beat ticks (zoom in first so beats clear the px floor).
+  // The toggle now lives on the editor pattern bar (#750); the ruler reacts
+  // via the shared units store.
   await page.locator('[data-full-song-zoom-in]').click()
   await page.locator('[data-full-song-zoom-in]').click()
-  const unitsToggle = page.locator('[data-full-song-units-toggle]')
+  const unitsToggle = page.locator('[data-testid="strudel-chrome-units-toggle"]').first()
   expect(await unitsToggle.textContent()).toBe('CYCLES')
   await unitsToggle.click()
   expect(await unitsToggle.textContent()).toBe('BARS')


### PR DESCRIPTION
Closes #750.

## What
The ruler units toggle (#412, CYCLES ↔ BARS) **moves off the Timeline controls onto the editor pattern (Strudel chrome) bar**, next to the set-bg button. The Timeline ruler still responds.

## Why this shape
`FullSongTimeline` (Timeline subtree) and the pattern-bar chrome (`StrudelEditorClient` subtree) share only `StaveApp` as a common ancestor. Rather than thread `units` through two large prop surfaces, a tiny shared store (`state/rulerUnits.ts` — `get/set/toggle/subscribe` + a `useRulerUnits` hook via `useSyncExternalStore`) owns it, mirroring the commands/keybindings store. In-session (survives Timeline remounts; resets on reload — same as the prior local `useState`). App-only, no `@stave/editor` dist rebuild.

## Changes
- `state/rulerUnits.ts`, `RulerUnitsButton.tsx` — new.
- `FullSongTimeline` — drop local `units` + toggle button; read the store; right-align the zoom cluster.
- `StrudelEditorClient` — inject `<RulerUnitsButton/>` into `chromeExtras` (pattern files only).

## Test plan
- Unit (616 pass): store toggle/subscribe/no-op; button flips the shared store; two instances stay in sync; the FullSongTimeline ruler test now drives the store (cycles→bars adds beat ticks).
- E2E (`full-song-zoom-ruler.spec.ts`): clicks the **new chrome toggle** and asserts the ruler gains beat ticks — end-to-end through the store.
- Observed on :3000 (P230): the `CYCLES` chip renders on the pattern bar (`▶ Play  ⊘  CYCLES  ● set bg ▾`); the old Timeline toggle is gone (count 0).
- `tsc --noEmit` clean.