### PR TITLE
🩺 fix(app): make the Transport LCD health meter honest about frame health

### DIFF
--- a/packages/app/src/components/TransportLCD.tsx
+++ b/packages/app/src/components/TransportLCD.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import React, { useEffect, useRef } from "react";
+import { perf } from "@stave/editor";
 import { useRulerUnits, toggleRulerUnits } from "../state/rulerUnits";
+import { healthClass, healthBars } from "./transportLcdHealth";
 
 /**
  * TransportLCD (#857) — a backlit hardware-style readout for the menubar's
@@ -12,6 +14,17 @@ import { useRulerUnits, toggleRulerUnits } from "../state/rulerUnits";
  * (position, tempo, FPS) are written straight to DOM refs on a rAF loop so the
  * menubar never re-renders per frame; only the slow state (isPlaying, mode)
  * flows through React.
+ *
+ * The health meter is layered and honest about what it can see:
+ *  - Profiler ON (perf overlay / setting): reads the canonical `perf.snapshot()`
+ *    — worst live viz-frame fps + slowFrames + longtasks — the same instrument
+ *    PerfOverlay uses, which reflects the actual viz render cadence, not just a
+ *    bare main-thread rAF.
+ *  - Profiler OFF (default): the rAF cadence, plus an always-on `longtask`
+ *    observer so a real main-thread stall pulls the meter to amber/red even when
+ *    the smoothed fps still looks fine.
+ *  - GPU/compositor strain while the profiler is OFF isn't main-thread-measurable
+ *    here (see the perf catalogue) and stays out of scope — not silently green.
  *
  * Display mode reuses the app-wide Ruler-units preference — CYCLES shows
  * `CYC 042.3 · 0.50 CPS`, BARS shows `BAR 011.3.1 · 120 BPM` — and clicking
@@ -116,17 +129,40 @@ export function TransportLCD({ isPlaying, getCycle, getCps }: TransportLCDProps)
     let raf = 0;
     let last = performance.now();
     let fps = 60;
-    let acc = 0;
+    let posAcc = 0;
+    let healthAcc = 0;
+    let prevLtCount = 0; // profiler longtask counter, diffed per health tick
+    let ownLtAt = -Infinity; // last main-thread stall we saw (profiler-OFF path)
+    let ownLtMs = 0;
+
+    // Always-on main-thread stall detector for when the profiler is off. Guarded:
+    // 'longtask' isn't observable in Safari / jsdom — the meter then just rides
+    // the rAF cadence, no worse than before.
+    let ltObs: PerformanceObserver | null = null;
+    try {
+      if (typeof PerformanceObserver !== "undefined") {
+        ltObs = new PerformanceObserver((list) => {
+          for (const e of list.getEntries()) {
+            ownLtAt = performance.now();
+            ownLtMs = e.duration;
+          }
+        });
+        ltObs.observe({ entryTypes: ["longtask"] });
+      }
+    } catch {
+      ltObs = null;
+    }
 
     const tick = (now: number): void => {
       const dt = Math.max(0.001, (now - last) / 1000);
       last = now;
-      // FPS from the rAF delta, smoothed so it reads steady not jittery.
+      // Smoothed rAF cadence — the fallback health signal when the profiler is off.
       fps += (1 / dt - fps) * 0.1;
 
-      acc += dt;
-      if (acc >= 0.08) {
-        acc = 0;
+      // Position / tempo — smooth (~12.5Hz) so the counter reads like a display.
+      posAcc += dt;
+      if (posAcc >= 0.08) {
+        posAcc = 0;
         const cps = getCpsRef.current();
         const cyc = getCycleRef.current();
         const inCycle = cycleModeRef.current;
@@ -139,12 +175,38 @@ export function TransportLCD({ isPlaying, getCycle, getCps }: TransportLCDProps)
           tempoRef.current.textContent =
             cps === null ? `${DASH}${DASH}` : inCycle ? cps.toFixed(2) : String(Math.round(cps * 240));
         }
+      }
 
-        const shown = Math.max(1, Math.round(fps));
+      // Health — coarser (~4Hz). Reuses the canonical profiler when it's on
+      // (worst live viz-frame fps + slowFrames + longtasks), else the rAF cadence
+      // dragged down by any recent main-thread stall.
+      healthAcc += dt;
+      if (healthAcc >= 0.25) {
+        healthAcc = 0;
+        let shownFps: number;
+        let slow = false;
+        let stallMs = 0;
+
+        if (perf.enabled) {
+          const snap = perf.snapshot();
+          const frameFps = Object.values(snap.frames)
+            .map((f) => f.fps)
+            .filter((v) => v > 0);
+          // The slowest live viz is what the eye actually reads as jank.
+          shownFps = frameFps.length ? Math.min(...frameFps) : fps;
+          slow = Object.values(snap.frames).some((f) => f.slowFrames > 0);
+          if (snap.longtasks.count > prevLtCount) stallMs = snap.longtasks.maxMs;
+          prevLtCount = snap.longtasks.count;
+        } else {
+          shownFps = fps;
+          if (now - ownLtAt < 1200) stallMs = ownLtMs;
+        }
+
+        const shown = Math.max(1, Math.round(shownFps));
         if (fpsNumRef.current) fpsNumRef.current.textContent = String(Math.min(shown, 120));
-        const cls = shown >= 55 ? "good" : shown >= 30 ? "warn" : "crit";
+        const cls = healthClass(shown, slow, stallMs);
         if (fpsWrapRef.current) fpsWrapRef.current.className = `stave-lcd-fps ${cls}`;
-        const lit = Math.round((Math.min(shown, 60) / 60) * 5);
+        const lit = healthBars(cls, shown);
         if (barsRef.current) {
           const bars = barsRef.current.children;
           for (let i = 0; i < bars.length; i++) {
@@ -155,7 +217,10 @@ export function TransportLCD({ isPlaying, getCycle, getCps }: TransportLCDProps)
       raf = requestAnimationFrame(tick);
     };
     raf = requestAnimationFrame(tick);
-    return () => cancelAnimationFrame(raf);
+    return () => {
+      cancelAnimationFrame(raf);
+      ltObs?.disconnect();
+    };
   }, []);
 
   return (

--- a/packages/app/src/components/__tests__/transportLcdHealth.test.ts
+++ b/packages/app/src/components/__tests__/transportLcdHealth.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { healthClass, healthBars } from "../transportLcdHealth";
+
+// The health meter's whole point (#859): a high fps must NOT read green when a
+// real main-thread stall or a slow viz cadence is present. These lock the
+// layered classification so the "blindly green" regression can't come back.
+describe("healthClass", () => {
+  it("is good only when fps is high AND nothing is stalling", () => {
+    expect(healthClass(60, false, 0)).toBe("good");
+    expect(healthClass(120, false, 0)).toBe("good");
+    expect(healthClass(55, false, 0)).toBe("good");
+  });
+
+  it("warns on a middling fps", () => {
+    expect(healthClass(54, false, 0)).toBe("warn");
+    expect(healthClass(31, false, 0)).toBe("warn");
+  });
+
+  it("crits below 30fps", () => {
+    expect(healthClass(29, false, 0)).toBe("crit");
+    expect(healthClass(1, false, 0)).toBe("crit");
+  });
+
+  it("a recent main-thread stall pulls it down even at high fps (the fix)", () => {
+    expect(healthClass(120, false, 1)).toBe("warn"); // any stall → not green
+    expect(healthClass(120, false, 60)).toBe("warn");
+    expect(healthClass(120, false, 120)).toBe("crit"); // a big block → crit
+    expect(healthClass(120, false, 300)).toBe("crit");
+  });
+
+  it("a uniformly-slow viz (profiler slowFrames) crits regardless of fps", () => {
+    expect(healthClass(60, true, 0)).toBe("crit");
+  });
+});
+
+describe("healthBars", () => {
+  it("crit lights one bar, warn three, good scales with fps", () => {
+    expect(healthBars("crit", 120)).toBe(1);
+    expect(healthBars("warn", 120)).toBe(3);
+    expect(healthBars("good", 60)).toBe(5);
+    expect(healthBars("good", 30)).toBe(3); // 30/60*5 = 2.5 → 3
+    expect(healthBars("good", 12)).toBe(1);
+  });
+});

--- a/packages/app/src/components/transportLcdHealth.ts
+++ b/packages/app/src/components/transportLcdHealth.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure health-meter classification for the Transport LCD (#859).
+ *
+ * Kept in its own module — with NO `@stave/editor` import — so the logic is
+ * unit-testable without dragging the editor barrel (gifenc/CJS) into a hermetic
+ * app test. TransportLCD imports these; the profiler read stays in the component.
+ */
+
+export type HealthClass = "good" | "warn" | "crit";
+
+/**
+ * Map a health sample to a meter class.
+ * `fps` is the worst live viz cadence (profiler on) or the rAF cadence (off);
+ * `slow` = the profiler saw a uniformly-slow viz; `stallMs` = the worst recent
+ * main-thread longtask (0 if none in the window). A recent stall pulls the
+ * meter down even when `fps` looks fine — the whole point of the layered signal.
+ */
+export function healthClass(fps: number, slow: boolean, stallMs: number): HealthClass {
+  if (fps < 30 || slow || stallMs >= 120) return "crit";
+  if (fps < 55 || stallMs > 0) return "warn";
+  return "good";
+}
+
+/** Lit-bar count (of 5) for a health class — warn/crit visibly drop bars even
+ *  when the smoothed fps number lags. */
+export function healthBars(cls: HealthClass, fps: number): number {
+  if (cls === "crit") return 1;
+  if (cls === "warn") return 3;
+  return Math.round((Math.min(fps, 60) / 60) * 5);
+}


