### PR TITLE
💄 fix(timeline): align the full-song zoom/follow controls to the left edge

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -1331,7 +1331,7 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
           surfaced via the data attribute below for Playwright observation. */}
       <div data-full-song-period={periodLabel} style={{ display: 'none' }} />
 
-      {/* Controls: zoom cluster (right). The CYCLES/BARS units toggle moved to
+      {/* Controls: zoom cluster (left). The CYCLES/BARS units toggle moved to
           the editor pattern bar (#750). ⌘/Ctrl+wheel also zooms. */}
       <div data-full-song="controls" style={styles.controls}>
         <div style={styles.zoomCluster} data-full-song-zoom={zoomPercent}>
@@ -1765,7 +1765,7 @@ const styles = {
     minHeight: CONTROLS_HEIGHT,
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'flex-end',
+    justifyContent: 'flex-start',
     gap: 8,
     padding: '0 8px',
     background: 'var(--bg-app, #090912)',


### PR DESCRIPTION
## Problem
The full-song controls row (FOLLOW · Fit · − · 100% · +) was right-aligned (`styles.controls` used `justifyContent: flex-end`), pinning the cluster to the right edge.

## Fix
One-line layout change: `styles.controls` → `justifyContent: flex-start`, so the cluster hugs the left edge. Buttons and behaviour unchanged. (Comment updated "right" → "left".)

## Test plan
- `tsc --noEmit` clean. No test asserts control alignment.
- **Observed on :3000** (screenshot): cluster now 8px from the container's left edge (its padding), ~963px of free space on the right; measured verdict LEFT-ALIGNED; zero console/page errors.

Closes #757