### PR TITLE
🔥 fix(timeline): drop the redundant numbered section bands from the full-song ruler

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -581,8 +581,6 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     [displayCycles, loopCycles, dragAwareContentWidth, onSeek],
   )
 
-  const sections = analysis?.sections ?? []
-
   // Canvas scene: per-lane density (from analysis) + capped mini-note marks
   // (collected app-side from the IR over the display span). Memoised so the
   // collect + build run only when the analysis or IR changes — NOT on scroll or
@@ -1395,7 +1393,7 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
         </div>
       </div>
 
-      {/* Ruler: section bands + cycle/bar ticks + clickable seek surface + playhead */}
+      {/* Ruler: cycle/bar ticks + clickable seek surface + playhead */}
       <div data-full-song="ruler" style={styles.topbar}>
         <div style={styles.gutter}>
           <span style={styles.caption}>SONG</span>
@@ -1410,30 +1408,6 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
             data-full-song="ruler-content"
             style={{ ...styles.scrollContent, width: contentWidth, transform: `translateX(${-scrollLeft}px)` }}
           >
-            {areaWidth > 0 &&
-              sections.map((s, i) => {
-                const left = songCycleToX(s.startCycle, displayCycles, contentWidth)
-                const right = songCycleToX(s.endCycle, displayCycles, contentWidth)
-                return (
-                  <div
-                    key={`section-${s.startCycle}-${s.endCycle}`}
-                    data-full-song-section={i}
-                    title={`Section ${i + 1} · cycles ${s.startCycle}–${s.endCycle - 1}`}
-                    style={{
-                      ...styles.sectionChip,
-                      left,
-                      width: Math.max(0, right - left),
-                      // alternate tint so adjacent sections read as distinct
-                      background:
-                        i % 2 === 0
-                          ? 'var(--bg-input, rgba(255,255,255,0.04))'
-                          : 'var(--bg-panel, rgba(255,255,255,0.08))',
-                    }}
-                  >
-                    <span style={styles.sectionLabel}>{i + 1}</span>
-                  </div>
-                )
-              })}
             {areaWidth > 0 &&
               ticks.map((t) => (
                 <div
@@ -1876,18 +1850,6 @@ const styles = {
     overflow: 'hidden',
     cursor: 'pointer' as const,
   },
-  sectionChip: {
-    position: 'absolute' as const,
-    top: 4,
-    bottom: 4,
-    borderRadius: 2,
-    borderLeft: '1px solid var(--border-subtle, rgba(255,255,255,0.12))',
-    display: 'flex',
-    alignItems: 'center',
-    paddingLeft: 4,
-    pointerEvents: 'none' as const,
-  },
-  sectionLabel: { fontSize: 9, color: 'var(--text-tertiary, rgba(255,255,255,0.4))' },
   tickMajor: {
     position: 'absolute' as const,
     bottom: 0,

--- a/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
+++ b/packages/app/src/components/__tests__/FullSongTimeline.test.tsx
@@ -151,13 +151,14 @@ describe('FullSongTimeline', () => {
     expect(container.querySelector('[data-full-song-lane="hh"]')).not.toBeNull()
   })
 
-  it('renders section chips on the ruler and mounts the canvas body', async () => {
+  it('mounts the canvas body without any DOM section chips on the ruler', async () => {
     const { container } = renderFull()
     await act(async () => {
       await Promise.resolve()
     })
-    // Section chips live on the (DOM) ruler overlay.
-    expect(container.querySelectorAll('[data-full-song-section]').length).toBe(2)
+    // Section bands were removed from the ruler (#752): the numbered labels
+    // collided with the cycle numbers and were a no-op for single-section songs.
+    expect(container.querySelectorAll('[data-full-song-section]').length).toBe(0)
     // The onset heatmap is now drawn on the canvas (the per-cell DOM nodes are
     // gone). Assert the canvas surface mounted; pixel output is covered by the
     // drawTimeline unit tests + the Playwright screenshot.


### PR DESCRIPTION
## Problem
The full-song ruler (`SONG` lane at the top of `FullSongTimeline`) rendered a tinted **section band** per structural section, each labelled with its 1-based index (`1`, `2`, …).

- **Redundant / confusing.** The ruler already prints cycle numbers `0,1,2,3,4…`. A band labelled `1` reads as a mislabelled cycle, not a section — the numbering fights the ruler it sits on.
- **Degenerate no-op in the common case.** A steady-groove song (active-lane set never changes) collapses to a single full-width faint band with a floating `1`: zero information, pure visual noise.

Example DOM node this removes:
```html
<div data-full-song-section="0" title="Section 1 · cycles 0–3" ...><span>1</span></div>
```

## Fix
- Remove the DOM section-band `.map` overlay + numbered labels from the ruler.
- Drop the now-orphaned `sections` local and the unused `sectionChip` / `sectionLabel` styles.
- Update the render test to assert **zero** `data-full-song-section` nodes.

**Out of scope:** the canvas body path (`drawTimeline.ts:131`) draws a faint, *unlabelled* alternating tint behind the lanes — a different element that doesn't carry the redundant-number problem. Left untouched.

## Test plan
- `tsc --noEmit` clean.
- `FullSongTimeline.test.tsx` (44) + `FullSongTimeline.voices.test.tsx` (3) — **47 passed**. The render test drives a mock `SongAnalysis` with 2 sections and now observes 0 chips rendered (before: 2), a genuine before/after on the render output.
- Dev server compiles clean on `:3000`.

Closes #752