### PR TITLE
✨ feat(timeline): eval-backed lanes for signal / bare-ref tracks

### DIFF
--- a/packages/app/src/components/musicalTimeline/__tests__/collectNoteMarks.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/collectNoteMarks.test.ts
@@ -75,18 +75,34 @@ describe('collectNoteMarks — eval-backed marks (#861)', () => {
     expect(marks.marksByLane.get('d2')?.map((n) => n.pitch)).toEqual([E3])
   })
 
-  it('routes a loc-less hap to the first-seen (default) lane, not dropped', () => {
-    // A sampled/continuous-signal hap carries NO loc → un-attributable by
-    // containment → the first IR lane (`d1`). Kept (still plays), just not
-    // lane-precise (the eval-backed-lanes follow-on, P1b).
+  it('routes a loc-less hap to its OWN eval lane by trackId, not a default IR lane (#864)', () => {
+    // A sampled-signal hap carries NO loc → un-attributable by containment. P1b
+    // routes it to an EVAL lane keyed by its producer id (`$1` → `d2`), NOT the
+    // first IR lane — so it neither vanishes nor pollutes an unrelated lane.
     const haps = [
-      { begin: 0, end: 1, trackId: '$3', note: 'C3', gain: 1 },
+      { begin: 0, end: 1, trackId: '$1', note: 'C3', gain: 1 },
     ] as unknown as Parameters<typeof collectNoteMarks>[0]
 
     const marks = collectNoteMarks(haps, { fake: true } as never, 4)
 
-    expect(marks.marksByLane.get('d1')?.map((n) => n.pitch)).toEqual([C3])
-    expect(marks.marksByLane.get('d2')).toBeUndefined()
+    // Its own eval lane `d2` (`$1` → d{1+1}); the IR lanes d1/d2 got no marks
+    // (d2 here is the EVAL lane, disjoint from any IR lane — the mock IR has
+    // events only under d1/d2 keys, but this hap has no loc so it can't attach).
+    expect(marks.marksByLane.get('d2')?.map((n) => n.pitch)).toEqual([C3])
+    // Not routed to the first IR lane (the old default-lane pollution bug).
+    expect(marks.marksByLane.get('d1')).toBeUndefined()
+  })
+
+  it('keys a named-producer eval lane by the name verbatim (#864)', () => {
+    // An un-attributable hap from a NAMED producer (no loc) → eval lane keyed by
+    // the name, not a positional `d{N}` — mirroring `trackIdFromLabel`.
+    const haps = [
+      { begin: 0, end: 1, trackId: 'bass', note: 'E3', gain: 1 },
+    ] as unknown as Parameters<typeof collectNoteMarks>[0]
+
+    const marks = collectNoteMarks(haps, { fake: true } as never, 4)
+
+    expect(marks.marksByLane.get('bass')?.map((n) => n.pitch)).toEqual([E3])
   })
 
   it('falls back to IR marks (source-lossy pitch) when there are no eval events', () => {

--- a/packages/app/src/components/musicalTimeline/__tests__/timelineScene.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/timelineScene.test.ts
@@ -305,3 +305,55 @@ describe('clipAtCycle', () => {
     expect(clipAtCycle(lane, -1)).toBeNull()
   })
 })
+
+describe('eval-backed lanes (#864 / P1b)', () => {
+  it('renders a lane for a marks key not present in the analysis, appended after IR lanes', () => {
+    // `d2` is an eval-only lane (a signal/bare-ref track the IR analysis missed):
+    // it appears in the marks but NOT in `analysisFixture.lanes` (bd, lead).
+    const scene = buildTimelineScene(
+      analysisFixture,
+      marks({
+        bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1 }],
+        d2: [
+          { cycle: 0, end: 0.5, pitch: 48, gain: 1 },
+          { cycle: 0, end: 0.5, pitch: 52, gain: 1 },
+          { cycle: 2, end: 2.5, pitch: 55, gain: 1 },
+        ],
+      }),
+    )
+    // IR lanes first (bd, lead), eval lane appended (d2).
+    expect(scene.lanes.map((l) => l.laneKey)).toEqual(['bd', 'lead', 'd2'])
+    const d2 = scene.lanes.find((l) => l.laneKey === 'd2')!
+    // Density synthesised from the marks: 2 onsets in cycle 0, 1 in cycle 2.
+    expect(d2.density).toEqual([2, 0, 1, 0])
+    // Pitch range from its marks; a positional display name (no labelOffset).
+    expect(d2.pitchMin).toBe(48)
+    expect(d2.pitchMax).toBe(55)
+    expect(d2.displayName).toBe('d2')
+    // One implicit clip spanning the display span (no armIndex on eval marks).
+    expect(d2.clips).toEqual([{ armIndex: -1, startCycle: 0, endCycle: 4, label: null }])
+  })
+
+  it('folds eval-lane density into peakDensity', () => {
+    const scene = buildTimelineScene(
+      analysisFixture, // IR peak is 3 (bd cell)
+      marks({
+        d2: [
+          { cycle: 1, end: 1.5, pitch: 60, gain: 1 },
+          { cycle: 1, end: 1.5, pitch: 62, gain: 1 },
+          { cycle: 1, end: 1.5, pitch: 64, gain: 1 },
+          { cycle: 1, end: 1.5, pitch: 65, gain: 1 }, // 4 onsets in cycle 1
+        ],
+      }),
+    )
+    expect(scene.peakDensity).toBe(4) // eval lane's busiest cell beats the IR peak
+  })
+
+  it('adds no lanes when every marks key is an IR lane (no regression)', () => {
+    const scene = buildTimelineScene(
+      analysisFixture,
+      marks({ bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1 }] }),
+    )
+    expect(scene.lanes.map((l) => l.laneKey)).toEqual(['bd', 'lead'])
+  })
+})

