### PR TITLE
🐛 fix(mixer): instrument picker shows the full live catalog before Play

### DIFF
--- a/packages/app/src/components/StaveApp.tsx
+++ b/packages/app/src/components/StaveApp.tsx
@@ -709,20 +709,34 @@ export function StaveApp({ initialProject }: StaveAppProps) {
     setSoundCatalogAccessor(() => groupSoundCatalog(readDict()));
     let lastCount = -1;
     let stable = 0;
+    let ticks = 0;
+    // Ceiling so we never poll forever if the engine never initializes (eager
+    // warm-up failed AND the user never pressed Play). ~2 min at 1.5s cadence.
+    const MAX_TICKS = 80;
     const tick = () => {
+      ticks += 1;
       const dict = readDict();
       const count = dict ? Object.keys(dict).length : 0;
       if (count !== lastCount) {
         lastCount = count;
         stable = 0;
         notifySoundCatalogChanged();
-      } else {
+      } else if (count > 0) {
+        // Only settle once we actually have a live list. A count stuck at 0
+        // means the engine hasn't inited yet (init is lazy — first Play or the
+        // eager warm-up in StrudelEditorClient) — keep polling so a later init
+        // refreshes the picker instead of leaving it on the curated fallback
+        // (#813). The old `else` incremented here even at 0, so a slow/late
+        // init would find the poll already dead and never repopulate.
         stable += 1;
       }
     };
     const id = window.setInterval(() => {
       tick();
-      if (stable >= 4) window.clearInterval(id); // count settled → stop polling
+      // Stop once a real (non-zero) list has settled, or give up at the ceiling.
+      if ((lastCount > 0 && stable >= 4) || ticks >= MAX_TICKS) {
+        window.clearInterval(id);
+      }
     }, 1500);
     tick();
     return () => {

--- a/packages/app/src/components/StrudelEditorClient.tsx
+++ b/packages/app/src/components/StrudelEditorClient.tsx
@@ -1438,6 +1438,45 @@ export default function StrudelEditorClient({
     });
   }, [runtimeStates, onActiveRuntimeStateChange]);
 
+  // #813 — Eager engine warm-up so the instrument picker is fully populated
+  // before the user presses Play. The picker reads superdough's global
+  // `soundMap`, which is published only when an engine initializes — and init
+  // is lazy (first Play). Without this, opening the picker on a fresh page
+  // shows only the ~27-item curated fallback. We create the active (or first)
+  // Strudel file's runtime and `init()` it on idle: init only registers sounds
+  // and fetches sample manifests — no scheduler.start(), and it creates the
+  // AudioContext suspended, so no user gesture is needed and no audio plays.
+  // The runtime + init are idempotent, so a later Play reuses this same warmed
+  // runtime (soundMap is a superdough module singleton — warming any one
+  // Strudel engine fills every picker). Runs once; retries via the file-list
+  // subscription because files load async (IDB) and may be absent at mount.
+  const warmedRef = useRef(false);
+  useEffect(() => {
+    const tryWarm = () => {
+      if (warmedRef.current) return;
+      const active = activeFileIdRef.current;
+      const fid =
+        active && getFile(active)?.language === "strudel"
+          ? active
+          : listWorkspaceFiles().find((f) => f.language === "strudel")?.id ??
+            null;
+      if (!fid) return; // no Strudel file yet — the subscription retries
+      warmedRef.current = true;
+      const warm = () => {
+        void getOrCreateRuntime(fid)
+          ?.init()
+          .catch(() => {}); // warm-up is best-effort; Play still inits on demand
+      };
+      const w = window as unknown as {
+        requestIdleCallback?: (cb: () => void) => number;
+      };
+      if (typeof w.requestIdleCallback === "function") w.requestIdleCallback(warm);
+      else window.setTimeout(warm, 0);
+    };
+    tryWarm(); // files already present at mount (warm start / cached project)
+    return subscribeToFileList(tryWarm); // or when they finish loading
+  }, [getOrCreateRuntime]);
+
   // Persist on every shell mutation (#175). Fires reactively from the
   // shell's single onGroupsChange sink; no debounce — localStorage
   // writes are O(1) and the snapshot is small.


### PR DESCRIPTION
## Problem

Opening the melodic instrument picker (Pattern-tab inspector) showed only the **~27-item curated fallback** instead of the **~494 live instruments**. Two compounding causes, both confirmed by observing `globalThis.soundMap` in the running app (`undefined` on load → 1853 keys only after a first Play):

1. **The data source is lazy.** The picker reads superdough's global `soundMap`, published only inside `engine.init()` — and init fires on the first **Play/eval**, never on mount. Until you play, `soundMap` is absent, so `MixerBody` renders `liveInstruments ?? INSTRUMENTS` → the fallback.
2. **The bridge poll killed itself at zero.** `StaveApp`'s 1.5s poll stopped after 4 *unchanged* ticks — but 'unchanged' counted being stuck at **0** (engine not yet inited). If you didn't Play within ~6s of load, the poll settled at 0 and cleared itself; a later Play then populated `soundMap` but nothing re-notified the picker → stuck on the fallback until a remount.

## Fix

- **Poll** (`StaveApp.tsx`): only begin the settle countdown once the count is non-zero; keep polling while the engine is still uninitialized, with a tick ceiling (~2 min) so it never polls forever. A slow/late init now refreshes the picker instead of finding a dead poll.
- **Eager warm-up** (`StrudelEditorClient.tsx`): on idle after mount, create the active (or first) Strudel file's runtime and `init()` it — init only registers sounds and fetches sample manifests (**no** `scheduler.start()`, the AudioContext is created *suspended*, so no user gesture and no audio). Runtime + init are idempotent, so a later Play reuses the warmed runtime; `soundMap` is a superdough module singleton, so warming any one engine fills every picker. Retries via the file-list subscription since files load async.

## Test plan

- **Observed (real browser, no Play, no keypress):** fresh page → `soundMap` reaches **1853 keys within ~1.5s** and the picker renders **495 options** across **Synths / Soundfonts / Wavetables / Samples**, sawtooth + soundfonts present, **zero page errors**.
- App unit suite: **630/630 green**.
- No new lint errors/warnings in the two changed files (the one `activeFileIdRef` immutability error is pre-existing on `studio_v0.2.0`).

Closes #813