### PR TITLE
🐛 Asset Library: windowing fixes dropped from #821 merge (F1/F2)

### DIFF
--- a/packages/app/src/assetLibrary/AssetLibraryPanel.tsx
+++ b/packages/app/src/assetLibrary/AssetLibraryPanel.tsx
@@ -24,6 +24,7 @@ import {
   collectAssets,
   type AssetFilter,
 } from "./filter";
+import { computeWindow } from "./windowing";
 import type { Asset, AssetPreviewHandle, AssetSource, AssetType } from "./types";
 
 const ROW_HEIGHT = 40;
@@ -170,6 +171,10 @@ export function AssetLibraryPanel({ onClose }: { onClose?: () => void }) {
         loading={loading}
         previewingKey={previewingKey}
         onTogglePreview={togglePreview}
+        // Reset scroll to top when the FILTER changes (not when the catalog
+        // grows under a stable filter) — a new search starts at the top, but
+        // browsing position survives a lazily-growing provider.
+        resetKey={`${type ?? ""}|${source ?? ""}|${query}`}
       />
     </div>
   );
@@ -196,6 +201,7 @@ function ChipRow<T extends string>({
       <button
         style={{ ...styles.chip, ...(active === null ? styles.chipActive : {}) }}
         onClick={() => onPick(null)}
+        aria-pressed={active === null}
         data-chip="all"
       >
         All
@@ -205,6 +211,7 @@ function ChipRow<T extends string>({
           key={v}
           style={{ ...styles.chip, ...(active === v ? styles.chipActive : {}) }}
           onClick={() => onPick(active === v ? null : v)}
+          aria-pressed={active === v}
           data-chip={v}
         >
           {render(v)}
@@ -222,30 +229,48 @@ function AssetList({
   loading,
   previewingKey,
   onTogglePreview,
+  resetKey,
 }: {
   assets: Asset[];
   loading: boolean;
   previewingKey: string | null;
   onTogglePreview: (key: string, asset: Asset) => void;
+  resetKey: string;
 }) {
-  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const nodeRef = useRef<HTMLDivElement | null>(null);
+  const roRef = useRef<ResizeObserver | null>(null);
   const [scrollTop, setScrollTop] = useState(0);
   const [viewportH, setViewportH] = useState(0);
 
-  useEffect(() => {
-    const el = scrollRef.current;
+  // Callback ref, NOT a mount effect: the scroll node only exists once the
+  // catalog is non-empty, so a one-shot `[]` effect that reads scrollRef at
+  // first mount misses the loading→loaded transition (the node is null then
+  // and the effect never re-runs). A stable callback ref fires on every
+  // attach/detach, so the observer wires up whenever the list actually renders
+  // — including after a lazy provider (sounds) warms up. (F1)
+  const setScrollEl = useCallback((el: HTMLDivElement | null) => {
+    roRef.current?.disconnect();
+    roRef.current = null;
+    nodeRef.current = el;
     if (!el) return;
-    const measure = () => setViewportH(el.clientHeight);
-    measure();
-    const ro = new ResizeObserver(measure);
+    setViewportH(el.clientHeight);
+    const ro = new ResizeObserver(() => setViewportH(el.clientHeight));
     ro.observe(el);
-    return () => ro.disconnect();
+    roRef.current = ro;
   }, []);
+  useEffect(() => () => roRef.current?.disconnect(), []);
+
+  // Reset scroll when the filter changes so a new search starts at the top and
+  // a stale scrollTop can't point past the (now shorter) content. (F2)
+  useEffect(() => {
+    if (nodeRef.current) nodeRef.current.scrollTop = 0;
+    setScrollTop(0);
+  }, [resetKey]);
 
   const total = assets.length;
-  const first = Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - OVERSCAN);
-  const visibleCount = Math.ceil(viewportH / ROW_HEIGHT) + OVERSCAN * 2;
-  const last = Math.min(total, first + visibleCount);
+  // `computeWindow` clamps `first` so a stale (too-large) scrollTop after the
+  // list shrinks can never produce an empty slice (start > end → blank). (F2)
+  const { first, last } = computeWindow(total, scrollTop, viewportH, ROW_HEIGHT, OVERSCAN);
   const slice = assets.slice(first, last);
 
   if (loading && total === 0) {
@@ -265,7 +290,7 @@ function AssetList({
 
   return (
     <div
-      ref={scrollRef}
+      ref={setScrollEl}
       style={styles.listScroll}
       onScroll={(e) => setScrollTop(e.currentTarget.scrollTop)}
       data-asset-list

--- a/packages/app/src/assetLibrary/__tests__/windowing.test.ts
+++ b/packages/app/src/assetLibrary/__tests__/windowing.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { computeWindow } from "../windowing";
+
+const RH = 40;
+const OV = 6;
+
+describe("computeWindow", () => {
+  it("empty list → zero range", () => {
+    expect(computeWindow(0, 0, 400, RH, OV)).toEqual({ first: 0, last: 0 });
+  });
+
+  it("top of a tall list renders viewport + overscan from 0", () => {
+    // viewport 400 → ceil(400/40)=10 + 12 overscan = 22 rows
+    const { first, last } = computeWindow(1000, 0, 400, RH, OV);
+    expect(first).toBe(0);
+    expect(last).toBe(22);
+  });
+
+  it("scrolled down renders the surrounding slice", () => {
+    // scrollTop 40000 → row 1000; first = 1000-6 = 994
+    const { first, last } = computeWindow(2000, 40000, 400, RH, OV);
+    expect(first).toBe(994);
+    expect(last).toBe(994 + 22);
+  });
+
+  it("F2: stale large scrollTop after the list shrinks never yields an empty slice", () => {
+    // Was scrolled to row ~1000, then a filter left only 2 matches.
+    const { first, last } = computeWindow(2, 40000, 400, RH, OV);
+    expect(first).toBe(0);
+    expect(last).toBe(2);
+    expect(last).toBeGreaterThan(first); // non-empty — the bug was slice(994,2)=[]
+  });
+
+  it("clamps first so the last page is fully shown, not scrolled past", () => {
+    // total 30, viewport 400 (22 visible). maxFirst = 30-22 = 8.
+    const { first, last } = computeWindow(30, 99999, 400, RH, OV);
+    expect(first).toBe(8);
+    expect(last).toBe(30);
+  });
+
+  it("viewportH 0 (not yet measured) still yields a non-empty slice", () => {
+    const { first, last } = computeWindow(100, 0, 0, RH, OV);
+    expect(first).toBe(0);
+    expect(last).toBe(12); // ceil(0/40)=0 + 12 overscan
+    expect(last).toBeGreaterThan(first);
+  });
+});

--- a/packages/app/src/assetLibrary/exampleProvider.ts
+++ b/packages/app/src/assetLibrary/exampleProvider.ts
@@ -9,10 +9,16 @@
  * to verify single-active-preview + the play/stop toggle.
  */
 
-import { registerAssetProvider } from "./registry";
-import type { Asset, AssetSource, AssetType } from "./types";
+import {
+  registerAssetProvider,
+  notifyAssetProvidersChanged,
+} from "./registry";
+import type { Asset, AssetProvider, AssetSource, AssetType } from "./types";
 
 const FLAG = "stave.assetLibrary.demo";
+/** `stave.assetLibrary.demoLazy` — start the sound provider empty + loading,
+ *  then fill after a tick, to exercise the loading→loaded transition (F1). */
+const LAZY_FLAG = "stave.assetLibrary.demoLazy";
 
 function makeAsset(
   type: AssetType,
@@ -60,29 +66,93 @@ const DEMO_ASSETS: Asset[] = [
   makeAsset("sound", "storepad", "Store Pad", "community", "Marketplace", ["pad"]),
 ];
 
+/** Pad the sound bucket up to `count` synthetic rows so the list is long
+ *  enough to scroll (needed to exercise the windowing paths). */
+function soundAssets(count: number): Asset[] {
+  const base = DEMO_ASSETS.filter((a) => a.type === "sound");
+  if (count <= base.length) return base;
+  const extra: Asset[] = [];
+  for (let i = base.length; i < count; i++) {
+    extra.push(
+      makeAsset("sound", `gen${i}`, `sound ${i}`, "built-in", "Generated", ["gen"]),
+    );
+  }
+  return [...base, ...extra];
+}
+
+const TYPE_LABEL: Record<AssetType, string> = {
+  sound: "Sounds",
+  viz: "Viz",
+  snippet: "Snippets",
+  sample: "Samples",
+};
+
 /**
  * Register the demo provider(s) when the flag is set. Returns an unregister fn
- * (no-op when the flag is off). The stub covers 4 types, so we register one
- * provider per distinct type it contains (the registry is keyed by type) —
- * which also mirrors the real model where each type is its own provider.
+ * (no-op when the flag is off). One provider per type (the registry is keyed by
+ * type), which mirrors the real model. Dev knobs on the flag VALUE:
+ *  - a positive integer N → pad the Sounds provider to N rows (scroll testing).
+ *  - `stave.assetLibrary.demoLazy` set → the Sounds provider starts empty +
+ *    loading, then fills on the next tick (loading→loaded transition).
  */
 export function registerDemoAssetProviders(): () => void {
   if (typeof window === "undefined") return () => {};
-  let on = false;
+  let raw: string | null = null;
+  let lazy = false;
   try {
-    on = window.localStorage.getItem(FLAG) != null;
+    raw = window.localStorage.getItem(FLAG);
+    lazy = window.localStorage.getItem(LAZY_FLAG) != null;
   } catch {
-    on = false;
+    return () => {};
   }
-  if (!on) return () => {};
+  if (raw == null) return () => {};
 
-  const types: AssetType[] = ["sound", "viz", "snippet", "sample"];
-  const unregs = types.map((t) =>
-    registerAssetProvider({
-      type: t,
-      label: { sound: "Sounds", viz: "Viz", snippet: "Snippets", sample: "Samples" }[t],
-      list: () => DEMO_ASSETS.filter((a) => a.type === t),
-    }),
-  );
-  return () => unregs.forEach((u) => u());
+  const count = Math.max(0, Number.parseInt(raw, 10) || 0);
+  const fullSounds = soundAssets(count);
+
+  // Lazy sound provider: empty + loading until `filled` flips on a timer, then
+  // notify so the panel re-lists — the exact shape of the real sound catalog
+  // warming up after engine init.
+  let filled = !lazy;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  if (lazy) {
+    // The lazy-flag VALUE is the fill delay in ms (default 1000) so a test can
+    // open the panel BEFORE the fill and observe the loading→loaded transition.
+    let delayMs = 1000;
+    try {
+      const v = Number.parseInt(window.localStorage.getItem(LAZY_FLAG) ?? "", 10);
+      if (Number.isFinite(v) && v > 0) delayMs = v;
+    } catch {
+      /* keep default */
+    }
+    timer = setTimeout(() => {
+      filled = true;
+      notifyAssetProvidersChanged();
+    }, delayMs);
+  }
+  const soundProvider: AssetProvider = {
+    type: "sound",
+    label: TYPE_LABEL.sound,
+    list: () => (filled ? fullSounds : []),
+    isLoading: () => !filled,
+  };
+
+  // In lazy mode register ONLY the (empty+loading) sound provider so the panel
+  // opens genuinely empty — the strict loading→loaded condition F1 fixes. The
+  // other types have data immediately and would otherwise keep total>0.
+  const otherTypes: AssetType[] = lazy ? [] : ["viz", "snippet", "sample"];
+  const unregs = [
+    registerAssetProvider(soundProvider),
+    ...otherTypes.map((t) =>
+      registerAssetProvider({
+        type: t,
+        label: TYPE_LABEL[t],
+        list: () => DEMO_ASSETS.filter((a) => a.type === t),
+      }),
+    ),
+  ];
+  return () => {
+    if (timer) clearTimeout(timer);
+    unregs.forEach((u) => u());
+  };
 }

--- a/packages/app/src/assetLibrary/windowing.ts
+++ b/packages/app/src/assetLibrary/windowing.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure windowing math for the asset list — extracted so the clamp that guards
+ * against a blank render (F2) is unit-testable without React/DOM.
+ *
+ * Maps a scroll offset + viewport height to the slice of fixed-height rows to
+ * render (with overscan). The critical invariant: when `total > 0` the returned
+ * range is always non-empty (`first < last`), even if `scrollTop` is stale and
+ * points past the (possibly just-shrunk) content — otherwise `slice(first,last)`
+ * with `first > last` yields `[]` and the list paints blank.
+ */
+
+export interface WindowRange {
+  first: number;
+  last: number;
+}
+
+export function computeWindow(
+  total: number,
+  scrollTop: number,
+  viewportH: number,
+  rowHeight: number,
+  overscan: number,
+): WindowRange {
+  if (total <= 0) return { first: 0, last: 0 };
+  const visibleCount = Math.ceil(viewportH / rowHeight) + overscan * 2;
+  const maxFirst = Math.max(0, total - visibleCount);
+  const first = Math.min(
+    maxFirst,
+    Math.max(0, Math.floor(scrollTop / rowHeight) - overscan),
+  );
+  const last = Math.min(total, first + visibleCount);
+  return { first, last };
+}


### PR DESCRIPTION
Follow-up to #819 / PR #821. The self-review windowing-fix commit (`a785bfa8`) **did not make it into the merge** — PR #821 was merged with `731f96d3` as its head (the fix push hadn't propagated to the PR view yet), so `studio_v0.2.0` currently ships the two windowing bugs the self-review caught. This re-applies that commit (cherry-picked, clean).

## Bugs restored-to-fixed
- **F1 — windowed list froze at ~12 rows after a lazy load.** ResizeObserver lived in a one-shot `[]` mount effect reading a ref; when the panel mounts empty+loading the scroll node isn't rendered, the effect bails on a null ref and never re-runs → `viewportH` stuck at 0 → only overscan rows render regardless of panel height. **Fix:** attach the observer from a stable **callback ref**.
- **F2 — filtering while scrolled down painted a blank list.** `slice(first,last)` with unclamped `first = floor(scrollTop/rh)-overscan`: after the list shrinks under a large scrollTop, `first > last` → empty slice → blank. **Fix:** pure `computeWindow` clamps `first` to `max(0, total-visibleCount)`; scroll resets on filter change.
- Also: `aria-pressed` on filter chips; the dev stub gains count + lazy-delay knobs so both conditions reproduce.

Both matter for #820's lazy ~1800-row Sounds provider.

## Test plan
- `pnpm --filter @stave/app test` — **653 green** (incl. 6 new `computeWindow` cases covering the shrink-while-scrolled regression).
- **Observed in the running app** (pre-merge, same commit): panel opens `data-state="loading"`, post-fill renders **31 rows** filling a 726px viewport (= `ceil(726/40)+12`; the bug gives 12); scroll-to-row-380-then-narrow yields **11 rendered, not blank**.

Closes the gap; no editor src touched.