### PR TITLE
✨ Asset Library: category filter tags with entry counts (#826)

### DIFF
--- a/packages/app/src/app/globals.css
+++ b/packages/app/src/app/globals.css
@@ -248,6 +248,13 @@ body {
   background-clip: padding-box;
 }
 
+/* Asset Library category-tag belt (#826): 2 rows that scroll horizontally with
+   NO visible scrollbar (inline styles can't target the pseudo-element). The belt
+   still scrolls; only the bar is hidden. */
+[data-filter="asset-category-filter"]::-webkit-scrollbar {
+  display: none;
+}
+
 /* --- Editor hover-doc width cap -------------------------------------------
    Monaco sizes a hover widget to the widest line of its markdown and SCROLLS
    overflow rather than wrapping it, so a long example line (e.g. pickRestart's

--- a/packages/app/src/assetLibrary/AssetLibraryPanel.tsx
+++ b/packages/app/src/assetLibrary/AssetLibraryPanel.tsx
@@ -289,7 +289,7 @@ function CategoryChips({
   onPick: (c: string | null) => void;
 }) {
   return (
-    <div style={styles.chipRow} data-filter="asset-category-filter" aria-label="Category filter">
+    <div style={styles.categoryChipRow} data-filter="asset-category-filter" aria-label="Category filter">
       <button
         style={{ ...styles.chip, ...(active === null ? styles.chipActive : {}) }}
         onClick={() => onPick(null)}
@@ -543,9 +543,23 @@ const styles: Record<string, React.CSSProperties> = {
     flexWrap: "wrap",
     gap: 4,
   },
+  // Category tags: capped at 2 rows that scroll horizontally (a column-flow
+  // grid — chips fill top-then-bottom per column, the belt overflows sideways).
+  // The scrollbar is hidden via a globals.css `::-webkit-scrollbar` rule on the
+  // `[data-filter="asset-category-filter"]` selector (inline can't do pseudos).
+  categoryChipRow: {
+    display: "grid",
+    gridAutoFlow: "column",
+    gridTemplateRows: "repeat(2, auto)",
+    gridAutoColumns: "max-content",
+    gap: 4,
+    overflowX: "auto",
+    overflowY: "hidden",
+  },
   chip: {
     padding: "2px 8px",
     fontSize: 11,
+    whiteSpace: "nowrap",
     color: "var(--text-secondary)",
     background: "transparent",
     // Longhand (not the `border` shorthand) so `chipActive`'s borderColor

--- a/packages/app/src/assetLibrary/AssetLibraryPanel.tsx
+++ b/packages/app/src/assetLibrary/AssetLibraryPanel.tsx
@@ -555,6 +555,11 @@ const styles: Record<string, React.CSSProperties> = {
     gap: 4,
     overflowX: "auto",
     overflowY: "hidden",
+    // Hide the scrollbar cross-browser: `scrollbarWidth` covers Firefox (which
+    // ignores the webkit pseudo); the globals.css `::-webkit-scrollbar` rule
+    // covers Blink/WebKit. The belt still scrolls. (Same dual pattern as
+    // WorkspaceShell's tabbar.)
+    scrollbarWidth: "none",
   },
   chip: {
     padding: "2px 8px",

--- a/packages/app/src/assetLibrary/AssetLibraryPanel.tsx
+++ b/packages/app/src/assetLibrary/AssetLibraryPanel.tsx
@@ -20,6 +20,7 @@ import {
   subscribeToAssetProviders,
 } from "./registry";
 import {
+  availableCategories,
   availableSources,
   availableTypes,
   collectAssets,
@@ -81,10 +82,11 @@ export function AssetLibraryPanel({ onClose }: { onClose?: () => void }) {
   const [query, setQuery] = useState("");
   const [type, setType] = useState<AssetType | null>(null);
   const [source, setSource] = useState<AssetSource | null>(null);
+  const [category, setCategory] = useState<string | null>(null);
 
   const filter: AssetFilter = useMemo(
-    () => ({ query, type, source }),
-    [query, type, source],
+    () => ({ query, type, source, category }),
+    [query, type, source, category],
   );
   const assets = useMemo(
     () => collectAssets(providers, filter),
@@ -93,6 +95,16 @@ export function AssetLibraryPanel({ onClose }: { onClose?: () => void }) {
 
   const types = useMemo(() => availableTypes(providers), [providers]);
   const sources = useMemo(() => availableSources(providers), [providers]);
+  // Category counts are scoped to the active type/source (so they match "All")
+  // but ignore the query/category, so the numbers stay put while browsing.
+  const categories = useMemo(
+    () => availableCategories(providers, { type, source }),
+    [providers, type, source],
+  );
+  const total = useMemo(
+    () => categories.reduce((n, c) => n + c.count, 0),
+    [categories],
+  );
   const loading = providers.some((p) => p.isLoading?.() ?? false);
 
   // A type/source chip that filters to a value no longer present would strand
@@ -103,6 +115,9 @@ export function AssetLibraryPanel({ onClose }: { onClose?: () => void }) {
   useEffect(() => {
     if (source && !sources.includes(source)) setSource(null);
   }, [source, sources]);
+  useEffect(() => {
+    if (category && !categories.some((c) => c.category === category)) setCategory(null);
+  }, [category, categories]);
 
   // ---- Single-active-preview: starting a row stops the previous one. --------
   const activePreview = useRef<{ key: string; handle: AssetPreviewHandle | null } | null>(null);
@@ -173,6 +188,14 @@ export function AssetLibraryPanel({ onClose }: { onClose?: () => void }) {
           data-asset-search
           aria-label="Search assets"
         />
+        {categories.length > 1 && (
+          <CategoryChips
+            active={category}
+            total={total}
+            categories={categories}
+            onPick={setCategory}
+          />
+        )}
         {types.length > 1 && (
           <ChipRow
             label="Type"
@@ -203,7 +226,7 @@ export function AssetLibraryPanel({ onClose }: { onClose?: () => void }) {
         // Reset scroll to top when the FILTER changes (not when the catalog
         // grows under a stable filter) — a new search starts at the top, but
         // browsing position survives a lazily-growing provider.
-        resetKey={`${type ?? ""}|${source ?? ""}|${query}`}
+        resetKey={`${type ?? ""}|${source ?? ""}|${category ?? ""}|${query}`}
       />
     </div>
   );
@@ -244,6 +267,46 @@ function ChipRow<T extends string>({
           data-chip={v}
         >
           {render(v)}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/** Category filter chips with entry counts: `All <total>` + one per category
+ *  (`Drums 1357`, `Soundfonts 125`, …). Picking narrows the list to that
+ *  category; clicking the active one (or All) clears it. Wraps to fit the
+ *  compact sidebar (the shared chipRow style). */
+function CategoryChips({
+  active,
+  total,
+  categories,
+  onPick,
+}: {
+  active: string | null;
+  total: number;
+  categories: { category: string; count: number }[];
+  onPick: (c: string | null) => void;
+}) {
+  return (
+    <div style={styles.chipRow} data-filter="asset-category-filter" aria-label="Category filter">
+      <button
+        style={{ ...styles.chip, ...(active === null ? styles.chipActive : {}) }}
+        onClick={() => onPick(null)}
+        aria-pressed={active === null}
+        data-chip="all"
+      >
+        All <span style={styles.chipCount}>{total}</span>
+      </button>
+      {categories.map(({ category, count }) => (
+        <button
+          key={category}
+          style={{ ...styles.chip, ...(active === category ? styles.chipActive : {}) }}
+          onClick={() => onPick(active === category ? null : category)}
+          aria-pressed={active === category}
+          data-chip={category}
+        >
+          {category} <span style={styles.chipCount}>{count}</span>
         </button>
       ))}
     </div>
@@ -485,7 +548,11 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: 11,
     color: "var(--text-secondary)",
     background: "transparent",
-    border: "1px solid var(--border-subtle)",
+    // Longhand (not the `border` shorthand) so `chipActive`'s borderColor
+    // override doesn't mix shorthand+longhand on re-render (React warns).
+    borderWidth: 1,
+    borderStyle: "solid",
+    borderColor: "var(--border-subtle)",
     borderRadius: 10,
     cursor: "pointer",
     fontFamily: "inherit",
@@ -495,6 +562,10 @@ const styles: Record<string, React.CSSProperties> = {
     color: "var(--text-primary)",
     background: "var(--accent-soft, var(--bg-chrome))",
     borderColor: "var(--accent-strong)",
+  },
+  chipCount: {
+    opacity: 0.6,
+    fontVariantNumeric: "tabular-nums",
   },
   listScroll: {
     flex: 1,

--- a/packages/app/src/assetLibrary/__tests__/assetLibrary.test.ts
+++ b/packages/app/src/assetLibrary/__tests__/assetLibrary.test.ts
@@ -11,6 +11,8 @@ import {
   matchesQuery,
   availableTypes,
   availableSources,
+  availableCategories,
+  assetCategory,
   type AssetFilter,
 } from "../filter";
 import type { Asset, AssetProvider, AssetType, AssetSource } from "../types";
@@ -99,7 +101,7 @@ describe("collectAssets", () => {
   ]);
   const viz = provider("viz", [asset("viz", "scope", "Scope", "built-in", ["wave"])]);
   const providers = [sounds, viz];
-  const base: AssetFilter = { query: "", type: null, source: null };
+  const base: AssetFilter = { query: "", type: null, source: null, category: null };
 
   it("flattens all providers with no filter", () => {
     expect(collectAssets(providers, base)).toHaveLength(3);
@@ -131,8 +133,20 @@ describe("collectAssets", () => {
   });
 
   it("combines type + source + query", () => {
-    const r = collectAssets(providers, { query: "piano", type: "sound", source: "built-in" });
+    const r = collectAssets(providers, { query: "piano", type: "sound", source: "built-in", category: null });
     expect(r.map((a) => a.id)).toEqual(["piano"]);
+  });
+
+  it("category filter restricts to one top-level group (#826)", () => {
+    const cats = provider("sound", [
+      asset("sound", "bd", "Kick", "built-in", [], "Drums · RolandTR909"),
+      asset("sound", "vln", "Violin", "built-in", [], "Soundfonts · Strings"),
+      asset("sound", "saw", "Saw", "built-in", [], "Synths"),
+    ]);
+    const r = collectAssets([cats], { ...base, category: "Soundfonts" });
+    expect(r.map((a) => a.id)).toEqual(["vln"]);
+    const drums = collectAssets([cats], { ...base, category: "Drums" });
+    expect(drums.map((a) => a.id)).toEqual(["bd"]);
   });
 });
 
@@ -152,6 +166,39 @@ describe("available filter values", () => {
       "built-in",
       "community",
       "user",
+    ]);
+  });
+});
+
+describe("categories (#826)", () => {
+  it("assetCategory takes the group prefix before ` · `, else the whole group, else Other", () => {
+    expect(assetCategory(asset("sound", "x", "x", "built-in", [], "Soundfonts · Strings"))).toBe("Soundfonts");
+    expect(assetCategory(asset("sound", "x", "x", "built-in", [], "Drums · RolandTR909"))).toBe("Drums");
+    expect(assetCategory(asset("sound", "x", "x", "built-in", [], "Synths"))).toBe("Synths");
+    expect(assetCategory(asset("sound", "x", "x", "built-in", []))).toBe("Other");
+  });
+
+  it("availableCategories counts entries per category, sorted by count desc", () => {
+    const p = provider("sound", [
+      asset("sound", "bd", "bd", "built-in", [], "Drums · RolandTR909"),
+      asset("sound", "sd", "sd", "built-in", [], "Drums · RolandTR808"),
+      asset("sound", "vln", "vln", "built-in", [], "Soundfonts · Strings"),
+      asset("sound", "saw", "saw", "built-in", [], "Synths"),
+    ]);
+    expect(availableCategories([p])).toEqual([
+      { category: "Drums", count: 2 },
+      { category: "Soundfonts", count: 1 },
+      { category: "Synths", count: 1 },
+    ]);
+  });
+
+  it("availableCategories scopes counts to the given type/source", () => {
+    const p = provider("sound", [
+      asset("sound", "bd", "bd", "built-in", [], "Drums · X"),
+      asset("sound", "mine", "mine", "user", [], "Samples"),
+    ]);
+    expect(availableCategories([p], { source: "user" })).toEqual([
+      { category: "Samples", count: 1 },
     ]);
   });
 });

