### PR TITLE
✨ Asset Library shell — sidebar browser + provider abstraction (#819)

### DIFF
--- a/packages/app/src/assetLibrary/AssetLibraryPanel.tsx
+++ b/packages/app/src/assetLibrary/AssetLibraryPanel.tsx
@@ -1,0 +1,492 @@
+"use client";
+
+/**
+ * Asset Library shell (#819) — the reusable browser that houses every asset
+ * type. It knows nothing sound- or viz-specific: it enumerates the registered
+ * {@link AssetProvider}s, applies the search + type + source filters, and
+ * renders a windowed list of provider-supplied {@link Asset}s. Each row exposes
+ * two uniform action slots — a primary preview (play/stop) and a hover insert —
+ * that just drive `asset.preview()` / `asset.insert()`.
+ *
+ * The concrete Sounds provider lands in #820; until then a demo stub (behind the
+ * `stave.assetLibrary.demo` localStorage flag) exercises the shell.
+ */
+
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Icon } from "../components/Icon";
+import {
+  listAssetProviders,
+  subscribeToAssetProviders,
+} from "./registry";
+import {
+  availableSources,
+  availableTypes,
+  collectAssets,
+  type AssetFilter,
+} from "./filter";
+import type { Asset, AssetPreviewHandle, AssetSource, AssetType } from "./types";
+
+const ROW_HEIGHT = 40;
+/** Extra rows rendered above/below the viewport so fast scrolls don't flash. */
+const OVERSCAN = 6;
+
+const TYPE_LABELS: Record<AssetType, string> = {
+  sound: "Sounds",
+  viz: "Viz",
+  snippet: "Snippets",
+  sample: "Samples",
+};
+const SOURCE_LABELS: Record<AssetSource, string> = {
+  "built-in": "Built-in",
+  user: "User",
+  community: "Community",
+};
+
+export function AssetLibraryPanel({ onClose }: { onClose?: () => void }) {
+  // Re-render on any provider registration / catalog change.
+  const [tick, setTick] = useState(0);
+  useEffect(() => subscribeToAssetProviders(() => setTick((t) => t + 1)), []);
+  const providers = useMemo(() => listAssetProviders(), [tick]);
+
+  const [query, setQuery] = useState("");
+  const [type, setType] = useState<AssetType | null>(null);
+  const [source, setSource] = useState<AssetSource | null>(null);
+
+  const filter: AssetFilter = useMemo(
+    () => ({ query, type, source }),
+    [query, type, source],
+  );
+  const assets = useMemo(
+    () => collectAssets(providers, filter),
+    [providers, filter],
+  );
+
+  const types = useMemo(() => availableTypes(providers), [providers]);
+  const sources = useMemo(() => availableSources(providers), [providers]);
+  const loading = providers.some((p) => p.isLoading?.() ?? false);
+
+  // A type/source chip that filters to a value no longer present would strand
+  // the list empty with no way back — drop the filter if its value vanished.
+  useEffect(() => {
+    if (type && !types.includes(type)) setType(null);
+  }, [type, types]);
+  useEffect(() => {
+    if (source && !sources.includes(source)) setSource(null);
+  }, [source, sources]);
+
+  // ---- Single-active-preview: starting a row stops the previous one. --------
+  const activePreview = useRef<{ key: string; handle: AssetPreviewHandle | null } | null>(null);
+  const [previewingKey, setPreviewingKey] = useState<string | null>(null);
+
+  const stopPreview = useCallback(() => {
+    activePreview.current?.handle?.stop();
+    activePreview.current = null;
+    setPreviewingKey(null);
+  }, []);
+
+  // Stop any preview when the panel unmounts (closed / project switch).
+  useEffect(() => stopPreview, [stopPreview]);
+
+  const togglePreview = useCallback(
+    async (key: string, asset: Asset) => {
+      if (!asset.preview) return;
+      if (previewingKey === key) {
+        stopPreview();
+        return;
+      }
+      stopPreview();
+      setPreviewingKey(key);
+      // Mark this the active request BEFORE awaiting so a slower earlier start
+      // can't clobber a newer one.
+      const token = { key, handle: null as AssetPreviewHandle | null };
+      activePreview.current = token;
+      try {
+        const handle = await asset.preview();
+        if (activePreview.current !== token) {
+          // A newer preview started (or stop fired) while we awaited — cancel.
+          handle?.stop();
+          return;
+        }
+        token.handle = handle ?? null;
+        // Fire-and-forget previews (void handle) clear the "playing" badge
+        // immediately; sustained ones keep it until stop.
+        if (!handle) setPreviewingKey((cur) => (cur === key ? null : cur));
+      } catch {
+        if (activePreview.current === token) stopPreview();
+      }
+    },
+    [previewingKey, stopPreview],
+  );
+
+  return (
+    <div style={styles.root} data-sidebar data-asset-library>
+      <div style={styles.header}>
+        <span>LIBRARY</span>
+        {onClose && (
+          <button
+            style={styles.headerClose}
+            title="Close"
+            aria-label="Close Library"
+            onClick={onClose}
+          >
+            <Icon name="chevron-left" size="14px" />
+          </button>
+        )}
+      </div>
+
+      <div style={styles.controls}>
+        <input
+          style={styles.search}
+          placeholder="Search assets…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          data-asset-search
+          aria-label="Search assets"
+        />
+        {types.length > 1 && (
+          <ChipRow
+            label="Type"
+            active={type}
+            values={types}
+            render={(t) => TYPE_LABELS[t]}
+            onPick={(t) => setType(t)}
+            dataAttr="asset-type-filter"
+          />
+        )}
+        {sources.length > 1 && (
+          <ChipRow
+            label="Source"
+            active={source}
+            values={sources}
+            render={(s) => SOURCE_LABELS[s]}
+            onPick={(s) => setSource(s)}
+            dataAttr="asset-source-filter"
+          />
+        )}
+      </div>
+
+      <AssetList
+        assets={assets}
+        loading={loading}
+        previewingKey={previewingKey}
+        onTogglePreview={togglePreview}
+        data-asset-list
+      />
+    </div>
+  );
+}
+
+/** A labelled row of mutually-exclusive filter chips ("All" + each value). */
+function ChipRow<T extends string>({
+  label,
+  active,
+  values,
+  render,
+  onPick,
+  dataAttr,
+}: {
+  label: string;
+  active: T | null;
+  values: readonly T[];
+  render: (v: T) => string;
+  onPick: (v: T | null) => void;
+  dataAttr: string;
+}) {
+  return (
+    <div style={styles.chipRow} data-filter={dataAttr} aria-label={`${label} filter`}>
+      <button
+        style={{ ...styles.chip, ...(active === null ? styles.chipActive : {}) }}
+        onClick={() => onPick(null)}
+        data-chip="all"
+      >
+        All
+      </button>
+      {values.map((v) => (
+        <button
+          key={v}
+          style={{ ...styles.chip, ...(active === v ? styles.chipActive : {}) }}
+          onClick={() => onPick(active === v ? null : v)}
+          data-chip={v}
+        >
+          {render(v)}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** Windowed list — renders only the rows in view (+overscan). The sound catalog
+ *  is ~1800 rows, so full rendering would jank; a fixed row height lets us map
+ *  scrollTop → visible slice without measuring. */
+function AssetList({
+  assets,
+  loading,
+  previewingKey,
+  onTogglePreview,
+}: {
+  assets: Asset[];
+  loading: boolean;
+  previewingKey: string | null;
+  onTogglePreview: (key: string, asset: Asset) => void;
+} & Record<`data-${string}`, string>) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [viewportH, setViewportH] = useState(0);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const measure = () => setViewportH(el.clientHeight);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const total = assets.length;
+  const first = Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - OVERSCAN);
+  const visibleCount = Math.ceil(viewportH / ROW_HEIGHT) + OVERSCAN * 2;
+  const last = Math.min(total, first + visibleCount);
+  const slice = assets.slice(first, last);
+
+  if (loading && total === 0) {
+    return (
+      <div style={styles.listEmpty} data-asset-list data-state="loading">
+        Loading assets…
+      </div>
+    );
+  }
+  if (total === 0) {
+    return (
+      <div style={styles.listEmpty} data-asset-list data-state="empty">
+        No assets match.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={scrollRef}
+      style={styles.listScroll}
+      onScroll={(e) => setScrollTop(e.currentTarget.scrollTop)}
+      data-asset-list
+      data-count={String(total)}
+    >
+      <div style={{ height: total * ROW_HEIGHT, position: "relative" }}>
+        {slice.map((asset, i) => {
+          const index = first + i;
+          const key = `${asset.type}:${asset.id}`;
+          return (
+            <AssetRow
+              key={key}
+              asset={asset}
+              rowKey={key}
+              top={index * ROW_HEIGHT}
+              previewing={previewingKey === key}
+              onTogglePreview={onTogglePreview}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function AssetRow({
+  asset,
+  rowKey,
+  top,
+  previewing,
+  onTogglePreview,
+}: {
+  asset: Asset;
+  rowKey: string;
+  top: number;
+  previewing: boolean;
+  onTogglePreview: (key: string, asset: Asset) => void;
+}) {
+  const [hovered, setHovered] = useState(false);
+  return (
+    <div
+      style={{ ...styles.row, top }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      data-asset-row={rowKey}
+    >
+      <div style={styles.rowText}>
+        <span style={styles.rowName}>{asset.name}</span>
+        {asset.group && <span style={styles.rowGroup}>{asset.group}</span>}
+      </div>
+      <div style={styles.rowActions}>
+        {/* Insert — hover-revealed secondary slot. */}
+        {asset.insert && (hovered || previewing) && (
+          <button
+            style={styles.rowBtn}
+            title="Insert into code"
+            aria-label={`Insert ${asset.name}`}
+            onClick={() => asset.insert?.()}
+            data-asset-insert={rowKey}
+          >
+            <Icon name="add" size="14px" />
+          </button>
+        )}
+        {/* Preview — primary slot; play toggles to stop while active. */}
+        {asset.preview && (
+          <button
+            style={{ ...styles.rowBtn, ...(previewing ? styles.rowBtnActive : {}) }}
+            title={previewing ? "Stop" : "Preview"}
+            aria-label={previewing ? `Stop ${asset.name}` : `Preview ${asset.name}`}
+            onClick={() => onTogglePreview(rowKey, asset)}
+            data-asset-preview={rowKey}
+          >
+            <Icon name={previewing ? "debug-stop" : "play"} size="14px" />
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  root: {
+    width: 260,
+    height: "100%",
+    background: "var(--bg-panel)",
+    borderRight: "1px solid var(--border-subtle)",
+    display: "flex",
+    flexDirection: "column",
+    fontFamily: "system-ui, -apple-system, sans-serif",
+    minHeight: 0,
+  },
+  header: {
+    padding: "10px 14px",
+    fontSize: 10,
+    fontWeight: 600,
+    letterSpacing: 0.8,
+    color: "var(--text-secondary)",
+    borderBottom: "1px solid var(--border-subtle)",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  headerClose: {
+    background: "none",
+    border: "none",
+    color: "var(--text-icon-muted)",
+    cursor: "pointer",
+    padding: 2,
+    display: "flex",
+    alignItems: "center",
+  },
+  controls: {
+    padding: "10px 12px",
+    display: "flex",
+    flexDirection: "column",
+    gap: 8,
+    borderBottom: "1px solid var(--border-subtle)",
+  },
+  search: {
+    width: "100%",
+    boxSizing: "border-box",
+    padding: "6px 8px",
+    fontSize: 12,
+    color: "var(--text-primary)",
+    background: "var(--bg-input, var(--bg-chrome))",
+    border: "1px solid var(--border-subtle)",
+    borderRadius: 4,
+    outline: "none",
+    fontFamily: "inherit",
+  },
+  chipRow: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: 4,
+  },
+  chip: {
+    padding: "2px 8px",
+    fontSize: 11,
+    color: "var(--text-secondary)",
+    background: "transparent",
+    border: "1px solid var(--border-subtle)",
+    borderRadius: 10,
+    cursor: "pointer",
+    fontFamily: "inherit",
+    lineHeight: 1.6,
+  },
+  chipActive: {
+    color: "var(--text-primary)",
+    background: "var(--accent-soft, var(--bg-chrome))",
+    borderColor: "var(--accent-strong)",
+  },
+  listScroll: {
+    flex: 1,
+    minHeight: 0,
+    overflowY: "auto",
+    overflowX: "hidden",
+  },
+  listEmpty: {
+    flex: 1,
+    minHeight: 0,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 20,
+    fontSize: 12,
+    color: "var(--text-tertiary)",
+    textAlign: "center",
+  },
+  row: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    height: ROW_HEIGHT,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    padding: "0 8px 0 14px",
+    boxSizing: "border-box",
+    gap: 6,
+  },
+  rowText: {
+    display: "flex",
+    flexDirection: "column",
+    minWidth: 0,
+    flex: 1,
+  },
+  rowName: {
+    fontSize: 12,
+    color: "var(--text-primary)",
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+  },
+  rowGroup: {
+    fontSize: 10,
+    color: "var(--text-tertiary)",
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+  },
+  rowActions: {
+    display: "flex",
+    alignItems: "center",
+    gap: 2,
+    flexShrink: 0,
+  },
+  rowBtn: {
+    width: 24,
+    height: 24,
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    background: "none",
+    border: "none",
+    borderRadius: 4,
+    color: "var(--text-icon-muted)",
+    cursor: "pointer",
+    padding: 0,
+  },
+  rowBtnActive: {
+    color: "var(--accent-strong)",
+  },
+};

--- a/packages/app/src/assetLibrary/AssetLibraryPanel.tsx
+++ b/packages/app/src/assetLibrary/AssetLibraryPanel.tsx
@@ -170,7 +170,6 @@ export function AssetLibraryPanel({ onClose }: { onClose?: () => void }) {
         loading={loading}
         previewingKey={previewingKey}
         onTogglePreview={togglePreview}
-        data-asset-list
       />
     </div>
   );
@@ -228,7 +227,7 @@ function AssetList({
   loading: boolean;
   previewingKey: string | null;
   onTogglePreview: (key: string, asset: Asset) => void;
-} & Record<`data-${string}`, string>) {
+}) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [scrollTop, setScrollTop] = useState(0);
   const [viewportH, setViewportH] = useState(0);

--- a/packages/app/src/assetLibrary/__tests__/assetLibrary.test.ts
+++ b/packages/app/src/assetLibrary/__tests__/assetLibrary.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  registerAssetProvider,
+  listAssetProviders,
+  getAssetProvider,
+  subscribeToAssetProviders,
+  notifyAssetProvidersChanged,
+} from "../registry";
+import {
+  collectAssets,
+  matchesQuery,
+  availableTypes,
+  availableSources,
+  type AssetFilter,
+} from "../filter";
+import type { Asset, AssetProvider, AssetType, AssetSource } from "../types";
+
+function asset(
+  type: AssetType,
+  id: string,
+  name: string,
+  source: AssetSource,
+  tags: string[] = [],
+  group?: string,
+): Asset {
+  return { type, id, name, source, tags, group };
+}
+
+function provider(
+  type: AssetType,
+  assets: Asset[],
+  extra: Partial<AssetProvider> = {},
+): AssetProvider {
+  return { type, label: type, list: () => assets, ...extra };
+}
+
+// The registry is a module singleton — clear it between tests.
+function clearRegistry() {
+  for (const p of listAssetProviders()) {
+    // register a throwaway of the same type then unregister to purge; simpler:
+    // rely on getAssetProvider identity via a fresh replace + unreg.
+    const unreg = registerAssetProvider(p);
+    unreg();
+  }
+}
+
+describe("asset registry", () => {
+  beforeEach(clearRegistry);
+
+  it("registers and lists a provider", () => {
+    const p = provider("sound", [asset("sound", "a", "a", "built-in")]);
+    registerAssetProvider(p);
+    expect(getAssetProvider("sound")).toBe(p);
+    expect(listAssetProviders()).toContain(p);
+  });
+
+  it("one provider per type — re-registering replaces", () => {
+    const p1 = provider("sound", []);
+    const p2 = provider("sound", []);
+    registerAssetProvider(p1);
+    registerAssetProvider(p2);
+    expect(getAssetProvider("sound")).toBe(p2);
+    expect(listAssetProviders().filter((p) => p.type === "sound")).toHaveLength(1);
+  });
+
+  it("unregister removes only the still-registered provider", () => {
+    const p1 = provider("sound", []);
+    const unreg1 = registerAssetProvider(p1);
+    const p2 = provider("sound", []);
+    registerAssetProvider(p2); // replaces p1
+    unreg1(); // stale — must NOT remove p2
+    expect(getAssetProvider("sound")).toBe(p2);
+  });
+
+  it("notifies subscribers on register, change, and unregister", () => {
+    let hits = 0;
+    const unsub = subscribeToAssetProviders(() => hits++);
+    const unreg = registerAssetProvider(provider("viz", []));
+    notifyAssetProvidersChanged();
+    unreg();
+    unsub();
+    expect(hits).toBe(3);
+  });
+});
+
+describe("matchesQuery", () => {
+  const a = asset("sound", "bd", "Bass Drum", "built-in", ["kick", "909"], "Drums");
+  it("empty query matches", () => expect(matchesQuery(a, "")).toBe(true));
+  it("matches name case-insensitively", () => expect(matchesQuery(a, "bass")).toBe(true));
+  it("matches a tag", () => expect(matchesQuery(a, "909")).toBe(true));
+  it("matches the group", () => expect(matchesQuery(a, "drum")).toBe(true));
+  it("no match returns false", () => expect(matchesQuery(a, "piano")).toBe(false));
+});
+
+describe("collectAssets", () => {
+  const sounds = provider("sound", [
+    asset("sound", "piano", "piano", "built-in", ["keys"]),
+    asset("sound", "mysample", "mysample", "user", ["import"]),
+  ]);
+  const viz = provider("viz", [asset("viz", "scope", "Scope", "built-in", ["wave"])]);
+  const providers = [sounds, viz];
+  const base: AssetFilter = { query: "", type: null, source: null };
+
+  it("flattens all providers with no filter", () => {
+    expect(collectAssets(providers, base)).toHaveLength(3);
+  });
+
+  it("type filter restricts to one provider", () => {
+    const r = collectAssets(providers, { ...base, type: "viz" });
+    expect(r.map((a) => a.id)).toEqual(["scope"]);
+  });
+
+  it("source filter is per-asset across providers", () => {
+    const r = collectAssets(providers, { ...base, source: "user" });
+    expect(r.map((a) => a.id)).toEqual(["mysample"]);
+  });
+
+  it("generic query matches name/tag when provider has no search", () => {
+    const r = collectAssets(providers, { ...base, query: "keys" });
+    expect(r.map((a) => a.id)).toEqual(["piano"]);
+  });
+
+  it("uses a provider's own search when present", () => {
+    const searchable = provider(
+      "snippet",
+      [asset("snippet", "x", "x", "built-in")],
+      { search: () => [asset("snippet", "hit", "hit", "built-in")] },
+    );
+    const r = collectAssets([searchable], { ...base, query: "anything" });
+    expect(r.map((a) => a.id)).toEqual(["hit"]);
+  });
+
+  it("combines type + source + query", () => {
+    const r = collectAssets(providers, { query: "piano", type: "sound", source: "built-in" });
+    expect(r.map((a) => a.id)).toEqual(["piano"]);
+  });
+});
+
+describe("available filter values", () => {
+  const providers = [
+    provider("sound", [
+      asset("sound", "a", "a", "built-in"),
+      asset("sound", "b", "b", "user"),
+    ]),
+    provider("viz", [asset("viz", "v", "v", "community")]),
+  ];
+  it("availableTypes lists present types", () => {
+    expect(availableTypes(providers).sort()).toEqual(["sound", "viz"]);
+  });
+  it("availableSources lists present sources", () => {
+    expect(availableSources(providers).sort()).toEqual([
+      "built-in",
+      "community",
+      "user",
+    ]);
+  });
+});

--- a/packages/app/src/assetLibrary/exampleProvider.ts
+++ b/packages/app/src/assetLibrary/exampleProvider.ts
@@ -10,7 +10,7 @@
  */
 
 import { registerAssetProvider } from "./registry";
-import type { Asset, AssetProvider, AssetSource, AssetType } from "./types";
+import type { Asset, AssetSource, AssetType } from "./types";
 
 const FLAG = "stave.assetLibrary.demo";
 
@@ -60,18 +60,11 @@ const DEMO_ASSETS: Asset[] = [
   makeAsset("sound", "storepad", "Store Pad", "community", "Marketplace", ["pad"]),
 ];
 
-const demoProvider: AssetProvider = {
-  type: "sound",
-  label: "Demo",
-  // A single stub stands in for every type; the shell filters it by type, so
-  // list() returns all demo assets and the type filter narrows them.
-  list: () => DEMO_ASSETS,
-};
-
 /**
  * Register the demo provider(s) when the flag is set. Returns an unregister fn
  * (no-op when the flag is off). The stub covers 4 types, so we register one
- * provider per distinct type it contains (the registry is keyed by type).
+ * provider per distinct type it contains (the registry is keyed by type) —
+ * which also mirrors the real model where each type is its own provider.
  */
 export function registerDemoAssetProviders(): () => void {
   if (typeof window === "undefined") return () => {};
@@ -91,8 +84,5 @@ export function registerDemoAssetProviders(): () => void {
       list: () => DEMO_ASSETS.filter((a) => a.type === t),
     }),
   );
-  // Keep the aggregate provider referenced so tree-shaking doesn't drop it and
-  // future manual testing can import it directly.
-  void demoProvider;
   return () => unregs.forEach((u) => u());
 }

--- a/packages/app/src/assetLibrary/exampleProvider.ts
+++ b/packages/app/src/assetLibrary/exampleProvider.ts
@@ -1,0 +1,98 @@
+/**
+ * Demo stub provider — exercises the shell (#819) before the real Sounds
+ * provider (#820) exists. Registered ONLY when the `stave.assetLibrary.demo`
+ * localStorage flag is set (matches the `stave.viz.*` dev-flag convention), so
+ * production is clean and #820 removes this file.
+ *
+ * It supplies a handful of assets across types + sources so type/source filters
+ * have something to filter, and a fake sustained preview (returns a stop handle)
+ * to verify single-active-preview + the play/stop toggle.
+ */
+
+import { registerAssetProvider } from "./registry";
+import type { Asset, AssetProvider, AssetSource, AssetType } from "./types";
+
+const FLAG = "stave.assetLibrary.demo";
+
+function makeAsset(
+  type: AssetType,
+  id: string,
+  name: string,
+  source: AssetSource,
+  group: string,
+  tags: string[],
+): Asset {
+  return {
+    type,
+    id,
+    name,
+    source,
+    group,
+    tags,
+    preview: () => {
+      // Fake a sustained preview: log start, return a stop handle. Real
+      // providers start audio here; the shell only needs the handle contract.
+      // eslint-disable-next-line no-console
+      console.log(`[asset-demo] preview ▶ ${name}`);
+      return {
+        stop: () => {
+          // eslint-disable-next-line no-console
+          console.log(`[asset-demo] preview ⏹ ${name}`);
+        },
+      };
+    },
+    insert: () => {
+      // eslint-disable-next-line no-console
+      console.log(`[asset-demo] insert ＋ ${name}`);
+    },
+  };
+}
+
+const DEMO_ASSETS: Asset[] = [
+  makeAsset("sound", "piano", "piano", "built-in", "Keys", ["melodic", "gm"]),
+  makeAsset("sound", "bd", "bd", "built-in", "Drums", ["kit", "percussion"]),
+  makeAsset("sound", "sawtooth", "sawtooth", "built-in", "Synths", ["synth"]),
+  makeAsset("sound", "mysample", "mysample", "user", "Imported", ["user"]),
+  makeAsset("viz", "pianoroll", "Piano Roll", "built-in", "p5", ["notes"]),
+  makeAsset("viz", "scope", "Scope", "built-in", "p5", ["waveform"]),
+  makeAsset("snippet", "fourfloor", "Four on the floor", "built-in", "Beats", ["drum"]),
+  makeAsset("sample", "kick909", "kick909.wav", "user", "Imported", ["kick"]),
+  makeAsset("sound", "storepad", "Store Pad", "community", "Marketplace", ["pad"]),
+];
+
+const demoProvider: AssetProvider = {
+  type: "sound",
+  label: "Demo",
+  // A single stub stands in for every type; the shell filters it by type, so
+  // list() returns all demo assets and the type filter narrows them.
+  list: () => DEMO_ASSETS,
+};
+
+/**
+ * Register the demo provider(s) when the flag is set. Returns an unregister fn
+ * (no-op when the flag is off). The stub covers 4 types, so we register one
+ * provider per distinct type it contains (the registry is keyed by type).
+ */
+export function registerDemoAssetProviders(): () => void {
+  if (typeof window === "undefined") return () => {};
+  let on = false;
+  try {
+    on = window.localStorage.getItem(FLAG) != null;
+  } catch {
+    on = false;
+  }
+  if (!on) return () => {};
+
+  const types: AssetType[] = ["sound", "viz", "snippet", "sample"];
+  const unregs = types.map((t) =>
+    registerAssetProvider({
+      type: t,
+      label: { sound: "Sounds", viz: "Viz", snippet: "Snippets", sample: "Samples" }[t],
+      list: () => DEMO_ASSETS.filter((a) => a.type === t),
+    }),
+  );
+  // Keep the aggregate provider referenced so tree-shaking doesn't drop it and
+  // future manual testing can import it directly.
+  void demoProvider;
+  return () => unregs.forEach((u) => u());
+}

--- a/packages/app/src/assetLibrary/filter.ts
+++ b/packages/app/src/assetLibrary/filter.ts
@@ -1,0 +1,72 @@
+/**
+ * Pure filtering over the union of all providers' assets. Kept separate from
+ * the panel component so the search/type/source logic is unit-testable without
+ * React. The panel calls {@link collectAssets} on every registry tick + filter
+ * change; the result is what the windowed list renders.
+ */
+
+import type { Asset, AssetProvider, AssetSource, AssetType } from "./types";
+
+export interface AssetFilter {
+  /** Trimmed search query; empty string matches everything. */
+  query: string;
+  /** null = all types; otherwise restrict to this one. */
+  type: AssetType | null;
+  /** null = all sources; otherwise restrict to this one. */
+  source: AssetSource | null;
+}
+
+/** Generic name/tag/group substring match — the fallback when a provider has no
+ *  own `search`. Case-insensitive, whitespace-trimmed. */
+export function matchesQuery(asset: Asset, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) return true;
+  if (asset.name.toLowerCase().includes(q)) return true;
+  if (asset.group && asset.group.toLowerCase().includes(q)) return true;
+  return asset.tags.some((t) => t.toLowerCase().includes(q));
+}
+
+/**
+ * Flatten every provider's assets into one list under the given filter.
+ * Type filter is applied at the provider level (skip whole providers) so a
+ * lazily-filling provider of another type isn't even enumerated; source and
+ * query are applied per-asset. A provider's own `search` wins over the generic
+ * matcher when a query is present.
+ */
+export function collectAssets(
+  providers: readonly AssetProvider[],
+  filter: AssetFilter,
+): Asset[] {
+  const q = filter.query.trim();
+  const out: Asset[] = [];
+  for (const provider of providers) {
+    if (filter.type && provider.type !== filter.type) continue;
+    const base = q && provider.search ? provider.search(q) : provider.list();
+    for (const asset of base) {
+      if (filter.source && asset.source !== filter.source) continue;
+      // Provider `search` already applied the query; only the generic path
+      // needs the substring gate here.
+      if (q && !provider.search && !matchesQuery(asset, q)) continue;
+      out.push(asset);
+    }
+  }
+  return out;
+}
+
+/** The set of types actually present across the providers — drives which type
+ *  filter chips are shown (no empty chips). */
+export function availableTypes(providers: readonly AssetProvider[]): AssetType[] {
+  const seen = new Set<AssetType>();
+  for (const p of providers) seen.add(p.type);
+  return Array.from(seen);
+}
+
+/** The set of sources actually present across all listed assets — drives which
+ *  source filter chips are shown. */
+export function availableSources(providers: readonly AssetProvider[]): AssetSource[] {
+  const seen = new Set<AssetSource>();
+  for (const p of providers) {
+    for (const a of p.list()) seen.add(a.source);
+  }
+  return Array.from(seen);
+}

--- a/packages/app/src/assetLibrary/registry.ts
+++ b/packages/app/src/assetLibrary/registry.ts
@@ -1,0 +1,58 @@
+/**
+ * Asset provider registry — module-level singleton, same shape as
+ * `panels/registry.ts` and `commands/registry.ts`. Providers register once
+ * (typically in a `useEffect` in the app shell) and the Asset Library panel
+ * enumerates them live; a lazily-filling provider calls
+ * {@link notifyAssetProvidersChanged} so the panel re-lists.
+ *
+ * One provider per {@link AssetType}: registering a type that's already present
+ * replaces it (last-writer-wins), which is how #820's real Sounds provider
+ * supersedes the demo stub.
+ */
+
+import type { AssetProvider, AssetType } from "./types";
+
+const providers = new Map<AssetType, AssetProvider>();
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  for (const l of listeners) l();
+}
+
+/** Register (or replace) the provider for its type. Returns an unregister fn. */
+export function registerAssetProvider(provider: AssetProvider): () => void {
+  providers.set(provider.type, provider);
+  notify();
+  return () => {
+    // Only remove if this exact provider is still the registered one — guards
+    // against a stale unregister clobbering a provider that replaced it.
+    if (providers.get(provider.type) === provider) {
+      providers.delete(provider.type);
+      notify();
+    }
+  };
+}
+
+/** All registered providers, in stable registration order. */
+export function listAssetProviders(): AssetProvider[] {
+  return Array.from(providers.values());
+}
+
+export function getAssetProvider(type: AssetType): AssetProvider | undefined {
+  return providers.get(type);
+}
+
+/**
+ * Signal that a provider's catalog changed (e.g. sounds finished warming up).
+ * The panel subscribes and re-lists; providers themselves also fire this.
+ */
+export function notifyAssetProvidersChanged(): void {
+  notify();
+}
+
+export function subscribeToAssetProviders(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}

--- a/packages/app/src/assetLibrary/types.ts
+++ b/packages/app/src/assetLibrary/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Asset Library — the typed model behind the unified sidebar browser (#818).
+ *
+ * One shell, pluggable providers. Every browsable thing — sounds, viz presets,
+ * snippets, user samples, and (later) community/marketplace items — is an
+ * {@link Asset} surfaced by an {@link AssetProvider}. The shell renders a search
+ * box + a type filter + a source filter over the union of all providers; it
+ * never knows what a "sound" or a "viz preset" is. Adding an asset type is
+ * registering one provider (see {@link ./registry}); adding the community store
+ * is one new `source` + a remote provider, not a UI rewrite.
+ *
+ * `preview()` / `insert()` live ON the asset (a sound auditions and writes
+ * `.sound()`; a viz preset renders a thumbnail and writes `.viz()`), so the
+ * shell drives them uniformly through the row action slots.
+ */
+
+/** Asset categories. Each maps to exactly one registered provider. */
+export type AssetType = "sound" | "viz" | "snippet" | "sample";
+
+/**
+ * Where an asset comes from — a filter axis, not a provider axis. `built-in`
+ * ships with Stave; `user` is locally imported (Pillar 6); `community` is the
+ * future marketplace, which slots in as a remote provider tagged this source
+ * with no shell changes.
+ */
+export type AssetSource = "built-in" | "user" | "community";
+
+/**
+ * A handle returned by {@link Asset.preview} so the shell can stop an in-flight
+ * preview (a sustained/looping audition) when another row starts or the panel
+ * closes. Providers whose preview is instantaneous may return a no-op.
+ */
+export interface AssetPreviewHandle {
+  /** Stop this preview. Idempotent — safe to call after it already ended. */
+  stop: () => void;
+}
+
+/**
+ * One browsable item. `preview`/`insert` are the two verbs the shell exposes
+ * as row action slots; both are optional so a provider can offer either, both,
+ * or (rarely) neither.
+ */
+export interface Asset {
+  readonly type: AssetType;
+  /** Stable within a provider; the shell keys rows on `${type}:${id}`. */
+  readonly id: string;
+  readonly name: string;
+  readonly source: AssetSource;
+  /** Free-form tags — searched alongside the name, shown as row metadata. */
+  readonly tags: readonly string[];
+  /** Optional secondary label (e.g. category / GM family) shown muted. */
+  readonly group?: string;
+  /**
+   * Start a preview. Returns a handle to stop it, or void for a fire-and-forget
+   * preview. May be async (engine warm-up). Absent → no preview affordance.
+   */
+  readonly preview?: () => AssetPreviewHandle | void | Promise<AssetPreviewHandle | void>;
+  /**
+   * Round-trip this asset into legible code (assign to the focused track, or
+   * insert at the cursor). Absent → no insert affordance.
+   */
+  readonly insert?: () => void | Promise<void>;
+}
+
+/**
+ * Supplies assets of one {@link AssetType}. Mirrors the accessor/registry model
+ * Stave already uses for sounds (`setSoundCatalogAccessor`) and viz
+ * (`VizPresetStore`): the provider owns enumeration; preview/insert live on the
+ * assets it returns.
+ */
+export interface AssetProvider {
+  readonly type: AssetType;
+  /** Human label for the type filter chip (e.g. "Sounds"). */
+  readonly label: string;
+  /**
+   * All assets this provider currently knows about. Cheap and synchronous —
+   * the shell re-lists on {@link ./registry.subscribeToAssetProviders} ticks,
+   * so a provider whose catalog fills lazily (sounds warm up after engine init)
+   * notifies the registry and returns the grown list here.
+   */
+  list: () => readonly Asset[];
+  /**
+   * Optional provider-specific search. When absent, the shell falls back to a
+   * generic name/tag/group substring match over {@link list}.
+   */
+  search?: (query: string) => readonly Asset[];
+  /**
+   * Whether this provider's catalog is still populating (engine warm-up). Drives
+   * the shell's loading state. Absent → treated as ready.
+   */
+  isLoading?: () => boolean;
+}

--- a/packages/app/src/components/StaveApp.tsx
+++ b/packages/app/src/components/StaveApp.tsx
@@ -59,6 +59,8 @@ import { IRInspectorPanel } from "./IRInspectorPanel";
 import { registerCommand } from "../commands/registry";
 import { installKeybindingDispatcher } from "../commands/keybindings";
 import { registerPanel } from "../panels/registry";
+import { AssetLibraryPanel } from "../assetLibrary/AssetLibraryPanel";
+import { registerDemoAssetProviders } from "../assetLibrary/exampleProvider";
 import {
   listWorkspaceFiles,
   subscribeToFileList,
@@ -1081,6 +1083,17 @@ export function StaveApp({ initialProject }: StaveAppProps) {
       render: () => null,
     }));
     unregs.push(registerPanel({
+      id: "library",
+      title: "Library",
+      icon: "library",
+      order: 40,
+      render: () => null,
+    }));
+    // Asset Library demo providers (#819) — only registered behind the
+    // `stave.assetLibrary.demo` localStorage flag; no-op in production. The
+    // real Sounds provider (#820) supersedes these.
+    unregs.push(registerDemoAssetProviders());
+    unregs.push(registerPanel({
       id: "console",
       title: "Console",
       icon: "terminal",
@@ -1228,6 +1241,9 @@ export function StaveApp({ initialProject }: StaveAppProps) {
               />
             </div>
           </div>
+        )}
+        {!zenMode && activePanelId === "library" && (
+          <AssetLibraryPanel onClose={() => setActivePanelId(null)} />
         )}
         {!zenMode && activePanelId === "console" && <ConsolePanel />}
         {!zenMode && activePanelId === "ir-inspector" && (


### PR DESCRIPTION
Part of the Asset Library epic (#818), **Phase 1**. Delivers the reusable shell that houses every asset type — built provider-first so it isn't sound-specific. The concrete Sounds provider follows in #820.

## What's in
- **`Asset` / `AssetProvider` model** (`types.ts`) — `Asset = { type, id, name, source, tags, preview(), insert() }`; one provider enumerates one type. `preview`/`insert` live on the asset so the shell drives them uniformly. The `source` axis (`built-in | user | community`) is a **filter**, so the future marketplace lands as a remote provider + source, not a redesign.
- **Provider registry** (`registry.ts`) — module singleton mirroring `panels/registry` & `commands/registry`. One provider per type (last-writer-wins), subscribable so a lazily-filling catalog re-lists.
- **Pure filter logic** (`filter.ts`) — flattens providers under search + type + source; provider-own `search` with a generic name/tag/group fallback. Fully unit-tested.
- **`AssetLibraryPanel`** — a new **"Library" `ActivityBar` item** opens a left **sidebar panel** (sibling to the file tree): search box, type/source filter chips, a **windowed** scrollable list (the sound catalog is ~1800 rows; no virtualization lib exists so a minimal fixed-row windower is included), shared row frame with a **hover-insert** slot + a **play/stop preview** slot, and **single-active-preview** (starting a row stops the previous). Empty/loading states included.
- **Demo stub provider** behind the `stave.assetLibrary.demo` localStorage flag (matches the `stave.viz.*` dev-flag convention) so the shell is observable now; production is clean and #820 removes it.

## Boundary decision
The whole library lives in **`@stave/app`** and consumes `@stave/editor` exports, per the established convention (`editor/src/index.ts:561`: *"panels live in @stave/app and import these via @stave/editor"*). Editor can't import from app, and the shell's mounting surface (ActivityBar, panels/registry, StaveApp) is app-only. Bonus: iteration avoids the editor dist-rebuild dance. **No editor src touched.**

## Test plan
- `pnpm --filter @stave/app test` — **647 green** (+17 new: registry identity/replace/subscribe, filter search/type/source combinations, available-value derivation).
- **Observed in the running app** (Playwright, demo flag on): Library item toggles the panel; 9 stub rows render; `type=viz` → 2 rows, `source=user` → 2 rows, `search="piano"` → 2 cross-type matches; single-active-preview logs `▶ piano → ⏹ piano → ▶ bd`; stop toggle + hover-insert fire; zero page errors.

## Out of scope (later children)
Concrete providers (Sounds = #820), real audition/play-pause wiring, community/remote sources.