### PR TITLE
✨ Viz library: curated viz packages added to the workspace (viz_lib/) (#834)

### DIFF
--- a/packages/app/src/assetLibrary/AssetLibraryPanel.tsx
+++ b/packages/app/src/assetLibrary/AssetLibraryPanel.tsx
@@ -484,8 +484,8 @@ function AssetRow({
         {asset.insert && (hovered || previewing) && (
           <button
             style={styles.rowBtn}
-            title="Insert into code"
-            aria-label={`Insert ${asset.name}`}
+            title={asset.insertLabel ?? "Insert into code"}
+            aria-label={`${asset.insertLabel ?? "Insert"} ${asset.name}`}
             onClick={() => asset.insert?.()}
             data-asset-insert={rowKey}
           >

--- a/packages/app/src/assetLibrary/__tests__/vizLibrary.test.ts
+++ b/packages/app/src/assetLibrary/__tests__/vizLibrary.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  VIZ_LIBRARY,
+  VIZ_LIB_ROOT,
+  planVizLibFiles,
+  type VizLibItem,
+} from "../vizLibrary";
+
+describe("VIZ_LIBRARY corpus (#834)", () => {
+  it("is the curated non-default shelf — Prism + Pulse Grid, both GLSL", () => {
+    expect(VIZ_LIBRARY.map((i) => i.name)).toEqual(["Prism", "Pulse Grid"]);
+    for (const item of VIZ_LIBRARY) expect(item.renderer).toBe("glsl");
+  });
+
+  it("every package has a primary file whose basename matches its name", () => {
+    // The primary file is what registers as `.viz("<name>")`, so exactly one
+    // must exist per package or the add wires up nothing (P118).
+    for (const item of VIZ_LIBRARY) {
+      const primaries = planVizLibFiles(item).filter((f) => f.isPrimary);
+      expect(primaries, `${item.name} has one primary file`).toHaveLength(1);
+    }
+  });
+
+  it("ships real shader source (not an empty stub)", () => {
+    for (const item of VIZ_LIBRARY) {
+      for (const f of item.files) {
+        expect(f.content).toContain("mainImage"); // ShaderToy entry point
+      }
+    }
+  });
+});
+
+describe("planVizLibFiles (#834)", () => {
+  const prism: VizLibItem = {
+    id: "prism",
+    name: "Prism",
+    renderer: "glsl",
+    files: [{ relPath: "Prism.glsl", content: "// prism", language: "glsl" }],
+  };
+
+  it("materialises under viz_lib/<Name>/<relPath> with a stable id", () => {
+    const [f] = planVizLibFiles(prism);
+    expect(f.path).toBe(`${VIZ_LIB_ROOT}/Prism/Prism.glsl`);
+    expect(f.workspaceId).toBe("vizlib_prism_Prism_glsl"); // sanitised, stable
+    expect(f.content).toBe("// prism");
+    expect(f.language).toBe("glsl");
+    expect(f.isPrimary).toBe(true);
+  });
+
+  it("gives a stable id for a name with a space (Pulse Grid)", () => {
+    const pulse: VizLibItem = {
+      id: "pulse-grid",
+      name: "Pulse Grid",
+      renderer: "glsl",
+      files: [{ relPath: "Pulse Grid.glsl", content: "x", language: "glsl" }],
+    };
+    const [f] = planVizLibFiles(pulse);
+    expect(f.path).toBe(`${VIZ_LIB_ROOT}/Pulse Grid/Pulse Grid.glsl`);
+    expect(f.workspaceId).toBe("vizlib_pulse-grid_Pulse_Grid_glsl");
+    expect(f.isPrimary).toBe(true);
+  });
+
+  it("marks a non-matching helper asset as NOT primary", () => {
+    // A future multi-file package: only the file whose basename matches the
+    // package name registers as the viz; sibling assets do not.
+    const withAsset: VizLibItem = {
+      id: "prism",
+      name: "Prism",
+      renderer: "glsl",
+      files: [
+        { relPath: "Prism.glsl", content: "// prism", language: "glsl" },
+        { relPath: "noise.glsl", content: "// helper", language: "glsl" },
+      ],
+    };
+    const planned = planVizLibFiles(withAsset);
+    expect(planned.map((f) => f.isPrimary)).toEqual([true, false]);
+  });
+
+  it("re-planning yields identical ids (idempotent add)", () => {
+    expect(planVizLibFiles(prism)).toEqual(planVizLibFiles(prism));
+  });
+});

--- a/packages/app/src/assetLibrary/__tests__/vizProvider.test.ts
+++ b/packages/app/src/assetLibrary/__tests__/vizProvider.test.ts
@@ -1,83 +1,79 @@
 import { describe, it, expect, vi } from "vitest";
 
-import {
-  createVizProvider,
-  vizPresetsToAssets,
-  type VizPresetLike,
-} from "../vizProvider";
+import { createVizProvider, vizLibraryToAssets } from "../vizProvider";
+import { VIZ_LIBRARY, type VizLibItem } from "../vizLibrary";
 
-const presets: VizPresetLike[] = [
-  { id: "aurora_p5_v1", name: "Aurora", renderer: "p5", requires: ["audio"] },
-  { id: "__bundled_pianoroll_p5__", name: "Piano Roll", renderer: "p5" },
-  { id: "kaleido_hydra_v1", name: "Kaleido", renderer: "hydra" },
+const items: VizLibItem[] = [
+  {
+    id: "aurora",
+    name: "Aurora",
+    renderer: "p5",
+    files: [{ relPath: "Aurora.p5", content: "// aurora", language: "p5js" }],
+  },
+  {
+    id: "prism",
+    name: "Prism",
+    renderer: "glsl",
+    files: [{ relPath: "Prism.glsl", content: "// prism", language: "glsl" }],
+  },
 ];
 
-// A preset id counts as bundled iff it carries the reserved prefix (mirrors the
-// editor's isBundledPresetId without importing it).
-const isBundled = (id: string) => id.startsWith("__bundled_");
-
-describe("vizPresetsToAssets (#832)", () => {
-  it("maps a preset to a viz Asset with id=preset.id and code/insert=preset.name", () => {
-    const onInsert = vi.fn();
-    const [a] = vizPresetsToAssets([presets[0]], { isBundled, onInsert });
+describe("vizLibraryToAssets (#834)", () => {
+  it("maps a package to a viz Asset (id=item.id, code=name, add-to-workspace)", () => {
+    const onAdd = vi.fn();
+    const [a] = vizLibraryToAssets([items[0]], { onAdd });
     expect(a).toMatchObject({
       type: "viz",
-      id: "aurora_p5_v1",
+      id: "aurora",
       name: "Aurora",
-      code: "Aurora", // .viz("Aurora") resolves by name, not the id
-      source: "user",
+      code: "Aurora", // the .viz("Aurora") token — diverges from the kebab id
+      source: "built-in",
       group: "P5",
+      insertLabel: "Add to workspace",
     });
-    expect(a.tags).toEqual(["p5", "audio"]);
+    expect(a.tags).toEqual(["p5"]);
     a.insert?.();
-    expect(onInsert).toHaveBeenCalledWith("Aurora"); // the NAME, not the id
-  });
-
-  it("tags bundled presets as built-in, user presets as user", () => {
-    const assets = vizPresetsToAssets(presets, { isBundled, onInsert: vi.fn() });
-    const byId = Object.fromEntries(assets.map((a) => [a.id, a.source]));
-    expect(byId["__bundled_pianoroll_p5__"]).toBe("built-in");
-    expect(byId["aurora_p5_v1"]).toBe("user");
+    expect(onAdd).toHaveBeenCalledWith(items[0]); // the whole package, not a name
   });
 
   it("labels the renderer as the group (→ category chip)", () => {
-    const assets = vizPresetsToAssets(presets, { isBundled, onInsert: vi.fn() });
-    expect(assets.find((a) => a.id === "kaleido_hydra_v1")?.group).toBe("Hydra");
+    const assets = vizLibraryToAssets(items, { onAdd: vi.fn() });
+    expect(assets.find((a) => a.id === "prism")?.group).toBe("GLSL");
   });
 
-  it("carries no preview affordance (MVP — thumbnail is a follow-up)", () => {
-    const [a] = vizPresetsToAssets([presets[0]], { isBundled, onInsert: vi.fn() });
+  it("carries no preview affordance (a viz thumbnail is a follow-up)", () => {
+    const [a] = vizLibraryToAssets([items[0]], { onAdd: vi.fn() });
     expect(a.preview).toBeUndefined();
   });
 
   it("sorts by (group, name)", () => {
-    const assets = vizPresetsToAssets(presets, { isBundled, onInsert: vi.fn() });
+    const assets = vizLibraryToAssets(items, { onAdd: vi.fn() });
     expect(assets.map((a) => `${a.group}/${a.name}`)).toEqual([
-      "Hydra/Kaleido",
+      "GLSL/Prism",
       "P5/Aurora",
-      "P5/Piano Roll",
     ]);
-  });
-
-  it("returns [] for a null (not-yet-loaded) preset list", () => {
-    expect(vizPresetsToAssets(null, { isBundled, onInsert: vi.fn() })).toEqual([]);
   });
 });
 
-describe("createVizProvider (#832)", () => {
-  it("is a viz provider that lists from the injected cache", () => {
-    const p = createVizProvider({
-      readPresets: () => presets,
-      isBundled,
-      onInsert: vi.fn(),
-    });
+describe("createVizProvider (#834)", () => {
+  it("is a viz provider that lists the curated library", () => {
+    const p = createVizProvider({ onAdd: vi.fn() });
     expect(p.type).toBe("viz");
     expect(p.label).toBe("Viz");
-    expect(p.list().map((a) => a.id)).toContain("aurora_p5_v1");
+    // Lists the real shelf (Prism + Pulse Grid today).
+    expect(p.list().map((a) => a.name)).toEqual(
+      expect.arrayContaining(["Prism", "Pulse Grid"]),
+    );
   });
 
-  it("isLoading is true only before the load resolves (null), not when empty", () => {
-    expect(createVizProvider({ readPresets: () => null, isBundled, onInsert: vi.fn() }).isLoading()).toBe(true);
-    expect(createVizProvider({ readPresets: () => [], isBundled, onInsert: vi.fn() }).isLoading()).toBe(false);
+  it("every listed item is built-in and offers an add affordance", () => {
+    const p = createVizProvider({ onAdd: vi.fn() });
+    for (const a of p.list()) {
+      expect(a.source).toBe("built-in");
+      expect(a.insert).toBeTypeOf("function");
+      expect(a.insertLabel).toBe("Add to workspace");
+    }
+    // The real corpus is non-empty (nothing filtered it to nothing).
+    expect(p.list().length).toBe(VIZ_LIBRARY.length);
   });
 });

--- a/packages/app/src/assetLibrary/types.ts
+++ b/packages/app/src/assetLibrary/types.ts
@@ -65,9 +65,16 @@ export interface Asset {
   readonly preview?: () => AssetPreviewHandle | void | Promise<AssetPreviewHandle | void>;
   /**
    * Round-trip this asset into legible code (assign to the focused track, or
-   * insert at the cursor). Absent → no insert affordance.
+   * insert at the cursor), or otherwise materialise it into the project. Absent
+   * → no insert affordance.
    */
   readonly insert?: () => void | Promise<void>;
+  /**
+   * Label for the {@link insert} affordance (tooltip / aria). Defaults to
+   * "Insert into code". Viz-library packages set "Add to workspace" since their
+   * `+` writes files under `viz_lib/` rather than inserting at the cursor.
+   */
+  readonly insertLabel?: string;
 }
 
 /**

--- a/packages/app/src/assetLibrary/vizLibrary.ts
+++ b/packages/app/src/assetLibrary/vizLibrary.ts
@@ -1,0 +1,163 @@
+/**
+ * Viz library corpus (#834) — the curated, non-default viz you can ADD to your
+ * workspace from the Asset Library. This is deliberately NOT the set of bundled
+ * default presets (Piano Roll, scope, …); those already ship in every project.
+ * The library is a shelf of opt-in viz *packages*.
+ *
+ * Each entry is a **package**: a named folder of one or more files. A viz often
+ * references its own assets (extra shader passes, textures) from its code, so it
+ * always lives in its own folder — even Prism, which is a single `.glsl` today.
+ * Adding a package materialises it under a root `viz_lib/<Name>/` folder:
+ *
+ *   viz_lib/Prism/Prism.glsl
+ *   viz_lib/Pulse Grid/Pulse Grid.glsl
+ *
+ * The `.glsl`/`.p5`/`.hydra` file then auto-registers as a named viz (the
+ * workspace-file → named-viz bridge keys off `language`, not path), so
+ * `.viz("Prism")` resolves. See {@link ./vizProvider} for the Asset adapter and
+ * `StaveApp` for the materialisation + registration.
+ *
+ * The GLSL sources below were previously seeded into every project by
+ * `templates.ts`; they now live here so the library is their single source.
+ */
+
+/** The viz languages a package file can be (a subset of `WorkspaceLanguage`).
+ *  Kept as local literals so this module — and the provider's tests — stay free
+ *  of a runtime `@stave/editor` import (which drags heavy viz/`gifenc` deps). */
+export type VizFileLanguage = "glsl" | "p5js" | "hydra";
+
+/** One file inside a viz package. */
+export interface VizLibFile {
+  /** Path relative to the package folder, e.g. `"Prism.glsl"`. */
+  readonly relPath: string;
+  readonly content: string;
+  readonly language: VizFileLanguage;
+}
+
+/** A curated viz package on the library shelf. */
+export interface VizLibItem {
+  /** Stable id (kebab-case) — also seeds the workspace-file ids so a second
+   *  "add" is idempotent. */
+  readonly id: string;
+  /** Display name, folder name, and the name the viz registers under
+   *  (`.viz("<name>")`), e.g. `"Prism"`. */
+  readonly name: string;
+  /** The renderer kind — drives the group label / category chip. */
+  readonly renderer: "glsl" | "p5" | "hydra";
+  /** The files that make up this package. The primary viz file (the one whose
+   *  basename matches {@link name}) is what registers as a named viz. */
+  readonly files: readonly VizLibFile[];
+}
+
+// ── Bundled GLSL example shaders (originally issue #287) ─────────────────
+// "Prism" is the classic "Creation" demo by Danilo Guanabara, made
+// audio-reactive for Stave, included with author credit. "Pulse Grid" is an
+// original Stave shader. Both are single-pass ShaderToy-style `mainImage`.
+
+const PRISM_GLSL_CODE = `// "Prism" — after "Creation" by Danilo Guanabara, made audio-reactive for Stave.
+// http://www.pouet.net/prod.php?which=57245
+// If you intend to reuse this shader, please add credits to 'Danilo Guanabara'.
+// iChannel0: row 0 (y=0.0) = FFT magnitude.
+#define t iTime
+#define r iResolution.xy
+
+void mainImage( out vec4 fragColor, in vec2 fragCoord ){
+    float bass   = texture(iChannel0, vec2(0.03, 0.0)).x;
+    float mid    = texture(iChannel0, vec2(0.30, 0.0)).x;
+    float treble = texture(iChannel0, vec2(0.65, 0.0)).x;
+    vec3 c;
+    float l, z = t;
+    for (int i = 0; i < 3; i++) {
+        vec2 uv, p = fragCoord.xy / r;
+        uv = p;
+        p -= .5;
+        p.x *= r.x / r.y;
+        z += .07 + bass * .08;                                  // bass drives the zoom
+        l = length(p);
+        uv += p / l * (sin(z) + 1.) * abs(sin(l * 9. - z - z))
+            * (1. + treble * 1.4);                              // treble ripples the warp
+        c[i] = .01 / length(mod(uv, 1.) - .5);
+    }
+    vec3 col = c / l;
+    col = mix(col, col.gbr, mid * .6);                          // mids swirl the hue
+    fragColor = vec4(col * (.6 + bass * 1.7), 1.0);             // bass brightens
+}
+`;
+
+const PULSEGRID_GLSL_CODE = `// "Pulse Grid" — pattern-event reactive cells. An original Stave shader.
+// Reacts to PATTERN EVENTS (uKick/uSnare/uHat/uRms), not the raw spectrum.
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+  vec2 uv = fragCoord / iResolution.xy;
+  vec2 g  = uv * vec2(8.0, 5.0);
+  vec2 cell = fract(g) - 0.5;
+  vec2 id   = floor(g);
+
+  // Per-cell random phase so the grid never pulses uniformly.
+  float phase = fract(sin(dot(id, vec2(12.9, 78.2))) * 43758.5);
+  float d   = max(abs(cell.x), abs(cell.y));
+  float box = smoothstep(0.46, 0.40, d);
+
+  vec3 col = vec3(0.02, 0.02, 0.05);
+  col += vec3(1.0, 0.3, 0.2) * uKick  * box * (0.4 + 0.6 * step(id.x, 3.0)); // kick → left red
+  col += vec3(0.3, 0.6, 1.0) * uSnare * box * step(2.0, id.y);               // snare → top blue
+  col += vec3(1.0)           * uHat   * box * (0.3 + 0.7 * phase);           // hat  → scattered white
+  col += box * uRms * 0.25 * (0.5 + 0.5 * sin(iTime * 3.0 + phase * 6.28));  // loudness → breathing
+  fragColor = vec4(col, 1.0);
+}
+`;
+
+/** The curated shelf. v1 = the two `#287` GLSL examples, each as a package. */
+export const VIZ_LIBRARY: readonly VizLibItem[] = [
+  {
+    id: "prism",
+    name: "Prism",
+    renderer: "glsl",
+    files: [{ relPath: "Prism.glsl", content: PRISM_GLSL_CODE, language: "glsl" }],
+  },
+  {
+    id: "pulse-grid",
+    name: "Pulse Grid",
+    renderer: "glsl",
+    files: [{ relPath: "Pulse Grid.glsl", content: PULSEGRID_GLSL_CODE, language: "glsl" }],
+  },
+];
+
+/** Root workspace folder every viz package is materialised under. */
+export const VIZ_LIB_ROOT = "viz_lib";
+
+/** A file to write into the workspace when a package is added. */
+export interface PlannedVizFile {
+  /** Stable workspace-file id — `vizlib_<item>_<relPath>` so re-adding is a
+   *  no-op (`seedWorkspaceFile` returns the persisted file for a known id). */
+  readonly workspaceId: string;
+  /** Full workspace path: `viz_lib/<Name>/<relPath>`. Folders are implicit. */
+  readonly path: string;
+  readonly content: string;
+  readonly language: VizFileLanguage;
+  /** True for the package's primary viz file — the one that registers as the
+   *  named viz (its basename matches the package name). Helper assets are
+   *  false. */
+  readonly isPrimary: boolean;
+}
+
+const sanitize = (s: string) => s.replace(/[^a-zA-Z0-9]/g, "_");
+
+/** Basename of a package-relative path, minus its extension. */
+const baseNameOf = (relPath: string) =>
+  relPath.split("/").pop()!.replace(/\.[^.]+$/, "");
+
+/**
+ * Pure plan: a viz package → the workspace files to write. The primary viz
+ * file is the one whose basename equals the package name (`Prism.glsl` for
+ * "Prism"); that's what registers as `.viz("<name>")`. Exported for unit tests
+ * and reused by `StaveApp`'s add handler.
+ */
+export function planVizLibFiles(item: VizLibItem): PlannedVizFile[] {
+  return item.files.map((f) => ({
+    workspaceId: `vizlib_${item.id}_${sanitize(f.relPath)}`,
+    path: `${VIZ_LIB_ROOT}/${item.name}/${f.relPath}`,
+    content: f.content,
+    language: f.language,
+    isPrimary: baseNameOf(f.relPath) === item.name,
+  }));
+}

--- a/packages/app/src/assetLibrary/vizProvider.ts
+++ b/packages/app/src/assetLibrary/vizProvider.ts
@@ -1,71 +1,56 @@
 /**
- * Viz AssetProvider (#832) — saved visualization presets as a browsable asset
- * type alongside Sounds. Reads the user's `VizPreset`s (built-in + saved), maps
- * each to an {@link Asset}, and inserts `.viz("name")` onto the pattern under the
- * cursor.
+ * Viz AssetProvider (#834) — the curated viz *library*. Unlike Sounds (which
+ * mirrors the whole soundMap) this lists a small, hand-picked shelf of
+ * non-default viz *packages* ({@link ./vizLibrary}), NOT the bundled default
+ * presets. Each row's primary action is **Add to workspace**, not insert: `+`
+ * materialises the package under `viz_lib/<Name>/` and registers it as a named
+ * viz so `.viz("<Name>")` resolves.
  *
- * Two things differ from Sounds:
- *  - `.viz()` resolves by preset NAME (`registerNamedViz(preset.name,…)`), while
- *    the row needs a unique key. So `id` = `preset.id` (unique) but `code`/insert
- *    use `preset.name`. For sounds these are the same string; here they diverge.
- *  - No `preview`: a viz is visual, and the 40px row has no thumbnail slot yet
- *    (a deliberate follow-up). Insert + Copy are the affordances.
- *
- * Like Sounds, the preset list + `isBundled` + `onInsert` are dependency-injected
- * so the pure mapping stays editor-free and unit-testable (importing the editor
- * barrel would drag its viz/`gifenc` deps into this provider's tests).
+ * The `onAdd` handler is dependency-injected (it needs `@stave/editor`'s
+ * workspace + viz-registration APIs), so this module stays free of a runtime
+ * editor import and its tests stay hermetic — the same pattern the Sounds
+ * provider uses.
  */
 
 import type { Asset } from "./types";
-
-/** The minimal shape read off a `VizPreset` (mirrors `@stave/editor`'s type;
- *  kept local so the provider doesn't depend on that module). */
-export interface VizPresetLike {
-  id: string;
-  name: string;
-  renderer: "hydra" | "p5" | "glsl";
-  requires?: readonly string[];
-}
+import { VIZ_LIBRARY, type VizLibItem } from "./vizLibrary";
 
 export interface VizProviderDeps {
-  /** The known presets (built-in + user), or `null` before the IDB load resolves. */
-  readPresets: () => readonly VizPresetLike[] | null;
-  /** Whether this id was app-bundled (→ `built-in`) vs user-saved (→ `user`). */
-  isBundled: (id: string) => boolean;
-  /** Attach `.viz("name")` at the cursor. */
-  onInsert: (name: string) => void;
+  /** Add a package to the workspace (materialise its files + register the
+   *  named viz). Wired in `StaveApp`. */
+  onAdd: (item: VizLibItem) => void;
 }
 
 /** Display label for a renderer — also the asset `group` and category chip. */
-const RENDERER_LABELS: Record<VizPresetLike["renderer"], string> = {
+const RENDERER_LABELS: Record<VizLibItem["renderer"], string> = {
   hydra: "Hydra",
   p5: "P5",
   glsl: "GLSL",
 };
 
 /**
- * Pure mapping: presets → sorted `Asset[]`. Sorted by (group, name) so presets
- * cluster by renderer in the shell's flat windowed list. Exported for unit tests.
+ * Pure mapping: curated packages → sorted `Asset[]`. Sorted by (group, name)
+ * so packages cluster by renderer in the shell's flat list. Exported for tests.
  */
-export function vizPresetsToAssets(
-  presets: readonly VizPresetLike[] | null | undefined,
-  deps: Pick<VizProviderDeps, "isBundled" | "onInsert">,
+export function vizLibraryToAssets(
+  items: readonly VizLibItem[],
+  deps: VizProviderDeps,
 ): Asset[] {
-  if (!presets) return [];
-  const assets = presets.map((p): Asset => {
-    const group = RENDERER_LABELS[p.renderer] ?? p.renderer;
-    return {
-      type: "viz",
-      id: p.id, // unique row key
-      name: p.name,
-      code: p.name, // the string written into `.viz("…")` and copied
-      source: deps.isBundled(p.id) ? "built-in" : "user",
-      group,
-      tags: [p.renderer, ...(p.requires ?? [])],
-      insert: () => deps.onInsert(p.name),
-      // no `preview` — thumbnail is a follow-up
-    };
-  });
+  const assets = items.map((item): Asset => ({
+    type: "viz",
+    id: item.id,
+    name: item.name,
+    // The string you'd type in `.viz("…")` — what Copy copies and what the
+    // added file registers under. Diverges from `id` (a kebab library key).
+    code: item.name,
+    source: "built-in",
+    group: RENDERER_LABELS[item.renderer] ?? item.renderer,
+    tags: [item.renderer],
+    // `+` adds the package to the workspace (see the row's `insertLabel`).
+    insert: () => deps.onAdd(item),
+    insertLabel: "Add to workspace",
+    // no `preview` — a viz thumbnail is a separate follow-up.
+  }));
   assets.sort(
     (a, b) => (a.group ?? "").localeCompare(b.group ?? "") || a.name.localeCompare(b.name),
   );
@@ -73,17 +58,13 @@ export function vizPresetsToAssets(
 }
 
 /**
- * Build the Viz provider. Presets are few (dozens), so `list()` maps on every
- * call — no memoisation needed (unlike the 1851-entry Sounds provider). `list()`
- * reads the injected cache synchronously; the app refreshes it (async IDB read)
- * and calls `notifyAssetProvidersChanged()` so the shell re-lists.
+ * Build the Viz provider. The shelf is a static in-module corpus, so `list()`
+ * maps it on every call (a handful of items — no memoisation, no async load).
  */
 export function createVizProvider(deps: VizProviderDeps) {
   return {
     type: "viz" as const,
     label: "Viz",
-    list: () => vizPresetsToAssets(deps.readPresets(), deps),
-    // `null` = still fetching from IDB; `[]` = fetched, user has no presets.
-    isLoading: () => deps.readPresets() === null,
+    list: () => vizLibraryToAssets(VIZ_LIBRARY, deps),
   };
 }

--- a/packages/app/src/components/StaveApp.tsx
+++ b/packages/app/src/components/StaveApp.tsx
@@ -97,8 +97,9 @@ import { getLogHistory } from "@stave/editor";
 import { startAudition } from "@stave/editor";
 import { gmFamily, soundfontGroupLabel } from "@stave/editor";
 import { isVizLanguage, languageForRenderer } from "@stave/editor";
-import { VizPresetStore, isBundledPresetId, type VizPreset } from "@stave/editor";
+import { getFile } from "@stave/editor";
 import { createVizProvider } from "../assetLibrary/vizProvider";
+import { planVizLibFiles, VIZ_LIB_ROOT, type VizLibItem } from "../assetLibrary/vizLibrary";
 import { PerfOverlay } from "./PerfOverlay";
 
 interface StaveAppProps {
@@ -769,48 +770,39 @@ export function StaveApp({ initialProject }: StaveAppProps) {
     };
   }, []);
 
-  // #832 — Asset Library Viz provider: browse saved viz presets, insert
-  // `.viz("name")` at the cursor. Presets live in IndexedDB (`VizPresetStore`);
-  // `list()` is synchronous, so we load into a ref cache and notify the shell.
-  // There is no preset-change event to subscribe to, so we also refetch when the
-  // Library panel opens (below) — a preset saved via the Viz editor then shows
-  // up without a reload.
-  const vizPresetsRef = useRef<VizPreset[] | null>(null);
-  const refreshVizPresets = useCallback(async () => {
-    try {
-      const presets = await VizPresetStore.getAll();
-      vizPresetsRef.current = presets;
-      notifyAssetProvidersChanged();
-    } catch {
-      // IDB unavailable/blocked (bounded — never hangs, PV151). Resolve the
-      // provider's loading state to "empty" instead of leaving it spinning.
-      if (vizPresetsRef.current === null) {
-        vizPresetsRef.current = [];
-        notifyAssetProvidersChanged();
+  // #834 — Asset Library Viz provider: a curated shelf of non-default viz
+  // *packages* you ADD to the workspace (not the bundled default presets). The
+  // `+` on a row materialises the package under `viz_lib/<Name>/` and registers
+  // its primary file as a named viz so `.viz("<Name>")` resolves immediately.
+  useEffect(() => {
+    const addVizPackage = (item: VizLibItem): void => {
+      const planned = planVizLibFiles(item);
+      // Idempotent: `seedWorkspaceFile` returns the persisted file for a known
+      // id without overwriting, so a second "add" of the same package is a
+      // no-op on already-present files.
+      let created = false;
+      for (const pf of planned) {
+        const existed = getFile(pf.workspaceId) !== undefined;
+        seedWorkspaceFile(pf.workspaceId, pf.path, pf.content, pf.language);
+        if (!existed) created = true;
       }
-    }
-  }, []);
-  useEffect(() => {
+      // The added file(s) register as named viz via StrudelEditorClient's
+      // file-list subscription (#834), so `.viz("<Name>")` resolves without a
+      // reload — the registration lives on the proven `registerAllVizFiles`
+      // path, not duplicated here.
+      showToast(
+        created
+          ? `Added ${item.name} → ${VIZ_LIB_ROOT}/${item.name}/. Use .viz("${item.name}").`
+          : `${item.name} is already in your workspace.`,
+        "info",
+      );
+    };
+
     const unregViz = registerAssetProvider(
-      createVizProvider({
-        readPresets: () => vizPresetsRef.current,
-        isBundled: isBundledPresetId,
-        onInsert: (name) => {
-          // A viz attaches to a pattern — if the cursor isn't on one, nothing is
-          // written. Guide the user instead of failing silently.
-          const wrote = shellRef.current?.assignVizToCursor(name);
-          if (!wrote) {
-            showToast("Place the cursor on a pattern to attach this viz.", "info");
-          }
-        },
-      }),
+      createVizProvider({ onAdd: addVizPackage }),
     );
-    void refreshVizPresets();
     return unregViz;
-  }, [refreshVizPresets]);
-  useEffect(() => {
-    if (activePanelId === "library") void refreshVizPresets();
-  }, [activePanelId, refreshVizPresets]);
+  }, []);
 
   // #515 / PV141 #6 — enumerate live drum banks for the Mixer's Kit picker.
   // Banks load from the tidal-drum-machines manifest (its keys are

--- a/packages/app/src/components/StrudelEditorClient.tsx
+++ b/packages/app/src/components/StrudelEditorClient.tsx
@@ -683,6 +683,17 @@ export default function StrudelEditorClient({
     [registerAllVizFiles],
   );
 
+  // #834 — a viz file added at RUNTIME (the Viz library's "Add to workspace",
+  // or the New File dialog) must register as a named viz too. The mount-time
+  // run above fires once, so re-run whenever the workspace file LIST changes
+  // (add / remove / rename — subscribeToFileList ignores content edits, so this
+  // is not per-keystroke). Without this, inline `.viz("<name>")` on a
+  // just-added file silently resolves to nothing until reload (P118).
+  useEffect(
+    () => subscribeToFileList(() => { void registerAllVizFiles(); }),
+    [registerAllVizFiles],
+  );
+
   // Register bundled presets as named viz (for `.viz("Piano Roll")` lookup).
   useEffect(() => {
     const p5Preset: VizPreset = {

--- a/packages/app/src/templates.ts
+++ b/packages/app/src/templates.ts
@@ -163,61 +163,6 @@ export interface ProjectTemplate {
 const p5PresetId = () => bundledPresetId("Piano Roll", "p5");
 const hydraPresetId = () => bundledPresetId("Piano Roll Hydra", "hydra");
 
-// Bundled GLSL example shaders (issue #287). "Pulse Grid" is an original Stave
-// shader; "Prism" is the classic "Creation" demo by Danilo Guanabara, included
-// with author credit. Both are single-pass ShaderToy-style `mainImage`.
-const PRISM_GLSL_CODE = `// "Prism" — after "Creation" by Danilo Guanabara, made audio-reactive for Stave.
-// http://www.pouet.net/prod.php?which=57245
-// If you intend to reuse this shader, please add credits to 'Danilo Guanabara'.
-// iChannel0: row 0 (y=0.0) = FFT magnitude.
-#define t iTime
-#define r iResolution.xy
-
-void mainImage( out vec4 fragColor, in vec2 fragCoord ){
-    float bass   = texture(iChannel0, vec2(0.03, 0.0)).x;
-    float mid    = texture(iChannel0, vec2(0.30, 0.0)).x;
-    float treble = texture(iChannel0, vec2(0.65, 0.0)).x;
-    vec3 c;
-    float l, z = t;
-    for (int i = 0; i < 3; i++) {
-        vec2 uv, p = fragCoord.xy / r;
-        uv = p;
-        p -= .5;
-        p.x *= r.x / r.y;
-        z += .07 + bass * .08;                                  // bass drives the zoom
-        l = length(p);
-        uv += p / l * (sin(z) + 1.) * abs(sin(l * 9. - z - z))
-            * (1. + treble * 1.4);                              // treble ripples the warp
-        c[i] = .01 / length(mod(uv, 1.) - .5);
-    }
-    vec3 col = c / l;
-    col = mix(col, col.gbr, mid * .6);                          // mids swirl the hue
-    fragColor = vec4(col * (.6 + bass * 1.7), 1.0);             // bass brightens
-}
-`;
-
-const PULSEGRID_GLSL_CODE = `// "Pulse Grid" — pattern-event reactive cells. An original Stave shader.
-// Reacts to PATTERN EVENTS (uKick/uSnare/uHat/uRms), not the raw spectrum.
-void mainImage(out vec4 fragColor, in vec2 fragCoord) {
-  vec2 uv = fragCoord / iResolution.xy;
-  vec2 g  = uv * vec2(8.0, 5.0);
-  vec2 cell = fract(g) - 0.5;
-  vec2 id   = floor(g);
-
-  // Per-cell random phase so the grid never pulses uniformly.
-  float phase = fract(sin(dot(id, vec2(12.9, 78.2))) * 43758.5);
-  float d   = max(abs(cell.x), abs(cell.y));
-  float box = smoothstep(0.46, 0.40, d);
-
-  vec3 col = vec3(0.02, 0.02, 0.05);
-  col += vec3(1.0, 0.3, 0.2) * uKick  * box * (0.4 + 0.6 * step(id.x, 3.0)); // kick → left red
-  col += vec3(0.3, 0.6, 1.0) * uSnare * box * step(2.0, id.y);               // snare → top blue
-  col += vec3(1.0)           * uHat   * box * (0.3 + 0.7 * phase);           // hat  → scattered white
-  col += box * uRms * 0.25 * (0.5 + 0.5 * sin(iTime * 3.0 + phase * 6.28));  // loudness → breathing
-  fragColor = vec4(col, 1.0);
-}
-`;
-
 // ── Templates ─────────────────────────────────────────────────────────
 
 /**
@@ -287,9 +232,9 @@ function makeStarterFiles(): TemplateFile[] {
     vizFile("scope", "hydra", HYDRA_SCOPE_CODE),
     vizFile("kaleidoscope", "hydra", HYDRA_KALEIDOSCOPE_CODE),
     vizFile("Signals (Bands)", "hydra", SIGNALS_BANDS_HYDRA_CODE),
-    // Viz presets — GLSL / ShaderToy (issue #287)
-    vizFile("Prism", "glsl", PRISM_GLSL_CODE),
-    vizFile("Pulse Grid", "glsl", PULSEGRID_GLSL_CODE),
+    // GLSL example shaders (Prism, Pulse Grid) are no longer seeded here — they
+    // moved to the curated Viz library (`assetLibrary/vizLibrary.ts`, #834), so
+    // the user opts into them via the Library's "Add to workspace" instead.
   ];
 }
 

--- a/packages/app/tests/glsl-seeded-viz.spec.ts
+++ b/packages/app/tests/glsl-seeded-viz.spec.ts
@@ -10,12 +10,13 @@
  * (worker:0, no error). tsc + 40 unit tests were green; only live observation
  * caught it.
  *
- * This spec closes that hole on the REAL path: the bundled `Prism.glsl` starter
- * file is seeded at project creation and registered by `registerAllVizFiles`
- * on mount (the consolidated `isVizLanguage` allow-list). The spec then drives
- * inline `.viz("Prism")` and OBSERVES the worker mount + draw frames + painted
- * pixels. If a future renderer kind is dropped from the allow-list
- * (`isVizLanguage` / `VIZ_LANGUAGES`), this goes red.
+ * This spec closes that hole on the REAL path: Prism is ADDED from the Viz
+ * library (#834) — `viz_lib/Prism/Prism.glsl` — and registered as a named viz
+ * by the runtime "Add to workspace" path (`registerAddedViz`, the same
+ * `isVizLanguage` allow-list). The spec then drives inline `.viz("Prism")` and
+ * OBSERVES the worker mount + draw frames + painted pixels. If a future renderer
+ * kind is dropped from the allow-list (`isVizLanguage` / `VIZ_LANGUAGES`) — or
+ * the library add stops registering — this goes red.
  *
  * Run HEADED on real GPU (P108) with per-test context isolation (PV84):
  *   E2E_VERIFY=1 pnpm --filter @stave/app exec playwright test glsl-seeded-viz.spec.ts --headed --timeout=180000 --workers=1
@@ -43,6 +44,24 @@ async function open(browser: Browser): Promise<{ ctx: BrowserContext; page: Page
   await page.locator('.monaco-editor').first().waitFor({ timeout: 30000 })
   await page.waitForTimeout(2500) // let startup seed + registerAllVizFiles (on mount) run
   return { ctx, page }
+}
+
+/** Add the Prism package from the Viz library (#834) — it is no longer seeded
+ *  at project creation, so the runtime "Add to workspace" path is what
+ *  registers it as a named viz (`registerAddedViz` → `.viz("Prism")` resolves). */
+async function addPrismFromLibrary(page: Page): Promise<void> {
+  await page.locator('[data-activity-bar] button[aria-label="Library"]').click()
+  const panel = page.locator('[data-asset-library]')
+  await panel.waitFor({ timeout: 10000 })
+  await panel.locator('[data-filter="asset-type-filter"] button[data-chip="viz"]').click()
+  const prism = panel.locator('[data-asset-row="viz:prism"]')
+  await prism.hover()
+  await prism.locator('[data-asset-insert]').click()
+  await page.getByText('Added Prism → viz_lib/Prism/. Use .viz("Prism").').waitFor({ timeout: 5000 })
+  await page.waitForTimeout(400) // let the file-list → registerAllVizFiles register it
+  // The add auto-opens Prism.glsl; switch back to the pattern editor to run code.
+  await page.locator('[data-workspace-tab="tab-pattern.strudel"]').click()
+  await page.waitForTimeout(400)
 }
 
 async function setCode(page: Page, code: string): Promise<void> {
@@ -98,9 +117,10 @@ test.describe('#293 GLSL seeded-`.viz()` path — P118/PV88 regression gate', ()
   }) => {
     const { ctx, page } = await open(browser)
     try {
-      // The bundled `Prism.glsl` starter is seeded at project creation and
-      // registered as a named viz by registerAllVizFiles on mount (the
-      // consolidated allow-list). Reference it from inline `.viz("Prism")`.
+      // Prism is added from the Viz library (#834) — no longer seeded — so the
+      // runtime "Add to workspace" path registers it as a named viz. Then
+      // reference it from inline `.viz("Prism")`.
+      await addPrismFromLibrary(page)
       const program = `$: s("bd*4, ~ sd, hh*8").bank("RolandTR909").viz('Prism')`
       await setCode(page, program)
       await press(page, `${MOD}+Enter`)

--- a/packages/app/tests/viz-hot-reload.spec.ts
+++ b/packages/app/tests/viz-hot-reload.spec.ts
@@ -22,8 +22,6 @@
 import { test, expect, type Browser, type BrowserContext, type Page } from '@playwright/test'
 import { vizFrameHashes, distinct } from './_vizFrames'
 
-const PRISM_FILE_ID = 'viz:__bundled_prism_glsl__'
-
 // A valid single-pass ShaderToy `mainImage` that paints ONE flat colour — no iTime,
 // no iChannel0, so it can NEVER animate. distinct === 1 ⇒ the new shader is live.
 const STATIC_GLSL = `void mainImage(out vec4 fragColor, in vec2 fragCoord){ fragColor = vec4(1.0, 0.0, 1.0, 1.0); }`
@@ -48,13 +46,31 @@ async function open(browser: Browser): Promise<{ ctx: BrowserContext; page: Page
   return { ctx, page }
 }
 
+/** Add the Prism package from the Viz library (#834) — it is no longer seeded,
+ *  so the runtime "Add to workspace" path registers it as a named viz. */
+async function addPrismFromLibrary(page: Page): Promise<void> {
+  await page.locator('[data-activity-bar] button[aria-label="Library"]').click()
+  const panel = page.locator('[data-asset-library]')
+  await panel.waitFor({ timeout: 10000 })
+  await panel.locator('[data-filter="asset-type-filter"] button[data-chip="viz"]').click()
+  const prism = panel.locator('[data-asset-row="viz:prism"]')
+  await prism.hover()
+  await prism.locator('[data-asset-insert]').click()
+  await page.getByText('Added Prism → viz_lib/Prism/. Use .viz("Prism").').waitFor({ timeout: 5000 })
+  await page.waitForTimeout(400) // let the file-list → registerAllVizFiles register it
+  // The add auto-opens Prism.glsl; switch back to the pattern editor to run code.
+  await page.locator('[data-workspace-tab="tab-pattern.strudel"]').click()
+  await page.waitForTimeout(400)
+}
+
 test.describe('inline `.viz()` hot-reload — save→repaint (PV89/PV90)', () => {
   test.skip(!process.env.E2E_VERIFY, 'acceptance gate — set E2E_VERIFY=1')
 
   test('editing a referenced .glsl preset + save repaints the running inline viz', async ({ browser }) => {
     const { ctx, page } = await open(browser)
     try {
-      // Play a pattern referencing the bundled animated Prism.glsl.
+      // Prism is added from the Viz library (#834), then referenced by a pattern.
+      await addPrismFromLibrary(page)
       const program = `$: s("bd*4, ~ sd, hh*8").bank("RolandTR909").viz('Prism')`
       await page.evaluate((c) => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -82,7 +98,7 @@ test.describe('inline `.viz()` hot-reload — save→repaint (PV89/PV90)', () =>
         (code) => (window as any).__staveOverrideVizFile('Prism', code),
         STATIC_GLSL,
       )
-      expect(fileId, 'Prism.glsl workspace file found').toBe(PRISM_FILE_ID)
+      expect(fileId, 'Prism.glsl workspace file found').not.toBeNull()
       const saved = await page.evaluate(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (id) => (window as any).__staveSaveVizFileById(id),

--- a/packages/app/tests/viz-library.spec.ts
+++ b/packages/app/tests/viz-library.spec.ts
@@ -106,6 +106,25 @@ test.describe('Asset Library — Viz library (#834)', () => {
     expect(await vizFileId(page, 'Prism')).not.toBeNull()
   })
 
+  test('adding Pulse Grid (a name with a space) materialises + is recognised', async ({ page }) => {
+    await boot(page)
+    expect(await vizFileId(page, 'Pulse Grid')).toBeNull()
+
+    const panel = await openLibrary(page)
+    await showVizType(page, panel)
+    const pulse = panel.locator('[data-asset-row="viz:pulse-grid"]')
+    await pulse.hover()
+    await pulse.locator('[data-asset-insert]').click()
+
+    await expect(
+      page.getByText('Added Pulse Grid → viz_lib/Pulse Grid/. Use .viz("Pulse Grid").'),
+    ).toBeVisible()
+    // The spaced folder/file path resolves as a viz-language file named
+    // "Pulse Grid" (so `.viz("Pulse Grid")` registers) — the one thing that
+    // could differ from Prism.
+    expect(await vizFileId(page, 'Pulse Grid')).not.toBeNull()
+  })
+
   test('adding the same package twice is idempotent (no duplicate)', async ({ page }) => {
     await boot(page)
     const panel = await openLibrary(page)

--- a/packages/app/tests/viz-library.spec.ts
+++ b/packages/app/tests/viz-library.spec.ts
@@ -1,29 +1,25 @@
 /**
- * Asset Library — Viz preset provider (#832) + default-to-type coexistence.
+ * Asset Library — Viz library (#834): curated viz *packages* you ADD to the
+ * workspace.
  *
- * End-to-end proof that saved viz presets browse alongside Sounds in one panel:
- * the panel defaults to a type (not the mixed "All" union), the Viz filter lists
- * presets grouped by renderer, inserting one writes `.viz("name")` onto the
- * pattern under the cursor, and attempting it with the cursor off any pattern
- * guides the user instead of failing silently.
+ * End-to-end proof that the Viz filter lists a small curated shelf of
+ * non-default viz (Prism + Pulse Grid), and that a row's `+` = "Add to
+ * workspace" materialises the package under `viz_lib/<Name>/` — a `.glsl` file
+ * that registers as a named viz — idempotently.
  *
- * Presets are seeded straight into IndexedDB (`stave-viz-presets`) — the same
- * store the app reads — with an `E2E ` name prefix so assertions don't depend on
- * the app's own bundled preset set (which shares the DB).
+ * Nothing is seeded into IndexedDB: the library is a static in-app corpus, so
+ * the Viz rows are present on boot. Registration/materialisation is observed
+ * via the `__staveOverrideVizFile` hook (finds a viz-language workspace file by
+ * basename — the exact predicate the named-viz bridge uses) and the file tree.
  */
 import { test, expect, type Page } from '@playwright/test'
 
-const VIZ_DB = 'stave-viz-presets'
-const VIZ_STORE = 'presets'
-
-type SeedPreset = { id: string; name: string; renderer: 'p5' | 'hydra' | 'glsl' }
-
-const SEEDS: SeedPreset[] = [
-  { id: 'e2e_aurora_p5', name: 'E2E Aurora', renderer: 'p5' },
-  { id: 'e2e_kaleido_hydra', name: 'E2E Kaleido', renderer: 'hydra' },
-]
-
 async function boot(page: Page): Promise<void> {
+  // Enable the `__stave*` E2E hooks (e.g. `__staveOverrideVizFile`) — they are
+  // gated on this flag and must be set before the app mounts.
+  await page.addInitScript(() => {
+    ;(window as unknown as { __STAVE_E2E__?: boolean }).__STAVE_E2E__ = true
+  })
   await page.goto('/')
   await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 30_000 })
   await page.waitForFunction(
@@ -35,146 +31,94 @@ async function boot(page: Page): Promise<void> {
   )
 }
 
-async function seedPresets(page: Page, presets: SeedPreset[]): Promise<void> {
-  await page.evaluate(
-    async ({ db, store, presets }) => {
-      const open = () =>
-        new Promise<IDBDatabase>((res, rej) => {
-          const req = indexedDB.open(db, 1)
-          req.onupgradeneeded = () => {
-            const d = req.result
-            if (!d.objectStoreNames.contains(store)) d.createObjectStore(store, { keyPath: 'id' })
-          }
-          req.onsuccess = () => res(req.result)
-          req.onerror = () => rej(req.error)
-        })
-      const d = await open()
-      for (const p of presets) {
-        await new Promise<void>((res, rej) => {
-          const r = d
-            .transaction(store, 'readwrite')
-            .objectStore(store)
-            .put({ ...p, code: '// e2e', requires: [], createdAt: 1_700_000_000_000, updatedAt: 1_700_000_000_000 })
-          r.onsuccess = () => res()
-          r.onerror = () => rej(r.error)
-        })
-      }
-      d.close()
-    },
-    { db: VIZ_DB, store: VIZ_STORE, presets },
-  )
-}
-
-async function setStrudelCode(page: Page, code: string, column: number): Promise<void> {
-  const ok = await page.evaluate(
-    ({ c, col }) => {
-      const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
-      const editors = (monaco?.editor?.getEditors?.() ?? []) as Array<{
-        getModel: () => { getLanguageId?: () => string; setValue: (s: string) => void; getValue: () => string } | null
-        focus: () => void
-        setPosition: (p: { lineNumber: number; column: number }) => void
-      }>
-      const t = editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
-      if (!t) return false
-      t.getModel()?.setValue(c)
-      t.setPosition({ lineNumber: 1, column: col })
-      t.focus()
-      return true
-    },
-    { c: code, col: column },
-  )
-  expect(ok).toBe(true)
-  await page.waitForTimeout(150)
-}
-
-async function strudelValue(page: Page): Promise<string> {
-  return page.evaluate(() => {
-    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
-    const editors = (monaco?.editor?.getEditors?.() ?? []) as Array<{
-      getModel: () => { getLanguageId?: () => string; getValue: () => string } | null
-    }>
-    const t = editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
-    return t?.getModel()?.getValue() ?? ''
-  })
-}
-
 async function openLibrary(page: Page) {
   await page.locator('[data-activity-bar] button[aria-label="Library"]').click()
   const panel = page.locator('[data-asset-library]')
   await panel.waitFor({ timeout: 10_000 })
-  // Let the async preset refetch (on library open) + notify land.
-  await page.waitForTimeout(500)
+  await page.waitForTimeout(200)
   return panel
 }
 
-/** Select the Viz type, then narrow to a single seeded preset via search so the
- *  windowed list renders exactly that row (no scroll-into-window needed). */
-async function showVizPreset(page: Page, panel: ReturnType<Page['locator']>, name: string) {
+async function showVizType(page: Page, panel: ReturnType<Page['locator']>) {
   await panel.locator('[data-filter="asset-type-filter"] button[data-chip="viz"]').click()
-  await panel.locator('[data-asset-search]').fill(name)
-  await page.waitForTimeout(150)
+  await page.waitForTimeout(100)
 }
 
-test.describe('Asset Library — Viz presets (#832)', () => {
-  test('defaults to Sounds (not All) and shows the Viz filter chip', async ({ page }) => {
+/** Whether a viz-language workspace file with the given basename exists (the
+ *  same predicate the named-viz bridge registers on). Returns the file id. */
+async function vizFileId(page: Page, basename: string): Promise<string | null> {
+  return page.evaluate(
+    (name) =>
+      (window as unknown as {
+        __staveOverrideVizFile?: (b: string, c: string) => string | null
+      }).__staveOverrideVizFile?.(name, `// probe ${Date.now()}`) ?? null,
+    basename,
+  )
+}
+
+test.describe('Asset Library — Viz library (#834)', () => {
+  test('lists the curated viz packages (Prism + Pulse Grid) grouped under GLSL', async ({ page }) => {
     await boot(page)
     const panel = await openLibrary(page)
+
+    // Viz is a first-class type — its chip is present without any seeding.
     const typeRow = panel.locator('[data-filter="asset-type-filter"]')
-    // Default-to-type: lands on the first type (Sounds), not the "All" union.
-    await expect(typeRow.locator('button[data-chip="sound"]')).toHaveAttribute('aria-pressed', 'true')
-    await expect(typeRow.locator('button[data-chip="all"]')).toHaveAttribute('aria-pressed', 'false')
-    // Viz is a first-class type — its chip is present.
     await expect(typeRow.locator('button[data-chip="viz"]')).toBeVisible()
+    await showVizType(page, panel)
+
+    const prism = panel.locator('[data-asset-row="viz:prism"]')
+    await expect(prism).toBeVisible()
+    await expect(prism).toContainText('Prism')
+    await expect(prism).toContainText('GLSL')
+
+    const pulse = panel.locator('[data-asset-row="viz:pulse-grid"]')
+    await expect(pulse).toBeVisible()
+    await expect(pulse).toContainText('Pulse Grid')
   })
 
-  test('lists seeded viz presets grouped by renderer under the Viz filter', async ({ page }) => {
+  test('the row action is "Add to workspace", not "Insert"', async ({ page }) => {
     await boot(page)
-    await seedPresets(page, SEEDS)
     const panel = await openLibrary(page)
-    await panel.locator('[data-filter="asset-type-filter"] button[data-chip="viz"]').click()
-
-    // Narrow to each seed and assert its row + renderer group.
-    await panel.locator('[data-asset-search]').fill('E2E Aurora')
-    const aurora = panel.locator('[data-asset-row="viz:e2e_aurora_p5"]')
-    await expect(aurora).toBeVisible()
-    await expect(aurora).toContainText('E2E Aurora')
-    await expect(aurora).toContainText('P5')
-
-    await panel.locator('[data-asset-search]').fill('E2E Kaleido')
-    const kaleido = panel.locator('[data-asset-row="viz:e2e_kaleido_hydra"]')
-    await expect(kaleido).toBeVisible()
-    await expect(kaleido).toContainText('Hydra')
+    await showVizType(page, panel)
+    const prism = panel.locator('[data-asset-row="viz:prism"]')
+    await prism.hover()
+    await expect(prism.locator('[data-asset-insert]')).toHaveAttribute('aria-label', /Add to workspace/)
   })
 
-  test('inserting a viz preset writes .viz("name") on the pattern under the cursor', async ({ page }) => {
+  test('adding Prism materialises viz_lib/Prism/Prism.glsl and registers it', async ({ page }) => {
     await boot(page)
-    await seedPresets(page, SEEDS)
-    await setStrudelCode(page, 'note("c4 e4 g4")', 8)
+    // Not present before the add.
+    expect(await vizFileId(page, 'Prism')).toBeNull()
+
     const panel = await openLibrary(page)
-    await showVizPreset(page, panel, 'E2E Aurora')
+    await showVizType(page, panel)
+    const prism = panel.locator('[data-asset-row="viz:prism"]')
+    await prism.hover()
+    await prism.locator('[data-asset-insert]').click()
 
-    const row = panel.locator('[data-asset-row="viz:e2e_aurora_p5"]')
-    await row.hover()
-    await row.locator('[data-asset-insert]').click()
-    await page.waitForTimeout(200)
+    // Guiding toast names the destination + how to use it.
+    await expect(page.getByText('Added Prism → viz_lib/Prism/. Use .viz("Prism").')).toBeVisible()
 
-    expect(await strudelValue(page)).toBe('note("c4 e4 g4").viz("E2E Aurora")')
+    // The file now exists in the workspace as a viz-language file named "Prism"
+    // (the predicate the named-viz bridge registers on, so `.viz("Prism")`
+    // resolves). Its exact path (`viz_lib/Prism/Prism.glsl`) is proven by the
+    // `planVizLibFiles` unit test + the toast above.
+    expect(await vizFileId(page, 'Prism')).not.toBeNull()
   })
 
-  test('guides the user when the cursor is not on a pattern (no silent no-op)', async ({ page }) => {
+  test('adding the same package twice is idempotent (no duplicate)', async ({ page }) => {
     await boot(page)
-    await seedPresets(page, SEEDS)
-    // Cursor on a comment line — no pattern chunk to attach to.
-    await setStrudelCode(page, '// scratch', 3)
     const panel = await openLibrary(page)
-    await showVizPreset(page, panel, 'E2E Aurora')
+    await showVizType(page, panel)
+    const prism = panel.locator('[data-asset-row="viz:prism"]')
 
-    const row = panel.locator('[data-asset-row="viz:e2e_aurora_p5"]')
-    await row.hover()
-    await row.locator('[data-asset-insert]').click()
+    await prism.hover()
+    await prism.locator('[data-asset-insert]').click()
+    await expect(page.getByText('Added Prism → viz_lib/Prism/. Use .viz("Prism").')).toBeVisible()
 
-    // A guiding toast appears, and the document is untouched.
-    await expect(page.getByText('Place the cursor on a pattern to attach this viz.')).toBeVisible()
-    expect(await strudelValue(page)).toBe('// scratch')
+    // Second add — the stable workspace id means it's already there.
+    await prism.hover()
+    await prism.locator('[data-asset-insert]').click()
+    await expect(page.getByText('Prism is already in your workspace.')).toBeVisible()
   })
 })

--- a/packages/app/tests/viz-library.spec.ts
+++ b/packages/app/tests/viz-library.spec.ts
@@ -104,6 +104,12 @@ test.describe('Asset Library — Viz library (#834)', () => {
     // resolves). Its exact path (`viz_lib/Prism/Prism.glsl`) is proven by the
     // `planVizLibFiles` unit test + the toast above.
     expect(await vizFileId(page, 'Prism')).not.toBeNull()
+
+    // The added file auto-opens as the active editor tab (desired UX — the user
+    // lands on the shader they just added).
+    await expect(
+      page.locator('[data-workspace-tab][data-tab-active="true"]'),
+    ).toContainText('Prism.glsl')
   })
 
   test('adding Pulse Grid (a name with a space) materialises + is recognised', async ({ page }) => {


### PR DESCRIPTION
## What

Reframes the Asset Library's **Viz** tab from a preset browser into a curated **viz-package library you add to your workspace**. Closes #834.

- **Content:** curated, *non-default* viz only — not the bundled defaults. v1 ships **Prism** + **Pulse Grid** (the two GLSL examples), each as a **package** (a folder, future-proofed for assets a viz references in its code).
- **The `+` = "Add to workspace"** (not insert-at-cursor). It materialises the package under a root `viz_lib/` folder:
  - `viz_lib/Prism/Prism.glsl`
  - `viz_lib/Pulse Grid/Pulse Grid.glsl`
- The added `.glsl` **auto-registers as a named viz**, so `.viz("Prism")` resolves immediately — no reload.
- **Idempotent:** a stable workspace-file id means a second `+` is a no-op (toast: “already in your workspace”).
- **Removed Prism + Pulse Grid from the starter seed** — the library is now their single source. Existing projects keep any copies they already have.

Supersedes the Phase 2a `.viz()`-cursor-insert provider (per the agreed rework-in-follow-up plan). **Stacked on `feat/832-viz-library`** — merge #831 → #833 → this, or retarget after they land.

## Why the runtime-registration change

`registerAllVizFiles` (StrudelEditorClient) only ran on **mount**, so a viz file added at **runtime** silently resolved to nothing — the named-viz registration filter never saw it. This PR re-runs it on workspace **file-list** changes (add/remove/rename, *not* content edits), so library-added **and** manually-created (New File) viz register live. This also closes a latent gap for the New File flow.

## Observed (real flow)

- **Headless** (`viz-library.spec`): Viz tab lists Prism + Pulse Grid under GLSL; `+` writes `viz_lib/Prism/Prism.glsl` (recognised as a viz file) with the guiding toast; a second `+` no-ops.
- **Headed, real GPU** (`glsl-seeded-viz`, the registration gate): after adding Prism from the library, inline `.viz("Prism")` **mounts in the worker** (live GL context, ~290 draw frames) and **paints animated frames** (`distinct=5/5`, 351 KB compositor capture). `viz-hot-reload` (add → edit → save → repaint) also green.

> Note: `+` auto-opens the added `Prism.glsl` as the active tab — **confirmed desired UX** (the user lands on the shader they just added). This rides the existing `openOrFocusFile`-on-file-list-add path (`StrudelEditorClient`), and is now locked by a regression assertion. The reworked gated specs switch back to the pattern tab before evaluating `.viz()`.

## Test plan

- `pnpm --filter @stave/app exec vitest run` — 682 pass (13 new: corpus / `planVizLibFiles` / provider).
- `pnpm --filter @stave/app exec playwright test viz-library --workers=1` — 4 pass.
- `E2E_VERIFY=1 … playwright test glsl-seeded-viz viz-hot-reload --headed` — both pass on real GPU.
- `tsc --noEmit` clean. All changes app-side — no `@stave/editor` `dist` rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
