### PR TITLE
✨ feat(app): Transport LCD in the menubar

### DIFF
--- a/packages/app/src/components/MenuBar.tsx
+++ b/packages/app/src/components/MenuBar.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import React, { useCallback, useEffect, useRef, useState } from "react";
+import { TransportLCD } from "./TransportLCD";
+import { useMenubarLcd } from "../state/menubarLcd";
 
 const GITHUB_REPO_URL = "https://github.com/MrityunjayBhardwaj/stave-code";
 
@@ -26,6 +28,10 @@ interface MenuBarProps {
   onRedo: () => void;
   canUndo: boolean;
   canRedo: boolean;
+  /** Transport LCD data (#857). Fed from the active runtime in StaveApp. */
+  isPlaying: boolean;
+  getCycle: () => number | null;
+  getCps: () => number | null;
 }
 
 type MenuId = "file" | "edit" | "view" | "help" | null;
@@ -49,9 +55,13 @@ export function MenuBar({
   onRedo,
   canUndo,
   canRedo,
+  isPlaying,
+  getCycle,
+  getCps,
 }: MenuBarProps) {
   const [openMenu, setOpenMenu] = useState<MenuId>(null);
   const barRef = useRef<HTMLDivElement>(null);
+  const lcdEnabled = useMenubarLcd();
 
   // Close menu on click outside OR Escape
   useEffect(() => {
@@ -126,9 +136,15 @@ export function MenuBar({
         />
       </MenuButton>
 
-      <div data-stave-brand style={styles.brand} aria-hidden="true">
-        Stave Code
-      </div>
+      {lcdEnabled ? (
+        <div style={styles.centerSlot}>
+          <TransportLCD isPlaying={isPlaying} getCycle={getCycle} getCps={getCps} />
+        </div>
+      ) : (
+        <div data-stave-brand style={styles.brand} aria-hidden="true">
+          Stave Code
+        </div>
+      )}
 
       <div style={styles.spacer} />
     </div>
@@ -210,6 +226,12 @@ const styles: Record<string, React.CSSProperties> = {
     fontWeight: 500,
     letterSpacing: 0.4,
     whiteSpace: "nowrap" as const,
+  },
+  centerSlot: {
+    position: "absolute" as const,
+    left: "50%",
+    top: "50%",
+    transform: "translate(-50%, -50%)",
   },
   menuButtonWrap: {
     position: "relative" as const,

--- a/packages/app/src/components/StaveApp.tsx
+++ b/packages/app/src/components/StaveApp.tsx
@@ -1260,6 +1260,10 @@ export function StaveApp({ initialProject }: StaveAppProps) {
         onRedo={() => { redo(); }}
         canUndo={undoState.canUndo}
         canRedo={undoState.canRedo}
+        // Transport LCD (#857) — same accessors the MusicalTimeline reads.
+        isPlaying={activeRuntime?.isPlaying ?? false}
+        getCycle={() => getCycleRef.current()}
+        getCps={() => getCpsRef.current()}
       />
 
       <div style={styles.main} data-stave-main-backdrop={backgroundFileId ? "on" : "off"}>

--- a/packages/app/src/components/TransportLCD.tsx
+++ b/packages/app/src/components/TransportLCD.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import React, { useEffect, useRef } from "react";
+import { useRulerUnits, toggleRulerUnits } from "../state/rulerUnits";
+
+/**
+ * TransportLCD (#857) — a backlit hardware-style readout for the menubar's
+ * centered slot: transport state, cycle position, tempo, and frame health.
+ *
+ * Data comes from the accessors the timeline already reads (`getCycle`/
+ * `getCps` on the active runtime) plus `isPlaying`. The fast-changing numbers
+ * (position, tempo, FPS) are written straight to DOM refs on a rAF loop so the
+ * menubar never re-renders per frame; only the slow state (isPlaying, mode)
+ * flows through React.
+ *
+ * Display mode reuses the app-wide Ruler-units preference — CYCLES shows
+ * `CYC 042.3 · 0.50 CPS`, BARS shows `BAR 011.3.1 · 120 BPM` — and clicking
+ * the screen flips it, keeping the LCD and the timeline ruler in agreement.
+ *
+ * The screen palette is fixed dark in both themes: a backlit display reads as
+ * a screen, not a themed card. The bezel/labels ride the chrome tokens.
+ */
+
+interface TransportLCDProps {
+  readonly isPlaying: boolean;
+  readonly getCycle: () => number | null;
+  readonly getCps: () => number | null;
+}
+
+const STYLE_ID = "stave-transport-lcd-styles";
+
+function ensureLcdStyles(): void {
+  if (typeof document === "undefined" || document.getElementById(STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+    .stave-lcd {
+      position: relative; display: flex; align-items: stretch; height: 22px;
+      border-radius: 4px; padding: 0 2px; overflow: hidden; cursor: pointer;
+      font-family: var(--font-mono, ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+      background: linear-gradient(180deg, #0a0a1a, #05050e);
+      border: 1px solid #01010a;
+      box-shadow: inset 0 1px 0 rgba(160,168,255,0.06),
+                  inset 0 0 12px rgba(80,90,200,0.14),
+                  0 0 0 1px rgba(120,124,255,0.10), 0 1px 2px rgba(0,0,0,0.6);
+    }
+    .stave-lcd:focus-visible { outline: 2px solid #7c7cff; outline-offset: 2px; }
+    .stave-lcd::after {
+      content: ""; position: absolute; inset: 0; border-radius: 4px; pointer-events: none;
+      background: repeating-linear-gradient(0deg, transparent 0, transparent 2px, rgba(0,0,0,0.16) 3px);
+      mix-blend-mode: multiply; opacity: .5;
+    }
+    .stave-lcd-seg { display: flex; align-items: center; gap: 5px; padding: 0 8px; height: 100%; }
+    .stave-lcd-seg + .stave-lcd-seg { box-shadow: inset 1px 0 0 rgba(120,124,255,0.10); }
+    .stave-lcd-label { font-size: 8px; letter-spacing: 0.14em; color: #6f6fa0; text-transform: uppercase; line-height: 1; }
+    .stave-lcd-dot { width: 7px; height: 7px; border-radius: 50%; background: #6f6fa0; flex: none; transition: background .15s, box-shadow .15s; }
+    .stave-lcd.run .stave-lcd-dot { background: #6bff8c; box-shadow: 0 0 6px rgba(107,255,140,0.55); animation: stave-lcd-pulse 1.05s ease-in-out infinite; }
+    @keyframes stave-lcd-pulse { 0%,100% { opacity: 1; } 50% { opacity: .45; } }
+    .stave-lcd-state { font-size: 8px; letter-spacing: 0.16em; color: #6f6fa0; text-transform: uppercase; }
+    .stave-lcd.run .stave-lcd-state { color: #6bff8c; }
+    .stave-lcd-readout { position: relative; display: inline-grid; }
+    .stave-lcd-readout > span { grid-area: 1 / 1; font-variant-numeric: tabular-nums; letter-spacing: 0.06em; font-size: 13px; font-weight: 600; white-space: pre; }
+    .stave-lcd-ghost { color: rgba(150,158,255,0.10); }
+    .stave-lcd-live { color: #bcc2ff; text-shadow: 0 0 6px rgba(150,158,255,0.55), 0 0 1px rgba(190,196,255,0.9); }
+    .stave-lcd-tempo { font-variant-numeric: tabular-nums; font-size: 12px; font-weight: 600; color: #9aa0e6; text-shadow: 0 0 5px rgba(140,148,230,0.4); letter-spacing: .04em; }
+    .stave-lcd-fps { display: flex; align-items: center; gap: 6px; }
+    .stave-lcd-bars { display: flex; align-items: flex-end; gap: 1.5px; height: 11px; }
+    .stave-lcd-bars i { width: 2.5px; background: #6f6fa0; border-radius: 1px; opacity: .3; }
+    .stave-lcd-bars i.on { opacity: 1; }
+    .stave-lcd-fps.good .stave-lcd-bars i.on { background: #6bff8c; box-shadow: 0 0 4px rgba(107,255,140,.55); }
+    .stave-lcd-fps.warn .stave-lcd-bars i.on { background: #ffcf7a; box-shadow: 0 0 4px rgba(255,207,122,.5); }
+    .stave-lcd-fps.crit .stave-lcd-bars i.on { background: #ff8080; box-shadow: 0 0 4px rgba(255,128,128,.5); }
+    .stave-lcd-fpsnum { font-variant-numeric: tabular-nums; font-size: 11px; font-weight: 600; color: #9aa0e6; }
+    @media (prefers-reduced-motion: reduce) { .stave-lcd.run .stave-lcd-dot { animation: none; } }
+  `;
+  document.head.appendChild(style);
+}
+
+const DASH = "—";
+
+/** `042.3` — three integer digits, one fractional. */
+function fmtCycle(c: number): string {
+  const [a, b] = c.toFixed(1).split(".");
+  return `${a.padStart(3, "0")}.${b}`;
+}
+
+/** `011.3.1` — bar·beat·tick (one cycle ≈ one bar, quarter-cycle beats). */
+function fmtBar(c: number): string {
+  const bar = Math.floor(c) + 1;
+  const beat = Math.floor((c % 1) * 4) + 1;
+  const tick = Math.floor(((c * 4) % 1) * 4) + 1;
+  return `${String(bar).padStart(3, "0")}.${beat}.${tick}`;
+}
+
+export function TransportLCD({ isPlaying, getCycle, getCps }: TransportLCDProps): React.ReactElement {
+  const units = useRulerUnits();
+  const cycleMode = units === "cycles";
+
+  // Keep the fast-path accessors and the current mode in refs so the rAF loop
+  // (mounted once) always reads the latest without restarting per render.
+  const getCycleRef = useRef(getCycle);
+  const getCpsRef = useRef(getCps);
+  const cycleModeRef = useRef(cycleMode);
+  getCycleRef.current = getCycle;
+  getCpsRef.current = getCps;
+  cycleModeRef.current = cycleMode;
+
+  const posRef = useRef<HTMLSpanElement>(null);
+  const tempoRef = useRef<HTMLSpanElement>(null);
+  const fpsWrapRef = useRef<HTMLDivElement>(null);
+  const fpsNumRef = useRef<HTMLSpanElement>(null);
+  const barsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    ensureLcdStyles();
+    let raf = 0;
+    let last = performance.now();
+    let fps = 60;
+    let acc = 0;
+
+    const tick = (now: number): void => {
+      const dt = Math.max(0.001, (now - last) / 1000);
+      last = now;
+      // FPS from the rAF delta, smoothed so it reads steady not jittery.
+      fps += (1 / dt - fps) * 0.1;
+
+      acc += dt;
+      if (acc >= 0.08) {
+        acc = 0;
+        const cps = getCpsRef.current();
+        const cyc = getCycleRef.current();
+        const inCycle = cycleModeRef.current;
+
+        if (posRef.current) {
+          posRef.current.textContent =
+            cyc === null ? `${DASH} ${DASH}` : inCycle ? fmtCycle(cyc) : fmtBar(cyc);
+        }
+        if (tempoRef.current) {
+          tempoRef.current.textContent =
+            cps === null ? `${DASH}${DASH}` : inCycle ? cps.toFixed(2) : String(Math.round(cps * 240));
+        }
+
+        const shown = Math.max(1, Math.round(fps));
+        if (fpsNumRef.current) fpsNumRef.current.textContent = String(Math.min(shown, 120));
+        const cls = shown >= 55 ? "good" : shown >= 30 ? "warn" : "crit";
+        if (fpsWrapRef.current) fpsWrapRef.current.className = `stave-lcd-fps ${cls}`;
+        const lit = Math.round((Math.min(shown, 60) / 60) * 5);
+        if (barsRef.current) {
+          const bars = barsRef.current.children;
+          for (let i = 0; i < bars.length; i++) {
+            (bars[i] as HTMLElement).classList.toggle("on", i < lit);
+          }
+        }
+      }
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, []);
+
+  return (
+    <div
+      className={`stave-lcd${isPlaying ? " run" : ""}`}
+      role="button"
+      tabIndex={0}
+      data-stave-transport-lcd
+      aria-label="Transport display — click to switch between cycle and bar display"
+      onClick={toggleRulerUnits}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          toggleRulerUnits();
+        }
+      }}
+    >
+      <div className="stave-lcd-seg">
+        <span className="stave-lcd-dot" />
+        <span className="stave-lcd-state">{isPlaying ? "PLAY" : "STOP"}</span>
+      </div>
+      <div className="stave-lcd-seg">
+        <span className="stave-lcd-label">{cycleMode ? "CYC" : "BAR"}</span>
+        <span className="stave-lcd-readout">
+          <span className="stave-lcd-ghost">{cycleMode ? "888.8" : "888.8.8"}</span>
+          <span className="stave-lcd-live" ref={posRef} data-stave-lcd-pos>
+            {cycleMode ? "000.0" : "000.0.0"}
+          </span>
+        </span>
+      </div>
+      <div className="stave-lcd-seg">
+        <span className="stave-lcd-tempo" ref={tempoRef} data-stave-lcd-tempo>
+          {DASH}
+        </span>
+        <span className="stave-lcd-label">{cycleMode ? "CPS" : "BPM"}</span>
+      </div>
+      <div className="stave-lcd-seg">
+        <div className="stave-lcd-fps good" ref={fpsWrapRef}>
+          <div className="stave-lcd-bars" ref={barsRef}>
+            {[0, 1, 2, 3, 4].map((i) => (
+              <i key={i} style={{ height: `${5 + i * 1.5}px` }} />
+            ))}
+          </div>
+          <span className="stave-lcd-fpsnum" ref={fpsNumRef}>
+            60
+          </span>
+        </div>
+        <span className="stave-lcd-label">FPS</span>
+      </div>
+    </div>
+  );
+}

--- a/packages/app/src/components/settings/SettingsPanel.tsx
+++ b/packages/app/src/components/settings/SettingsPanel.tsx
@@ -49,6 +49,7 @@ import {
   type AliasRowError,
 } from "../signalAliasRows";
 import { getRulerUnits, setRulerUnits, type RulerUnits } from "../../state/rulerUnits";
+import { getMenubarLcdEnabled, setMenubarLcdEnabled } from "../../state/menubarLcd";
 import { getVizPreviewHeight, setVizPreviewHeight } from "../../state/vizPreviewHeight";
 import { Switch } from "./Switch";
 import { SettingRow } from "./SettingRow";
@@ -89,6 +90,7 @@ const ADAPTERS: Record<string, SettingAdapter> = {
     set: (v) => { if (Boolean(v) !== getEditorMinimap()) toggleEditorMinimap(); },
   },
   trackColourBar: { get: getTrackColourBarsEnabled, set: (v) => setTrackColourBarsEnabled(Boolean(v)) },
+  menubarLcd: { get: getMenubarLcdEnabled, set: (v) => setMenubarLcdEnabled(Boolean(v)) },
   noteColor: { get: getNoteColorMode, set: (v) => setNoteColorMode(v as NoteColorMode) },
   rulerUnits: { get: getRulerUnits, set: (v) => setRulerUnits(v as RulerUnits) },
   timelineSubRow: { get: getMusicalTimelineSubRowHeight, set: (v) => setMusicalTimelineSubRowHeight(Number(v)) },

--- a/packages/app/src/components/settings/settingsSections.ts
+++ b/packages/app/src/components/settings/settingsSections.ts
@@ -94,6 +94,7 @@ export const SECTION_DEFS: readonly SettingsSectionDef[] = [
       { key: "iconSize", name: "Icon size", description: "Toolbar and gutter icon scale.", kind: "slider", min: 10, max: 32, unit: "px" },
       { key: "minimap", name: "Minimap", description: "Show the code minimap on the right edge.", kind: "switch" },
       { key: "trackColourBar", name: "Track colour bar", description: "Per-track colour stripe on the left gutter.", kind: "switch" },
+      { key: "menubarLcd", name: "Transport LCD", description: "Show the live transport readout (position, tempo, frame health) in the menubar's centre. Off shows the Stave Code label instead.", kind: "switch" },
     ],
   },
   {

--- a/packages/app/src/state/menubarLcd.ts
+++ b/packages/app/src/state/menubarLcd.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+/**
+ * Whether the menubar's Transport LCD is shown (#857).
+ *
+ * The LCD replaces the passive "Stave Code" brand in the menubar's centered
+ * slot. Two subtrees care — `MenuBar` (renders the LCD or the brand) and the
+ * Settings panel (toggles it) — so, like `rulerUnits`, it lives in a tiny
+ * external store rather than being threaded through prop surfaces.
+ *
+ * Persisted (localStorage, default ON) so the choice survives reloads, the
+ * way the theme does. Reads are SSR-safe: the default is returned when there
+ * is no window, and the store hydrates from storage on first client read.
+ */
+
+const STORAGE_KEY = "stave:menubarLcd";
+const DEFAULT_ENABLED = true;
+
+function read(): boolean {
+  try {
+    if (typeof window === "undefined") return DEFAULT_ENABLED;
+    const saved = window.localStorage?.getItem(STORAGE_KEY);
+    if (saved === null || saved === undefined) return DEFAULT_ENABLED;
+    return saved === "1";
+  } catch {
+    return DEFAULT_ENABLED;
+  }
+}
+
+function write(next: boolean): void {
+  try {
+    window.localStorage?.setItem(STORAGE_KEY, next ? "1" : "0");
+  } catch {
+    /* storage unavailable — in-session value still updates */
+  }
+}
+
+let current = read();
+const listeners = new Set<() => void>();
+
+export function getMenubarLcdEnabled(): boolean {
+  return current;
+}
+
+export function setMenubarLcdEnabled(next: boolean): void {
+  if (next === current) return;
+  current = next;
+  write(next);
+  for (const l of listeners) l();
+}
+
+export function subscribeMenubarLcd(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+/** React binding — re-renders the caller whenever the flag changes. */
+export function useMenubarLcd(): boolean {
+  return useSyncExternalStore(subscribeMenubarLcd, getMenubarLcdEnabled, () => DEFAULT_ENABLED);
+}

--- a/packages/app/tests/menubar-transport-lcd.spec.ts
+++ b/packages/app/tests/menubar-transport-lcd.spec.ts
@@ -1,0 +1,59 @@
+// Transport LCD in the menubar (#857): shown by default, reflects transport
+// state, advances position while playing, flips display mode on click, and
+// hides behind the Editor Settings toggle (brand returns).
+import { test, expect, type Page } from '@playwright/test'
+
+async function boot(page: Page): Promise<void> {
+  await page.goto('/')
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 15_000 })
+  await page.waitForFunction(
+    () => {
+      const m = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+      return (m?.editor?.getEditors?.()?.length ?? 0) > 0
+    },
+    { timeout: 15_000 },
+  )
+}
+
+const LCD = '[data-stave-transport-lcd]'
+
+test('shows by default and reflects transport + mode + settings toggle', async ({ page }) => {
+  await boot(page)
+
+  // Default ON: the LCD is present, the brand label is not.
+  const lcd = page.locator(LCD)
+  await expect(lcd).toBeVisible()
+  await expect(page.locator('[data-stave-brand]')).toHaveCount(0)
+
+  // Stopped state before play.
+  await expect(lcd).toContainText('STOP')
+
+  // Play → the LCD reads PLAY and the position advances over time.
+  await page.locator('[data-testid="strudel-chrome-transport"]').click()
+  await expect(lcd).toContainText('PLAY', { timeout: 8000 })
+  const pos = page.locator('[data-stave-lcd-pos]')
+  const first = await pos.textContent()
+  await page.waitForTimeout(700)
+  const second = await pos.textContent()
+  expect(second, 'position should advance while playing').not.toBe(first)
+
+  // Click the screen flips the display mode (CYC → BAR), which drives both the
+  // LCD label and the shared ruler-units preference.
+  await expect(lcd).toContainText('CYC')
+  await lcd.click()
+  await expect(lcd).toContainText('BAR')
+  await lcd.click()
+  await expect(lcd).toContainText('CYC')
+
+  // Editor Settings toggle hides the LCD and brings the brand back.
+  await page.locator('[data-testid="strudel-chrome-transport"]').click() // stop
+  await page.getByText('File', { exact: true }).click()
+  await page.getByText('Editor Settings...', { exact: true }).click()
+  const lcdSwitch = page.locator('[data-testid="setting-menubarLcd"]')
+  await expect(lcdSwitch).toBeVisible({ timeout: 5000 })
+  await lcdSwitch.click()
+  // Close the settings surface (Escape) and verify the swap.
+  await page.keyboard.press('Escape')
+  await expect(page.locator(LCD)).toHaveCount(0)
+  await expect(page.locator('[data-stave-brand]')).toBeVisible()
+})


### PR DESCRIPTION
Closes #857. Implements the **Stave Transport LCD** mockup — a backlit, groovebox-style readout in the menubar's dead-center slot.

### What it shows (left→right)
- **Transport** — pulsing dot + PLAY / STOP (green running, dim halted)
- **Position** — phosphor counter over ghosted `888` — `CYC 042.3` or `BAR 011.3.1`
- **Tempo** — `0.50 CPS` (cycle) / `120 BPM` (bars); `bpm = cps × 240`
- **Health** — 5-bar meter + FPS from the rAF delta (green ≥55 / amber / red)

### Decisions (per discussion)
- **ON by default** — toggled under **Editor Settings → Appearance → "Transport LCD"**; when off, the `Stave Code` brand returns (no layout shift).
- **Mode reuses the existing Ruler-units setting** (cycles/bars); clicking the screen flips it, so the LCD and the timeline ruler always agree — no new mode state.

### Wiring (all app-side, no editor rebuild)
- `state/menubarLcd.ts` — persisted (localStorage, default on) store mirroring `state/rulerUnits.ts`; `useMenubarLcd()` hook.
- `TransportLCD.tsx` — reads `useRulerUnits()`, flips via `toggleRulerUnits()`; a rAF loop samples `getCycle`/`getCps` + derives FPS, writing fast readouts straight to refs so the menubar never re-renders per frame. Screen palette fixed-dark in both themes; honours `prefers-reduced-motion`.
- `MenuBar` renders it in the centered slot when enabled; `StaveApp` feeds `activeRuntime.isPlaying` + the `getCycle`/`getCps` closures the timeline reads.
- Settings: `menubarLcd` switch (`settingsSections` + `SettingsPanel` adapter; coverage test balances).

### Test plan
- **Observed live** (screenshots + e2e): default-on with brand hidden; `PLAY` on play; position advances; click flips `CYC 000.7 · 0.54 CPS` ↔ `BAR 002.1.2 · 130 BPM`; the settings switch hides the LCD and restores the brand.
- App `tsc` clean; settings unit **8 green**; menubar regression **3 green**; new `menubar-transport-lcd.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)