--- a/packages/app/src/assetLibrary/filter.ts
+++ b/packages/app/src/assetLibrary/filter.ts
@@ -14,6 +14,23 @@ export interface AssetFilter {
   type: AssetType | null;
   /** null = all sources; otherwise restrict to this one. */
   source: AssetSource | null;
+  /** null = all categories; otherwise restrict to this top-level category
+   *  (the group prefix, e.g. "Drums" / "Soundfonts"). See {@link assetCategory}. */
+  category: string | null;
+}
+
+/**
+ * An asset's top-level category — the group prefix before ` · `
+ * (`Soundfonts · Strings` → `Soundfonts`, `Drums · RolandTR909` → `Drums`,
+ * `Synths` → `Synths`). Groupless assets fall under `Other`. This is the
+ * dimension the category filter chips slice on; it's derived from the same
+ * `group` convention (`<Category> · <sub>`) the providers already use.
+ */
+export function assetCategory(asset: Asset): string {
+  const g = asset.group?.trim();
+  if (!g) return "Other";
+  const i = g.indexOf(" · ");
+  return i > 0 ? g.slice(0, i) : g;
 }
 
 /** Generic name/tag/group substring match — the fallback when a provider has no
@@ -44,6 +61,7 @@ export function collectAssets(
     const base = q && provider.search ? provider.search(q) : provider.list();
     for (const asset of base) {
       if (filter.source && asset.source !== filter.source) continue;
+      if (filter.category && assetCategory(asset) !== filter.category) continue;
       // Provider `search` already applied the query; only the generic path
       // needs the substring gate here.
       if (q && !provider.search && !matchesQuery(asset, q)) continue;
@@ -69,4 +87,29 @@ export function availableSources(providers: readonly AssetProvider[]): AssetSour
     for (const a of p.list()) seen.add(a.source);
   }
   return Array.from(seen);
+}
+
+/**
+ * The categories present, each with its entry count — drives the category
+ * filter chips and their counts. Scoped to the current type/source (so counts
+ * match what "All" would show) but NOT the query or category itself, so the
+ * numbers stay stable while the musician types or switches chips. Sorted by
+ * count desc (biggest buckets first), then name for ties.
+ */
+export function availableCategories(
+  providers: readonly AssetProvider[],
+  scope?: { type?: AssetType | null; source?: AssetSource | null },
+): { category: string; count: number }[] {
+  const counts = new Map<string, number>();
+  for (const p of providers) {
+    if (scope?.type && p.type !== scope.type) continue;
+    for (const a of p.list()) {
+      if (scope?.source && a.source !== scope.source) continue;
+      const c = assetCategory(a);
+      counts.set(c, (counts.get(c) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .map(([category, count]) => ({ category, count }))
+    .sort((a, b) => b.count - a.count || a.category.localeCompare(b.category));
 }


### PR DESCRIPTION
Closes #826.

## Problem
The Asset Library was a flat ~1851-row searchable list with only a search box — no way to narrow to a category ("just the drum machines", "just the soundfonts") without knowing a search term.

## Fix
A **category chip row under the search**: `All` + one chip per top-level category, each with its **entry count**:

`All 1851 · Drums 1357 · Samples 337 · Soundfonts 125 · Synths 25 · Wavetables 7`

Picking a chip filters the list to that category; clicking the active chip (or All) clears it.

- **Category = the group prefix before ` · `** (`Soundfonts · Strings` → `Soundfonts`, `Drums · RolandTR909` → `Drums`, `Synths` → `Synths`). New `category` dimension in `filter.ts` + `assetCategory()` / `availableCategories()`. Generic across providers — the future viz/snippet providers get category chips for free.
- **Counts** are scoped to the active type/source (so they match "All") but ignore the query/category, so the numbers stay stable while typing or switching chips. Sorted by count desc.
- Reset scroll on category change (extended the windowed-list reset key).
- Fixed a latent React shorthand/longhand `border` warning in the shared chip style that only surfaced once a chip row actually rendered.

## Test plan
- **38 asset-library unit tests** green (+ category filter, `assetCategory`, `availableCategories` count/scope/sort).
- **Observed** (Playwright, no Play): chips render `All 1851 · Drums 1357 · Samples 337 · Soundfonts 125 · Synths 25 · Wavetables 7` (sums to 1851); clicking Soundfonts → 125 rows all grouped "Soundfonts"; Drums → 1357; All → 1851; zero page errors. Screenshot confirms the chip row under the search.

Independent of #825 (GM families) — category is the top-level prefix, unaffected by sub-family grouping. Follow-up #827 brings the same tags+counts to the Mixer picker.

Studio isn't default → I'll close #826 manually after merge.