--- a/packages/app/src/components/musicalTimeline/timelineMarks.ts
+++ b/packages/app/src/components/musicalTimeline/timelineMarks.ts
@@ -57,10 +57,6 @@ export function collectNoteMarks(
   const useEval = Array.isArray(events) && events.length > 0
   // IR-derived note marks — the pre-eval fallback. Left empty when `useEval`.
   const marksByLane = new Map<string, SceneNote[]>()
-  // First-seen IR lane keys — the containment default for a hap with no `loc`
-  // (continuous/sampled signal) or a `loc` before every lane's statement.
-  const laneOrder: string[] = []
-  const laneSeen = new Set<string>()
   // Per-lane representative source offset for expand-to-bind: the FIRST event of
   // the lane that carries a `loc` (char offsets into the evaluated source). The
   // bind maps this → editor cursor → the Pattern panel rebinds (#422). First-
@@ -109,10 +105,6 @@ export function collectNoteMarks(
     const cycle = ev.begin
     if (!Number.isFinite(cycle) || cycle < 0 || cycle >= displayCycles) continue
     const key = laneKeyOf(ev)
-    if (!laneSeen.has(key)) {
-      laneSeen.add(key)
-      laneOrder.push(key)
-    }
     if (!sourceByLane.has(key)) {
       const offset = ev.loc?.[0]?.start
       if (typeof offset === 'number' && Number.isFinite(offset)) sourceByLane.set(key, offset)
@@ -181,7 +173,7 @@ export function collectNoteMarks(
   // (NOT trackId equality, which diverges for anon `$:` — PV175). Structure
   // (source/arrange/label offsets, clips) stays IR-owned above.
   const activeMarksByLane = useEval
-    ? collectHapMarks(events as IREvent[], displayCycles, labelOffsetByLane, laneOrder)
+    ? collectHapMarks(events as IREvent[], displayCycles, labelOffsetByLane)
     : marksByLane
   // Bound each lane to `capPerLane` marks by downsampling ACROSS its span (keep
   // every Nth), not by dropping the tail. A dense lane (e.g. a drum stack at
@@ -231,51 +223,66 @@ export function collectNoteMarks(
 }
 
 /**
- * Derive note marks from EVALUATED haps (#861), attributed to the IR lanes by
- * SOURCE CONTAINMENT — the lane whose `$:`/`name:` statement offset (`dollarPos`,
- * carried in `labelOffsetByLane`) is the LARGEST one ≤ the hap's `loc[0].start`.
+ * Lane key for an eval hap that has no IR lane — a signal (`.segment`) or
+ * bare-ref track the static IR never emitted events for (#864 / P1b). Mirrors
+ * `trackIdFromLabel`: an anonymous `$:` producer id (`$N`, source-ordered) → the
+ * positional `d{N+1}`; a named track keeps its name. This aligns eval-only lane
+ * identity with the IR convention (a signal at source position 1 reads `d2`, not
+ * `$1`) and keeps eval lanes disjoint from IR lanes (which exist only for
+ * event-producing tracks). Absent trackId (hand-built haps) → a single `d1`.
+ */
+function evalTrackIdToLaneKey(trackId: string | undefined): string {
+  if (!trackId) return 'd1'
+  const m = /^\$(\d+)$/.exec(trackId)
+  return m ? `d${Number(m[1]) + 1}` : trackId
+}
+
+/**
+ * Derive note marks from EVALUATED haps (#861), attributed to a lane by SOURCE
+ * CONTAINMENT when possible, else to an EVAL-BACKED lane (#864 / P1b).
  *
- * Not `laneKeyOf(hap)` string equality: the IR lane key for an anonymous `$:` is
- * `d{N}` (trackId.ts) while the eval hap's trackId is `$N`, so equality would
- * SPLIT them (PV175). Containment aligns them via the shared source offsets both
- * sides already carry.
+ * Containment: the IR lane whose `$:`/`name:` statement offset (`dollarPos`, in
+ * `labelOffsetByLane`) is the LARGEST one ≤ the hap's `loc[0].start`. NOT
+ * `laneKeyOf(hap)` string equality — the IR lane key for an anon `$:` is `d{N}`
+ * while the eval hap trackId is `$N`, so equality would SPLIT them (PV175).
+ * Containment aligns them via the source offsets both sides already carry.
  *
- * A hap with no `loc` (a continuous/sampled signal) or a `loc` before every
- * lane's statement is attributed to the first-seen IR lane (`laneOrder[0]`) —
- * kept, not dropped (it still plays; it's just not yet lane-attributable; a
- * dedicated eval-backed lane for signal/bare-ref tracks is the P1b follow-on).
- * Returns an empty map when the IR produced no lanes (nothing to attach to).
+ * When a hap has no `loc` (a sampled signal), or its `loc` lands before every IR
+ * lane's statement (a bare-ref whose `loc` points at the `const` definition), it
+ * belongs to a track the static IR produced no lane for. It is routed to an EVAL
+ * lane keyed by its own `trackId` (`evalTrackIdToLaneKey`); `buildTimelineScene`
+ * renders those keys as their own rows (#864). This surfaces signal/bare-ref
+ * tracks AND stops their marks polluting an unrelated IR lane (the prior
+ * default-lane behaviour).
  *
  * Pitch comes from `extractPitch` — the hap's `note` is already the RESOLVED
- * name/number ("C3", or a fractional MIDI for a sampled signal), so no scale/
- * degree logic is needed here.
+ * name/number ("C3", or a fractional MIDI for a sampled signal).
  */
 function collectHapMarks(
   events: readonly IREvent[],
   displayCycles: number,
   labelOffsetByLane: ReadonlyMap<string, number>,
-  laneOrder: readonly string[],
 ): Map<string, SceneNote[]> {
   const out = new Map<string, SceneNote[]>()
-  const defaultLane = laneOrder[0]
   // (laneKey, dollarPos) pairs ascending by dollarPos — the containment index.
   const anchors = [...labelOffsetByLane].sort((a, b) => a[1] - b[1])
-  const laneFor = (start: number | undefined): string | undefined => {
-    if (typeof start === 'number' && Number.isFinite(start)) {
-      let hit: string | undefined
-      for (const [key, pos] of anchors) {
-        if (pos <= start) hit = key
-        else break // ascending → no later anchor can be ≤ start
-      }
-      if (hit !== undefined) return hit
+  // Containment hit (an IR lane), or undefined when the hap's source start lands
+  // before every lane's statement (or it has no `loc`).
+  const irLaneFor = (start: number | undefined): string | undefined => {
+    if (typeof start !== 'number' || !Number.isFinite(start)) return undefined
+    let hit: string | undefined
+    for (const [key, pos] of anchors) {
+      if (pos <= start) hit = key
+      else break // ascending → no later anchor can be ≤ start
     }
-    return defaultLane
+    return hit
   }
   for (const ev of events) {
     const cycle = ev.begin
     if (!Number.isFinite(cycle) || cycle < 0 || cycle >= displayCycles) continue
-    const key = laneFor(ev.loc?.[0]?.start)
-    if (key === undefined) continue // no IR lanes → nothing to attach to
+    // Containment first (keeps a hap on its named/positional IR lane); else an
+    // eval-backed lane keyed by the hap's own producer id (#864 / P1b).
+    const key = irLaneFor(ev.loc?.[0]?.start) ?? evalTrackIdToLaneKey(ev.trackId)
     let arr = out.get(key)
     if (!arr) {
       arr = []

--- a/packages/app/src/components/musicalTimeline/timelineScene.ts
+++ b/packages/app/src/components/musicalTimeline/timelineScene.ts
@@ -242,15 +242,33 @@ export function buildTimelineScene(
         ? Math.max(1, analysis.periodCycles ?? analysis.horizonCycles)
         : 1
   const lanesIn = analysis?.lanes ?? []
+  const analysisKeys = new Set(lanesIn.map((l) => l.laneKey))
+  const nCycles = Math.ceil(displayCycles)
 
-  // Peak onset across all lanes (≥1) so the busiest cell is full-intensity.
+  // Eval-backed lanes (#864 / P1b): marks lanes the static-IR analysis never
+  // produced — a signal (`.segment`) or bare-ref track that emits no static IR
+  // events, so it has no `LaneActivity` here. `collectHapMarks` already keys them
+  // by the positional/named eval identity (`evalTrackIdToLaneKey`), disjoint from
+  // the IR lane keys, so any marks key not in `analysisKeys` is one such track.
+  // Their coarse density is synthesised from their marks (below); they append
+  // AFTER the IR lanes in first-seen (Map) order. Absent → the IR-only behaviour.
+  const evalLaneKeys = [...marks.marksByLane.keys()].filter((k) => !analysisKeys.has(k))
+  const evalDensities = new Map<string, number[]>()
+  for (const key of evalLaneKeys) {
+    evalDensities.set(key, densityFromNotes(marks.marksByLane.get(key) ?? [], nCycles))
+  }
+
+  // Peak onset across ALL lanes (IR + eval, ≥1) so the busiest cell is full-intensity.
   let peakDensity = 1
   for (const lane of lanesIn) {
     for (const c of lane.onsetsByCycle) if (c > peakDensity) peakDensity = c
   }
+  for (const density of evalDensities.values()) {
+    for (const c of density) if (c > peakDensity) peakDensity = c
+  }
 
-  const lanes: SceneLane[] = lanesIn.map((lane) => {
-    const notes = marks.marksByLane.get(lane.laneKey) ?? []
+  const buildLane = (laneKey: string, density: readonly number[]): SceneLane => {
+    const notes = marks.marksByLane.get(laneKey) ?? []
     let pitchMin: number | null = null
     let pitchMax: number | null = null
     for (const n of notes) {
@@ -258,41 +276,44 @@ export function buildTimelineScene(
       if (pitchMin == null || n.pitch < pitchMin) pitchMin = n.pitch
       if (pitchMax == null || n.pitch > pitchMax) pitchMax = n.pitch
     }
-    // Clips: an arrangement track contributes per-arm clips; a bare track (no
-    // combinator → no `armIndex` events) gets ONE implicit clip spanning the
+    // Clips: an arrangement track contributes per-arm clips; a bare/eval track
+    // (no combinator → no `armIndex` events) gets ONE implicit clip spanning the
     // whole song (design §5 option b). The implicit clip is synthesised here
     // (the pure builder owns `displayCycles`) so every lane has ≥1 clip.
-    const clips: SceneClip[] = marks.clipsByLane.get(lane.laneKey) ?? [
+    const clips: SceneClip[] = marks.clipsByLane.get(laneKey) ?? [
       { armIndex: -1, startCycle: 0, endCycle: displayCycles, label: null },
     ]
     // Display name (#579 STEP 2): a NAMED track's source label, else the
     // positional `d{N}`. Both the name AND the colour key on it, so a named
     // lane reads + colours identically to its Mixer strip (one `trackIdentity`).
-    const displayName = resolveLaneName(
-      lane.laneKey,
-      marks.labelOffsetByLane.get(lane.laneKey),
-      code,
-    )
+    // An eval lane has no `labelOffset` → `resolveLaneName` returns the key, which
+    // `evalTrackIdToLaneKey` already made the positional `d{N}` (or the name).
+    const displayName = resolveLaneName(laneKey, marks.labelOffsetByLane.get(laneKey), code)
     // Colour resolves through the SHARED `trackIdentity` (V-track-1/2): the
     // deterministic palette by default, the per-track custom override when set —
     // `customColor ?? colorForTrack(displayName)` — keyed by the display name so
     // the lane matches its Mixer strip. Drives the dot AND the canvas density bars
     // (the renderer reads `lane.color`).
     return {
-      laneKey: lane.laneKey,
+      laneKey,
       displayName,
       color: trackIdentity(displayName, customColorByName?.get(displayName)).color,
-      density: lane.onsetsByCycle,
+      density,
       notes,
       pitchMin,
       pitchMax,
       voices: groupVoices(notes),
       clips,
-      sourceOffset: marks.sourceByLane.get(lane.laneKey) ?? null,
-      arrangeOffset: marks.arrangeByLane.get(lane.laneKey) ?? null,
-      labelOffset: marks.labelOffsetByLane.get(lane.laneKey) ?? null,
+      sourceOffset: marks.sourceByLane.get(laneKey) ?? null,
+      arrangeOffset: marks.arrangeByLane.get(laneKey) ?? null,
+      labelOffset: marks.labelOffsetByLane.get(laneKey) ?? null,
     }
-  })
+  }
+
+  const lanes: SceneLane[] = [
+    ...lanesIn.map((lane) => buildLane(lane.laneKey, lane.onsetsByCycle)),
+    ...evalLaneKeys.map((key) => buildLane(key, evalDensities.get(key)!)),
+  ]
 
   return {
     lanes,
@@ -316,6 +337,23 @@ export function clipAtCycle(lane: SceneLane, cycle: number): SceneClip | null {
     if (cycle >= clip.startCycle && cycle < clip.endCycle) return clip
   }
   return null
+}
+
+/**
+ * Per-integer-cycle onset counts for a lane synthesised from its marks (#864).
+ * Eval-backed lanes have no `analyzeSong` `LaneActivity`, so their coarse density
+ * (the zoomed-out heatmap) is counted here from the note onsets by `floor(cycle)`
+ * — the same bucketing `accumulateLanes` uses for IR lanes. Length is `nCycles`
+ * (the display span); onsets outside `[0, nCycles)` are ignored, mirroring the
+ * IR path. PURE — operates on already-collected marks only.
+ */
+function densityFromNotes(notes: readonly SceneNote[], nCycles: number): number[] {
+  const density = new Array<number>(Math.max(0, nCycles)).fill(0)
+  for (const n of notes) {
+    const c = Math.floor(n.cycle)
+    if (c >= 0 && c < density.length) density[c] += 1
+  }
+  return density
 }
 
 /**

--- a/packages/app/tests/full-song-eval-lanes.spec.ts
+++ b/packages/app/tests/full-song-eval-lanes.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Eval-backed lanes (#864 / P1b) — Playwright observation spec.
+ *
+ * AnviDev observe gate: the unit tests (collectNoteMarks / timelineScene) cover
+ * the lane-synthesis logic against a mocked IR; this drives the REAL app to
+ * confirm the end-to-end path — a track that emits NO static-IR events (a
+ * sampled signal) still gets its own timeline lane from the evaluated haps,
+ * instead of vanishing (or polluting a neighbouring lane).
+ *
+ * `toHaveCount` auto-retries, so this waits for the analysis + marks to settle
+ * rather than racing a one-shot `count()` (the settle-race the older
+ * full-song-timeline spec is prone to on a cold server).
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+async function boot(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('stave:bottomPanel.height', '320')
+      localStorage.setItem('stave:bottomPanel.open', 'true')
+      localStorage.setItem('stave:bottomPanel.activeTabId', 'musical-timeline')
+    } catch {
+      /* ignore */
+    }
+  })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => {
+      const m = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+      return (m?.editor?.getEditors?.()?.length ?? 0) > 0
+    },
+    { timeout: 20_000 },
+  )
+}
+
+async function evalCode(page: Page, code: string): Promise<void> {
+  const ok = await page.evaluate((c) => {
+    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+    const editors = (monaco?.editor?.getEditors?.() ?? []) as Array<{
+      getModel: () => { getLanguageId?: () => string; setValue: (s: string) => void } | null
+      focus: () => void
+    }>
+    const target = editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
+    if (!target) return false
+    target.getModel()?.setValue(c)
+    target.focus()
+    return true
+  }, code)
+  expect(ok).toBe(true)
+  await page.waitForTimeout(150)
+  await page.keyboard.press(`${MOD}+Enter`)
+}
+
+test('a sampled-signal track (no static-IR events) gets its own eval-backed lane', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await boot(page)
+  // Track 1: a normal drum pattern (produces static-IR events → an IR lane).
+  // Track 2: a SAMPLED SIGNAL — `.segment` yields discrete haps but no static-IR
+  // note events, so pre-P1b it had no lane and its haps fell to the drum lane.
+  await evalCode(page, '$: s("bd sd hh")\n$: note(sine.range(48,72).segment(8))')
+
+  await page.locator('[data-full-song="root"]').waitFor({ timeout: 10_000 })
+
+  // Both tracks now render a lane — the drum IR lane AND the signal eval lane.
+  // `toHaveCount` retries until the analysis + marks settle.
+  const lanes = page.locator('[data-full-song-lane]')
+  await expect(lanes).toHaveCount(2, { timeout: 10_000 })
+
+  // The signal track owns the positional `d2` row (source-order after the drums),
+  // i.e. it is NOT folded into the drum lane.
+  await expect(page.locator('[data-full-song-lane="d1"]')).toHaveCount(1)
+  await expect(page.locator('[data-full-song-lane="d2"]')).toHaveCount(1)
+
+  expect(errors).toEqual([])
+})


### PR DESCRIPTION
Follow-on to #862 (eval-backed marks). Closes #864.

## Problem

P1 made the timeline note MARKS eval-backed, but LANES still came only from the static-IR analysis (`analyzeSong` → `collectCycles`). A track that emits no static note events had no lane, so its evaluated haps had nowhere to land:

| Code | Lanes before |
|---|---|
| `note(sine.range(48,72).segment(8))` (sampled signal) | `[]` — has haps, no lane |
| `s("bd sd hh")` + a signal track | `["d1"]` — signal vanishes; its loc-less haps pollute the drum row |
| `const beat = n("0 2 4 5")` / `$: stack(beat)` (bare-ref) | `[]` |

## Fix — additive eval lanes

Keep the IR-driven lane path untouched; ADD eval-only lanes for the tracks the IR missed:

- `collectHapMarks` routes a hap that misses source containment (no `loc`, or a `loc` before every statement) to a lane keyed by its own evaluated producer id — `$N` → the positional `d{N+1}`, a named track verbatim (mirroring the IR's track-id convention) — instead of dropping it on the default lane. Surfaces the track AND kills the pollution.
- `buildTimelineScene` renders a row for any marks lane key not in the analysis, synthesising its coarse density from its marks; eval lanes append after the IR lanes.

## Observed (rendered `data-full-song-lane`)

| Case | After |
|---|---|
| sampled signal | `["d1"]` ✓ |
| drum + signal | `["d1","d2"]` ✓ — signal on its own row, no pollution |
| bare-ref `stack(beat)` | `["d1"]` ✓ — DISPLAY works straight from eval haps |
| continuous signal | `[]` — 0 discrete haps, nothing to draw (residual) |

## Test plan

- **Unit**: eval-lane routing (`collectNoteMarks` — `$1`→`d2`, named verbatim, no default-lane pollution) and eval-only row rendering + synthesised density + peak (`timelineScene`).
- **E2E**: new `full-song-eval-lanes.spec.ts` drives a real drum+signal song and asserts the signal gets its own lane — uses auto-retrying `toHaveCount`, so it waits for analysis to settle rather than racing it.
- **Regression**: app unit suite (707) and timeline suites (328) green.

> Note: `full-song-timeline.spec.ts:93` fails on a fresh clean-P1 server AND this branch (identical) — a pre-existing one-shot-`count()` settle race (the song renders all its lanes given time). Not introduced here; flagged for the stale-spec cleanup.

## Follow-ons (not in scope)

- Binding resolution for bare-ref *editing* (display already works here).
- Source-order interleaving of eval lanes (they append at the end today).