### PR TITLE
✨ feat(settings): keyboard-shortcuts editor (Phase B)

### DIFF
--- a/packages/app/src/commands/__tests__/keybindings.test.ts
+++ b/packages/app/src/commands/__tests__/keybindings.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { registerCommand } from "../registry";
+import {
+  setKeybindingOverride,
+  getKeybindingFor,
+  isKeybindingOverridden,
+  resetAllKeybindings,
+  hasAnyKeybindingOverride,
+  findConflicts,
+  conflictsForCommand,
+  subscribeKeybindings,
+} from "../keybindings";
+
+const STORAGE_KEY = "stave:keybindings";
+
+// This jsdom (opaque about:blank origin) ships no functional localStorage, so
+// install a Map-backed stub. The store survives vi.resetModules so the
+// "load at module init" fresh-import test can read what we wrote.
+const store = new Map<string, string>();
+const localStorageMock: Storage = {
+  getItem: (k) => (store.has(k) ? store.get(k)! : null),
+  setItem: (k, v) => { store.set(k, String(v)); },
+  removeItem: (k) => { store.delete(k); },
+  clear: () => { store.clear(); },
+  key: (i) => Array.from(store.keys())[i] ?? null,
+  get length() { return store.size; },
+};
+Object.defineProperty(window, "localStorage", { value: localStorageMock, configurable: true, writable: true });
+
+// Register two disposable commands with default bindings for the whole file.
+let dispose: Array<() => void> = [];
+
+beforeEach(() => {
+  resetAllKeybindings();
+  window.localStorage.clear();
+  dispose = [
+    registerCommand({ id: "test.undo", title: "Undo", category: "Edit", keybinding: "mod+z", run: () => {} }),
+    registerCommand({ id: "test.redo", title: "Redo", category: "Edit", keybinding: "mod+shift+z", run: () => {} }),
+  ];
+});
+
+afterEach(() => {
+  dispose.forEach((d) => d());
+  resetAllKeybindings();
+  window.localStorage.clear();
+});
+
+describe("keybinding overrides — persistence", () => {
+  it("writes an override through to localStorage", () => {
+    setKeybindingOverride("test.undo", "mod+j");
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    expect(raw).toBeTruthy();
+    expect(JSON.parse(raw!)).toEqual({ "test.undo": "mod+j" });
+  });
+
+  it("getKeybindingFor prefers the override over the declared default", () => {
+    setKeybindingOverride("test.undo", "mod+j");
+    expect(getKeybindingFor({ id: "test.undo", title: "Undo", keybinding: "mod+z", run: () => {} })).toBe("mod+j");
+  });
+
+  it("loads persisted overrides at module init (fresh import)", async () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ "test.undo": "mod+k" }));
+    vi.resetModules();
+    const fresh = await import("../keybindings");
+    expect(
+      fresh.getKeybindingFor({ id: "test.undo", title: "Undo", keybinding: "mod+z", run: () => {} }),
+    ).toBe("mod+k");
+  });
+});
+
+describe("keybinding overrides — reset", () => {
+  it("per-binding reset falls back to the declared default", () => {
+    setKeybindingOverride("test.undo", "mod+j");
+    expect(isKeybindingOverridden("test.undo")).toBe(true);
+    setKeybindingOverride("test.undo", null);
+    expect(isKeybindingOverridden("test.undo")).toBe(false);
+    expect(getKeybindingFor({ id: "test.undo", title: "Undo", keybinding: "mod+z", run: () => {} })).toBe("mod+z");
+  });
+
+  it("resetAllKeybindings clears every override", () => {
+    setKeybindingOverride("test.undo", "mod+j");
+    setKeybindingOverride("test.redo", "mod+y");
+    expect(hasAnyKeybindingOverride()).toBe(true);
+    resetAllKeybindings();
+    expect(hasAnyKeybindingOverride()).toBe(false);
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY)!)).toEqual({});
+  });
+});
+
+describe("findConflicts", () => {
+  it("finds a command whose binding matches the chord, excluding self", () => {
+    // Rebind redo onto undo's chord.
+    setKeybindingOverride("test.redo", "mod+z");
+    const hits = findConflicts("mod+z", "test.redo");
+    expect(hits.map((c) => c.id)).toContain("test.undo");
+    expect(hits.map((c) => c.id)).not.toContain("test.redo");
+  });
+
+  it("is modifier-order-insensitive", () => {
+    // 'shift+mod+z' should collide with redo's 'mod+shift+z'.
+    const hits = findConflicts("shift+mod+z", "test.undo");
+    expect(hits.map((c) => c.id)).toContain("test.redo");
+  });
+
+  it("returns [] for an empty chord", () => {
+    expect(findConflicts("", "test.undo")).toEqual([]);
+  });
+
+  it("conflictsForCommand reports the other side of a collision", () => {
+    setKeybindingOverride("test.redo", "mod+z");
+    expect(conflictsForCommand("test.redo").map((c) => c.id)).toContain("test.undo");
+    expect(conflictsForCommand("test.undo").map((c) => c.id)).toContain("test.redo");
+  });
+});
+
+describe("subscribeKeybindings", () => {
+  it("notifies on set and reset", () => {
+    const cb = vi.fn();
+    const unsub = subscribeKeybindings(cb);
+    setKeybindingOverride("test.undo", "mod+j");
+    expect(cb).toHaveBeenCalledTimes(1);
+    resetAllKeybindings();
+    expect(cb).toHaveBeenCalledTimes(2);
+    unsub();
+    setKeybindingOverride("test.undo", "mod+j");
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/app/src/commands/keybindings.ts
+++ b/packages/app/src/commands/keybindings.ts
@@ -6,23 +6,112 @@
  * two-chord). The dispatcher below matches a KeyboardEvent against
  * those strings.
  *
- * User customization (future): overrides live in a Map keyed by
- * command id → chord string. For now we only consume the command's
- * own declared binding, but the override indirection is already here.
+ * User customization (#743): overrides live in a Map keyed by command id →
+ * chord string, PERSISTED to localStorage (`stave:keybindings`) so a rebind
+ * survives reload. Writes are write-through + notify subscribers. Persistence
+ * lives here in the app package — the editor package must NOT depend on app
+ * commands (layering).
  */
 
-import { executeCommand, listCommands, type Command } from "./registry";
+import { executeCommand, listCommands, getCommand, type Command } from "./registry";
 
-/** Map of command id → override chord. Empty today, future settings UI. */
+const STORAGE_KEY = "stave:keybindings";
+
+/** Map of command id → override chord (user customisation). */
 const overrides = new Map<string, string>();
+
+type KeybindingListener = () => void;
+const keybindingListeners = new Set<KeybindingListener>();
+
+function notifyKeybindings(): void {
+  for (const l of keybindingListeners) l();
+}
+
+/** Subscribe to override changes (set / reset). Returns an unsubscribe. */
+export function subscribeKeybindings(cb: KeybindingListener): () => void {
+  keybindingListeners.add(cb);
+  return () => { keybindingListeners.delete(cb); };
+}
+
+/** SSR-guarded: read persisted overrides once at module load. */
+function loadOverrides(): void {
+  if (typeof window === "undefined") return;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    for (const [id, chord] of Object.entries(parsed)) {
+      if (typeof chord === "string" && chord) overrides.set(id, chord);
+    }
+  } catch (err) {
+    console.warn("[stave] failed to load persisted keybindings:", err);
+  }
+}
+
+/** SSR-guarded: write the current overrides map through to localStorage. */
+function persistOverrides(): void {
+  if (typeof window === "undefined") return;
+  try {
+    const obj: Record<string, string> = {};
+    for (const [id, chord] of overrides) obj[id] = chord;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(obj));
+  } catch (err) {
+    console.warn("[stave] failed to persist keybindings:", err);
+  }
+}
+
+loadOverrides();
 
 export function setKeybindingOverride(commandId: string, chord: string | null): void {
   if (chord === null) overrides.delete(commandId);
   else overrides.set(commandId, chord);
+  persistOverrides();
+  notifyKeybindings();
+}
+
+/** True when a command's binding has been user-overridden (differs from default). */
+export function isKeybindingOverridden(commandId: string): boolean {
+  return overrides.has(commandId);
+}
+
+/** Clear every user override — all commands fall back to their declared default. */
+export function resetAllKeybindings(): void {
+  if (overrides.size === 0) return;
+  overrides.clear();
+  persistOverrides();
+  notifyKeybindings();
+}
+
+export function hasAnyKeybindingOverride(): boolean {
+  return overrides.size > 0;
 }
 
 export function getKeybindingFor(cmd: Command): string | undefined {
   return overrides.get(cmd.id) ?? cmd.keybinding;
+}
+
+/**
+ * Commands whose EFFECTIVE binding matches `chord`, excluding `excludeId`.
+ * Pure — used to flag conflicts when a user assigns a chord already in use.
+ * Chord comparison is modifier-order-insensitive (see chordMatches).
+ */
+export function findConflicts(chord: string, excludeId: string): Command[] {
+  if (!chord) return [];
+  const hits: Command[] = [];
+  for (const cmd of listCommands()) {
+    if (cmd.id === excludeId) continue;
+    const binding = getKeybindingFor(cmd);
+    if (binding && chordMatches(chord, binding)) hits.push(cmd);
+  }
+  return hits;
+}
+
+/** Conflicts for a command's own current binding (excludes itself). */
+export function conflictsForCommand(commandId: string): Command[] {
+  const cmd = getCommand(commandId);
+  const binding = cmd && getKeybindingFor(cmd);
+  if (!binding) return [];
+  return findConflicts(binding, commandId);
 }
 
 /** Display one chord part ('mod', 'shift', 'z') as a symbol / label. */

--- a/packages/app/src/components/settings/KeyboardShortcutsPanel.tsx
+++ b/packages/app/src/components/settings/KeyboardShortcutsPanel.tsx
@@ -2,7 +2,18 @@
 
 import React, { useEffect, useMemo, useState } from "react";
 import { listCommands, subscribeToCommands, type Command } from "../../commands/registry";
-import { keybindingTokens, getKeybindingFor, setKeybindingOverride } from "../../commands/keybindings";
+import {
+  keybindingTokens,
+  getKeybindingFor,
+  setKeybindingOverride,
+  subscribeKeybindings,
+  isKeybindingOverridden,
+  resetAllKeybindings,
+  hasAnyKeybindingOverride,
+  conflictsForCommand,
+} from "../../commands/keybindings";
+import { EDITOR_OWNED_KEYS, EDITOR_OWNED_CATEGORY } from "./editorOwnedKeys";
+import { IconWarn } from "./icons";
 
 interface KeyboardShortcutsPanelProps {
   query: string;
@@ -14,21 +25,24 @@ interface Row {
 }
 
 /**
- * The Keyboard Shortcuts surface (#739) inside the shell pane. Ports the
- * legacy ShortcutsOverlay's search + click-to-rebind capture into the
- * shell's category nav + kb-row styling.
+ * The Keyboard Shortcuts surface (#739 Phase B) inside the shell pane.
  *
- * Phase A keeps the existing (in-memory) override behaviour so both tabs
- * are functional; Phase B (#743/#744/#745) adds persistence, conflict
- * detection, and read-only "System" rows for editor-owned Monaco keys.
+ * - B1: rebinds persist (via commands/keybindings.ts) and survive reload;
+ *   the panel subscribes so it re-renders on any override change.
+ * - B2: inline conflict badge when a chord collides with another command;
+ *   per-binding reset (only shown when overridden) + a global
+ *   "Reset all keybindings".
+ * - B3: editor-owned Monaco keys render as read-only "System" rows in an
+ *   "Editor" category — searchable, but not rebindable (dispatcher-skipped).
  */
 export function KeyboardShortcutsPanel({ query }: KeyboardShortcutsPanelProps) {
-  const [, force] = useState(0);
+  const [ver, force] = useState(0);
   const tick = () => force((t) => t + 1);
   const [activeCat, setActiveCat] = useState("all");
   const [capturingId, setCapturingId] = useState<string | null>(null);
 
   useEffect(() => subscribeToCommands(tick), []);
+  useEffect(() => subscribeKeybindings(tick), []);
 
   // Capture: while capturing, the next non-modifier keydown becomes the
   // binding; Escape cancels. Capture-phase + stopPropagation so it never
@@ -45,9 +59,8 @@ export function KeyboardShortcutsPanel({ query }: KeyboardShortcutsPanelProps) {
       if (e.shiftKey) parts.push("shift");
       if (e.altKey) parts.push("alt");
       parts.push(e.key.toLowerCase());
-      setKeybindingOverride(capturingId, parts.join("+"));
+      setKeybindingOverride(capturingId, parts.join("+")); // persists + notifies
       setCapturingId(null);
-      tick();
     };
     window.addEventListener("keydown", onKey, true);
     return () => window.removeEventListener("keydown", onKey, true);
@@ -56,8 +69,7 @@ export function KeyboardShortcutsPanel({ query }: KeyboardShortcutsPanelProps) {
   const q = query.trim().toLowerCase();
   const searching = q.length > 0;
 
-  // All commands → rows, grouped by category.
-  const { categories, byCat } = useMemo(() => {
+  const { commandCats, byCat } = useMemo(() => {
     const rows: Row[] = listCommands().map((c) => ({ cmd: c, binding: getKeybindingFor(c) ?? "" }));
     const map = new Map<string, Row[]>();
     for (const r of rows) {
@@ -67,18 +79,24 @@ export function KeyboardShortcutsPanel({ query }: KeyboardShortcutsPanelProps) {
       map.set(cat, list);
     }
     const cats = Array.from(map.keys()).sort((a, b) => a.localeCompare(b));
-    return { categories: cats, byCat: map };
+    return { commandCats: cats, byCat: map };
+    // `ver` bumps on every command/keybinding change so the memoised rows
+    // (which snapshot each command's binding) refresh after a rebind/reset.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query]);
+  }, [query, ver]);
 
   const rowMatches = (r: Row): boolean =>
     !q || `${r.cmd.category ?? ""} ${r.cmd.title}`.toLowerCase().includes(q);
+  const editorKeyMatches = (name: string): boolean => !q || name.toLowerCase().includes(q);
 
-  const visibleCats = searching
-    ? categories
-    : activeCat === "all"
-      ? categories
-      : categories.filter((c) => c === activeCat);
+  const totalCount = listCommands().length + EDITOR_OWNED_KEYS.length;
+  const editorMatchCount = EDITOR_OWNED_KEYS.filter((k) => editorKeyMatches(k.name)).length;
+
+  // Which categories to render (command cats + the synthetic Editor group).
+  const showCat = (cat: string): boolean => {
+    if (searching) return true;
+    return activeCat === "all" || activeCat === cat;
+  };
 
   const renderChord = (r: Row): React.ReactNode => {
     const capturing = capturingId === r.cmd.id;
@@ -101,59 +119,109 @@ export function KeyboardShortcutsPanel({ query }: KeyboardShortcutsPanelProps) {
     );
   };
 
+  const renderCommandRow = (r: Row): React.ReactNode => {
+    const conflicts = r.binding ? conflictsForCommand(r.cmd.id) : [];
+    const overridden = isKeybindingOverridden(r.cmd.id);
+    return (
+      <div className="kb-row" key={r.cmd.id}>
+        <div className="kb-cmd">
+          <div className="kb-name">{r.cmd.title}</div>
+          {conflicts.length ? (
+            <div className="conflict" data-testid={`conflict-${r.cmd.id}`}>
+              <IconWarn /> Also bound to{" "}
+              <strong style={{ margin: "0 3px" }}>{conflicts.map((c) => c.title).join(", ")}</strong> — one will win.
+            </div>
+          ) : null}
+        </div>
+        <div className="kb-right">
+          {overridden ? (
+            <button
+              className="kb-reset"
+              title="Reset to default"
+              data-testid={`reset-${r.cmd.id}`}
+              onClick={() => setKeybindingOverride(r.cmd.id, null)}
+            >
+              ↺
+            </button>
+          ) : null}
+          {renderChord(r)}
+        </div>
+      </div>
+    );
+  };
+
   return (
     <>
       <nav className="nav">
         <div className="nav-eyebrow">Commands</div>
-        <button
-          className="nav-item"
-          aria-current={!searching && activeCat === "all"}
-          onClick={() => setActiveCat("all")}
-        >
+        <button className="nav-item" aria-current={!searching && activeCat === "all"} onClick={() => setActiveCat("all")}>
           <span>All</span>
-          <span className="nav-count">{listCommands().length}</span>
+          <span className="nav-count">{totalCount}</span>
         </button>
-        {categories.map((cat) => (
-          <button
-            key={cat}
-            className="nav-item"
-            aria-current={!searching && activeCat === cat}
-            onClick={() => setActiveCat(cat)}
-          >
+        {commandCats.map((cat) => (
+          <button key={cat} className="nav-item" aria-current={!searching && activeCat === cat} onClick={() => setActiveCat(cat)}>
             <span>{cat}</span>
             <span className="nav-count">{byCat.get(cat)!.length}</span>
           </button>
         ))}
+        <button
+          className="nav-item"
+          aria-current={!searching && activeCat === EDITOR_OWNED_CATEGORY}
+          onClick={() => setActiveCat(EDITOR_OWNED_CATEGORY)}
+        >
+          <span>{EDITOR_OWNED_CATEGORY}</span>
+          <span className="nav-count">{EDITOR_OWNED_KEYS.length}</span>
+        </button>
       </nav>
 
       <div className="content" tabIndex={-1} data-testid="keys-content">
-        {visibleCats.map((cat) => {
+        {hasAnyKeybindingOverride() ? (
+          <div className="grp-head" style={{ paddingTop: 10 }}>
+            <button className="reset" data-testid="reset-all-keybindings" onClick={() => resetAllKeybindings()}>
+              ↺ Reset all keybindings
+            </button>
+          </div>
+        ) : null}
+
+        {commandCats.map((cat) => {
+          if (!showCat(cat)) return null;
           const rows = (byCat.get(cat) ?? []).filter(rowMatches);
           if (rows.length === 0) return null;
           return (
             <section className="grp" key={cat} data-testid={`keys-section-${cat}`}>
               <div className="grp-head"><div className="grp-title">{cat}</div></div>
-              {rows.map((r) => (
-                <div className="kb-row" key={r.cmd.id}>
-                  <div className="kb-cmd"><div className="kb-name">{r.cmd.title}</div></div>
-                  <div className="kb-right">
-                    {r.binding ? (
-                      <button
-                        className="kb-reset"
-                        title="Reset to default"
-                        onClick={() => { setKeybindingOverride(r.cmd.id, null); tick(); }}
-                      >
-                        ↺
-                      </button>
-                    ) : null}
-                    {renderChord(r)}
-                  </div>
-                </div>
-              ))}
+              {rows.map(renderCommandRow)}
             </section>
           );
         })}
-        {visibleCats.every((cat) => (byCat.get(cat) ?? []).filter(rowMatches).length === 0) ? (
+
+        {/* B3 — read-only editor-owned Monaco keys. */}
+        {showCat(EDITOR_OWNED_CATEGORY) && editorMatchCount > 0 ? (
+          <section className="grp" data-testid={`keys-section-${EDITOR_OWNED_CATEGORY}`}>
+            <div className="grp-head">
+              <div className="grp-title">{EDITOR_OWNED_CATEGORY}</div>
+              <span className="badge">Owned by the code editor</span>
+            </div>
+            <div className="grp-note">
+              These live in the Monaco editor, not the command registry — shown for reference, not yet rebindable here.
+            </div>
+            {EDITOR_OWNED_KEYS.filter((k) => editorKeyMatches(k.name)).map((k) => (
+              <div className="kb-row" key={k.name}>
+                <div className="kb-cmd"><div className="kb-name">{k.name}</div></div>
+                <div className="kb-right">
+                  <span className="tag">System</span>
+                  <span className="chord system" data-testid={`system-${k.name}`}>
+                    {keybindingTokens(k.chord).map((t, i) => <kbd key={i}>{t}</kbd>)}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </section>
+        ) : null}
+
+        {searching &&
+        commandCats.every((cat) => (byCat.get(cat) ?? []).filter(rowMatches).length === 0) &&
+        editorMatchCount === 0 ? (
           <div className="empty">No shortcuts match “{query}”.</div>
         ) : null}
       </div>

--- a/packages/app/src/components/settings/editorOwnedKeys.ts
+++ b/packages/app/src/components/settings/editorOwnedKeys.ts
@@ -1,0 +1,28 @@
+/**
+ * Editor-owned Monaco keys (#745).
+ *
+ * These shortcuts live in scattered Monaco / editor handlers OUTSIDE the app
+ * command registry, so they are not dispatched by installKeybindingDispatcher
+ * and cannot (yet) be rebound here. Rather than hide them — which would read
+ * as "Stave has no Run shortcut" — we surface them as READ-ONLY "System" rows
+ * for reference. Rerouting Monaco through the registry is deliberately out of
+ * scope (decision D2).
+ *
+ * Chords are in the same `mod+key` form the rest of the shell uses, so
+ * `keybindingTokens` renders them identically (⌘⏎, ⌘., ⌘/, ⇧⌥F).
+ */
+
+export interface EditorOwnedKey {
+  readonly name: string;
+  readonly chord: string;
+}
+
+export const EDITOR_OWNED_KEYS: readonly EditorOwnedKey[] = [
+  { name: "Run / Evaluate", chord: "mod+enter" },
+  { name: "Stop", chord: "mod+." },
+  { name: "Toggle Line Comment", chord: "mod+/" },
+  { name: "Format Document", chord: "shift+alt+f" },
+];
+
+/** Nav / display label for the read-only editor-owned group. */
+export const EDITOR_OWNED_CATEGORY = "Editor";

--- a/packages/app/tests/keybindings-editor.spec.ts
+++ b/packages/app/tests/keybindings-editor.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect, type Page } from '@playwright/test'
+
+// #739 Phase B — the finished keyboard-shortcuts editor: rebinds persist
+// across reload, conflicts are flagged, editor-owned Monaco keys are shown
+// read-only, and reset (per-binding + global) restores defaults.
+
+test.beforeEach(async ({ page }) => {
+  // Each test gets a fresh browser context (empty localStorage), so no
+  // clearing is needed — and clearing via addInitScript would re-fire on the
+  // reload inside the persistence test and wipe the very override under test.
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-workspace-shell="root"]').waitFor({ timeout: 15000 })
+  await page.locator('.monaco-editor').first().waitFor({ timeout: 15000 })
+})
+
+async function openKeys(page: Page) {
+  await page.getByRole('button', { name: 'File', exact: true }).click()
+  await page.getByText('Keyboard Shortcuts...').click()
+  await expect(page.getByTestId('settings-shell')).toBeVisible({ timeout: 4000 })
+  await expect(page.getByTestId('settings-tab-keys')).toHaveAttribute('aria-selected', 'true')
+}
+
+// Enter capture and wait for the "Press keys…" state (proof the capture
+// listener is attached) before dispatching, so the press can't race the
+// React effect that installs it.
+async function rebind(page: Page, id: string, keys: string) {
+  const chord = page.getByTestId(`chord-${id}`)
+  await chord.click()
+  await expect(chord).toContainText('Press keys')
+  await page.keyboard.press(keys)
+}
+
+test('a rebind persists across reload', async ({ page }) => {
+  await openKeys(page)
+  // Rebind "Quick Open (Go to File)" (stave.quickOpen, default ⌘P) to ⌘J.
+  await rebind(page, 'stave.quickOpen', 'Meta+J')
+  await expect(page.getByTestId('chord-stave.quickOpen')).toContainText('J')
+  // Reload, reopen — override survived.
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await page.locator('.monaco-editor').first().waitFor({ timeout: 15000 })
+  await openKeys(page)
+  await expect(page.getByTestId('chord-stave.quickOpen')).toContainText('J')
+})
+
+test('assigning an in-use chord flags a conflict', async ({ page }) => {
+  await openKeys(page)
+  // Rebind quickOpen onto the command palette's ⌘⇧P (in use).
+  await rebind(page, 'stave.quickOpen', 'Meta+Shift+P')
+  // A conflict badge appears on the rebent row.
+  await expect(page.getByTestId('conflict-stave.quickOpen')).toBeVisible()
+  await expect(page.getByTestId('conflict-stave.quickOpen')).toContainText('Also bound to')
+})
+
+test('editor-owned keys are read-only System rows', async ({ page }) => {
+  await openKeys(page)
+  // The "all" view already renders the read-only Editor section.
+  const runRow = page.getByTestId('system-Run / Evaluate')
+  await expect(runRow).toBeVisible()
+  // System chord is a <span>, not a rebindable <button> — no chord-* testid.
+  await expect(page.locator('[data-testid="chord-Run / Evaluate"]')).toHaveCount(0)
+  await expect(page.getByText('Owned by the code editor')).toBeVisible()
+})
+
+test('per-binding reset only appears after an override, and restores the default', async ({ page }) => {
+  await openKeys(page)
+  // No reset button before overriding.
+  await expect(page.getByTestId('reset-stave.quickOpen')).toHaveCount(0)
+  await rebind(page, 'stave.quickOpen', 'Meta+J')
+  const reset = page.getByTestId('reset-stave.quickOpen')
+  await expect(reset).toBeVisible()
+  await reset.click()
+  // Back to the default ⌘P; reset button gone.
+  await expect(page.getByTestId('chord-stave.quickOpen')).toContainText('P')
+  await expect(page.getByTestId('reset-stave.quickOpen')).toHaveCount(0)
+})
+
+test('global reset-all clears every override', async ({ page }) => {
+  await openKeys(page)
+  await rebind(page, 'stave.quickOpen', 'Meta+J')
+  const resetAll = page.getByTestId('reset-all-keybindings')
+  await expect(resetAll).toBeVisible()
+  await resetAll.click()
+  await expect(page.getByTestId('chord-stave.quickOpen')).toContainText('P')
+  await expect(page.getByTestId('reset-all-keybindings')).toHaveCount(0)
+})


### PR DESCRIPTION
Replaces #747, which GitHub auto-closed when its base branch `feat/739-settings-shell-phase-a` was deleted on the #746 merge (stacked-child branch-deletion closes rather than retargets). Phase A content is already in `studio_v0.2.0` via #746; this carries only the Phase B commit.

Phase B — keyboard-shortcuts editor: persist / conflict-detect / reset / System rows. Closes #743, #744, #745.

Full app suite green, tsc clean. Local test-merge onto current `studio_v0.2.0` is conflict-free.