### PR DESCRIPTION
Closes #859. Follow-up to the Transport LCD (#858).

### Problem
The LCD's health meter derived FPS from a bare `requestAnimationFrame` delta — a **main-thread** cadence. When heavy GLSL/worker viz saturate the GPU, the compositor drops frames while the main thread can sit idle, so the meter could read a blind green (60/120) while the real experience is janky. It overclaimed "frame health."

### Fix — reuse the canonical instrument, be honest about the rest
- **Profiler ON** (perf overlay / setting): read `perf.snapshot()` — worst live viz-frame fps + `slowFrames` + longtasks — the same instrument `PerfOverlay` uses, reflecting actual viz render cadence.
- **Profiler OFF** (default): keep the rAF cadence, but add an always-on `PerformanceObserver('longtask')` so a real main-thread stall pulls the meter to amber/red even when the smoothed fps looks fine. Bar count follows the health class.
- **GPU/compositor strain while the profiler is off** is not main-thread-measurable here (the perf catalogue marks it unsolved) — kept explicitly out of scope, not silently green.

No new deps (reuses the already-imported `perf`). Health sampling throttled to ~4Hz; the profiler is only snapshotted when enabled (zero-cost-when-disabled preserved). Classification lives in a pure module (`transportLcdHealth.ts`, no `@stave/editor` import) so it's unit-testable without the editor-barrel/gifenc trap.

### Test plan
- **Observed live**: profiler off, real boot-time longtasks (hydration/monaco) show **WARN at 120fps**, then settle to **GOOD** when the main thread quiets — the layered signal reacting to genuine stalls, not a blind green. (`longtask` confirmed supported; a busy block fired one.)
- **6 unit tests** lock the classification (`healthClass`/`healthBars`) — including "a recent stall must not read green at high fps."
- `menubar-transport-lcd` e2e still green; app `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)