### PR TITLE
🐛 fix(timeline): render eval-backed lanes in source order

### DIFF
--- a/packages/app/src/components/FullSongTimeline.tsx
+++ b/packages/app/src/components/FullSongTimeline.tsx
@@ -41,6 +41,7 @@ import {
   type VoiceOrderByLane,
 } from './musicalTimeline/stableVoiceOrder'
 import { collectNoteMarks } from './musicalTimeline/timelineMarks'
+import { sourceTrackOrder } from './musicalTimeline/trackOrder'
 import { computeLaneLayout, laneAtY, type LaneLayout } from './musicalTimeline/laneLayout'
 import {
   loadTimelineCamera,
@@ -607,6 +608,13 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
     const events = props.getTimelineEvents?.(loopCycles) ?? null
     return collectNoteMarks(events, props.ir ?? null, loopCycles)
   }, [props.ir, loopCycles, props.getTimelineEvents])
+  // #871 — the lane order the user WROTE, read off the IR's track list. Lane
+  // order is structure, and structure is IR-owned: the IR carries a Track node
+  // per statement even when that track emits no static-IR events (a signal, a
+  // bare ref), which is exactly the case the eval-backed lanes cover. Without it
+  // the scene can only append those lanes after the IR ones, so a signal written
+  // first renders last.
+  const trackOrder = useMemo(() => sourceTrackOrder(props.ir ?? null), [props.ir])
   // Per-lane voice sub-row order is pinned first-seen across re-evals (#480) so
   // reordering clips in time doesn't reshuffle the instrument rows — the SAME
   // first-seen stability `stableTrackOrder` gives the top-level lanes, one level
@@ -623,11 +631,18 @@ export function FullSongTimeline(props: FullSongTimelineProps): React.ReactEleme
   // exactly when the user picks, not on every render.
   const { customColorByName } = props
   const scene = useMemo(() => {
-    const raw = buildTimelineScene(analysis, marks, displayCycles, source, customColorByName)
+    const raw = buildTimelineScene(
+      analysis,
+      marks,
+      displayCycles,
+      source,
+      customColorByName,
+      trackOrder,
+    )
     const { scene: ordered, order } = applyStableVoiceOrder(raw, voiceOrderRef.current)
     voiceOrderRef.current = order
     return ordered
-  }, [analysis, marks, displayCycles, source, customColorByName])
+  }, [analysis, marks, displayCycles, source, customColorByName, trackOrder])
 
   // ── Expand + bind (#422) ─────────────────────────────────────────────────
   // Click/expand a lane → accordion it taller (read-only note detail) AND bind

--- a/packages/app/src/components/musicalTimeline/__tests__/timelineScene.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/timelineScene.test.ts
@@ -357,3 +357,47 @@ describe('eval-backed lanes (#864 / P1b)', () => {
     expect(scene.lanes.map((l) => l.laneKey)).toEqual(['bd', 'lead'])
   })
 })
+
+describe('source lane order (#871)', () => {
+  // An eval-only lane (`sig`) written BEFORE the IR-backed lanes. Without a
+  // source order the scene can only append it after them (the default above).
+  const evalFirst = () =>
+    marks({
+      sig: [{ cycle: 0, end: 0.5, pitch: 48, gain: 1 }],
+      bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1 }],
+      lead: [{ cycle: 0, end: 0.5, pitch: 60, gain: 1 }],
+    })
+
+  const keys = (analysis: SongAnalysis, order?: readonly string[]) =>
+    buildTimelineScene(analysis, evalFirst(), undefined, undefined, undefined, order).lanes.map(
+      (l) => l.laneKey,
+    )
+
+  it('ranks an eval lane INTO source order, not after the IR lanes', () => {
+    expect(keys(analysisFixture, ['sig', 'bd', 'lead'])).toEqual(['sig', 'bd', 'lead'])
+  })
+
+  it('places the eval lane between IR lanes when that is where it was written', () => {
+    expect(keys(analysisFixture, ['bd', 'sig', 'lead'])).toEqual(['bd', 'sig', 'lead'])
+  })
+
+  it('leaves an IR-only song untouched (its analysis order already follows the IR)', () => {
+    const irOnly = marks({ bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1 }] })
+    const scene = buildTimelineScene(analysisFixture, irOnly, undefined, undefined, undefined, [
+      'bd',
+      'lead',
+    ])
+    expect(scene.lanes.map((l) => l.laneKey)).toEqual(['bd', 'lead'])
+  })
+
+  it('falls back to the appended order when there is no source order', () => {
+    expect(keys(analysisFixture)).toEqual(['bd', 'lead', 'sig'])
+    expect(keys(analysisFixture, [])).toEqual(['bd', 'lead', 'sig'])
+  })
+
+  it('keeps a lane the order does not mention (no source position) at the end', () => {
+    // `lead` is absent from the track list — it keeps its relative place last
+    // rather than being dropped or guessed at.
+    expect(keys(analysisFixture, ['sig', 'bd'])).toEqual(['sig', 'bd', 'lead'])
+  })
+})

--- a/packages/app/src/components/musicalTimeline/__tests__/trackOrder.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/trackOrder.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Source track order off the IR (#871) — the lane order the user wrote.
+ *
+ * The IR is the structure layer, and it carries a Track node per statement even
+ * for a track that emits NO events (a signal, a bare ref) — which is precisely
+ * the track the eval-backed lanes exist for. These pin that contract on the IR
+ * SHAPES the real parser produces (observed via parseStrudel).
+ */
+import { describe, it, expect } from 'vitest'
+import type { PatternIR } from '@stave/editor'
+import { sourceTrackOrder } from '../trackOrder'
+
+const track = (trackId: string, start?: number): PatternIR =>
+  ({
+    tag: 'Track',
+    trackId,
+    body: { tag: 'Code', code: '', lang: 'strudel' },
+    ...(start != null ? { loc: [{ start, end: start + 1 }] } : {}),
+  }) as unknown as PatternIR
+
+const stack = (...tracks: PatternIR[]): PatternIR => ({ tag: 'Stack', tracks }) as unknown as PatternIR
+
+describe('sourceTrackOrder', () => {
+  it('reads a Stack root in source order (the multi-track shape)', () => {
+    // `$: note(sine…segment(8))` then `$: s("bd sd hh")` — the signal track is
+    // FIRST in the source and emits no events, but the IR still names it d1.
+    expect(sourceTrackOrder(stack(track('d1', 0), track('d2', 38)))).toEqual(['d1', 'd2'])
+  })
+
+  it('reads named tracks verbatim (the lane-key space the eval lanes share)', () => {
+    expect(sourceTrackOrder(stack(track('sig', 0), track('drums', 40)))).toEqual(['sig', 'drums'])
+  })
+
+  it('reads a bare Track root (single track / bare loop)', () => {
+    expect(sourceTrackOrder(track('d1', 0))).toEqual(['d1'])
+    expect(sourceTrackOrder(track('d1'))).toEqual(['d1']) // bare loop: no loc
+  })
+
+  it('returns nothing to order by when the IR is absent or trackless', () => {
+    expect(sourceTrackOrder(null)).toEqual([])
+    expect(sourceTrackOrder(undefined)).toEqual([])
+    expect(sourceTrackOrder({ tag: 'Pure', value: 1 } as unknown as PatternIR)).toEqual([])
+    // A Stack whose children aren't Tracks contributes no order.
+    expect(sourceTrackOrder(stack({ tag: 'Pure', value: 1 } as unknown as PatternIR))).toEqual([])
+  })
+
+  it('skips unidentified tracks and dedupes', () => {
+    const noId = { tag: 'Track', body: { tag: 'Code' } } as unknown as PatternIR
+    expect(sourceTrackOrder(stack(track('d1'), noId, track('d1'), track('d2')))).toEqual(['d1', 'd2'])
+  })
+})

--- a/packages/app/src/components/musicalTimeline/timelineScene.ts
+++ b/packages/app/src/components/musicalTimeline/timelineScene.ts
@@ -211,9 +211,10 @@ export const EMPTY_MARKS: CollectedMarks = {
 
 /**
  * Build the render scene from the analysis (density, sections, span, period)
- * merged with the collected note marks. PURE — no IR walk, no canvas. Lanes
- * keep `analyzeSong`'s first-seen order and key, so the canvas rows line up
- * with the DOM lane labels exactly.
+ * merged with the collected note marks. PURE — no IR walk, no canvas. Lanes keep
+ * `analyzeSong`'s key, so the canvas rows line up with the DOM lane labels
+ * exactly; their ORDER is the caller's `sourceTrackOrder` when given (#871),
+ * else `analyzeSong`'s first-seen order with the eval lanes appended.
  */
 export function buildTimelineScene(
   analysis: SongAnalysis | null,
@@ -229,6 +230,12 @@ export function buildTimelineScene(
    *  → the deterministic palette. Drives the lane dot AND the canvas density bars
    *  (the renderer reads `lane.color`). */
   customColorByName?: ReadonlyMap<string, string>,
+  /** Track ids in SOURCE order (#871), from the IR's track list — the lane order
+   *  the user wrote. Ranks IR-backed and eval-backed lanes together, so a track
+   *  that emits no static-IR events (a signal, a bare ref) sits where it was
+   *  written instead of after every IR lane. Absent/empty → no order information,
+   *  keep `analyzeSong`'s first-seen order with the eval lanes appended. */
+  sourceTrackOrder?: readonly string[],
 ): TimelineScene {
   // The caller (FullSongTimeline) owns the authoritative span — it floors a bare
   // loop to a minimum arrangement length so the single implicit clip has room to
@@ -310,10 +317,30 @@ export function buildTimelineScene(
     }
   }
 
-  const lanes: SceneLane[] = [
+  // IR lanes keep `analyzeSong`'s first-seen order; eval lanes follow in marks
+  // order. That concatenation is only a DEFAULT — it puts every eval lane after
+  // every IR lane, which reverses a signal/bare-ref track written first (#871).
+  const built: SceneLane[] = [
     ...lanesIn.map((lane) => buildLane(lane.laneKey, lane.onsetsByCycle)),
     ...evalLaneKeys.map((key) => buildLane(key, evalDensities.get(key)!)),
   ]
+  // Source order (#871): rank IR-backed and eval-backed lanes TOGETHER by the
+  // IR's track list, so each lane sits where the user wrote it regardless of
+  // which layer produced its marks. A lane whose key isn't a track id (a hand-
+  // built IR, an `s`-keyed fallback lane) has no source position — it keeps its
+  // relative order at the end rather than being dropped or guessed at. The sort
+  // is stable, so an IR-only song (whose analysis order ALREADY follows the IR)
+  // is unchanged.
+  const rank = new Map(sourceTrackOrder?.map((id, i) => [id, i] as const) ?? [])
+  const lanes: SceneLane[] =
+    rank.size === 0
+      ? built
+      : [
+          ...built
+            .filter((l) => rank.has(l.laneKey))
+            .sort((a, b) => rank.get(a.laneKey)! - rank.get(b.laneKey)!),
+          ...built.filter((l) => !rank.has(l.laneKey)),
+        ]
 
   return {
     lanes,

--- a/packages/app/src/components/musicalTimeline/trackOrder.ts
+++ b/packages/app/src/components/musicalTimeline/trackOrder.ts
@@ -1,0 +1,41 @@
+/**
+ * Source order of a song's tracks, read off the static IR (#871).
+ *
+ * The timeline's lane ORDER is structure, and structure is IR-owned — the IR
+ * carries a `Track` node per `$:`/`name:` statement, in source order, keyed by
+ * the SAME `trackId` the lanes key on (`d{N}` for an anonymous track, the label
+ * for a named one). Crucially it carries that node even for a track that emits
+ * NO static-IR events (a sampled signal, a bare-ref `$: beat`) — those tracks
+ * are absent from `analyzeSong`'s lanes (which accumulate over EVENTS) and get
+ * their marks from the evaluated haps instead (#865). Without this order the
+ * scene could only append them after the IR lanes, so a signal written FIRST
+ * rendered below a drum track written second.
+ *
+ * Pure and structural: no eval, no source scanning — the IR already knows.
+ */
+import type { PatternIR } from '@stave/editor'
+
+/**
+ * The `trackId`s of the song's top-level tracks, in source order. `[]` when the
+ * IR is absent or carries no identified track (a hand-built IR in a test, an IR
+ * whose root is neither a `Track` nor a `Stack` of them) — callers treat that as
+ * "no order information" and keep their existing lane order.
+ *
+ * Only the TOP level is walked: a track's inner structure (an `arrange`/`cat`
+ * combinator, a nested stack of voices) lives inside ONE lane, so it has no say
+ * in lane order.
+ */
+export function sourceTrackOrder(ir: PatternIR | null | undefined): readonly string[] {
+  if (!ir) return []
+  const roots: readonly PatternIR[] = ir.tag === 'Stack' ? ir.tracks : [ir]
+  const out: string[] = []
+  const seen = new Set<string>()
+  for (const node of roots) {
+    if (node?.tag !== 'Track') continue
+    const id = node.trackId
+    if (typeof id !== 'string' || id.length === 0 || seen.has(id)) continue
+    seen.add(id)
+    out.push(id)
+  }
+  return out
+}

--- a/packages/app/tests/full-song-eval-lanes.spec.ts
+++ b/packages/app/tests/full-song-eval-lanes.spec.ts
@@ -34,6 +34,18 @@ async function boot(page: Page): Promise<void> {
     },
     { timeout: 20_000 },
   )
+  // #872 — the editor's content is a CONTROLLED value fed by the async project
+  // file load. Seeding before that lands lets it overwrite our code, and the app
+  // evaluates the STARTER example instead (silently: the spec still runs, just
+  // against the wrong song). Wait for the load: the model goes empty → file.
+  await page.waitForFunction(
+    () => {
+      const m = (window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getValue?: () => string } | null }> } } }).monaco
+      const eds = m?.editor?.getEditors?.() ?? []
+      return eds.some((e) => (e.getModel()?.getValue?.()?.length ?? 0) > 0)
+    },
+    { timeout: 20_000 },
+  )
 }
 
 async function evalCode(page: Page, code: string): Promise<void> {

--- a/packages/app/tests/full-song-lane-source-order.spec.ts
+++ b/packages/app/tests/full-song-lane-source-order.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Eval-backed lanes sit in SOURCE order (#871) — Playwright observation spec.
+ *
+ * AnviDev observe gate: the unit tests pin the pure pieces (`sourceTrackOrder`
+ * off the IR, the scene's ranking); this drives the REAL app end-to-end.
+ *
+ * A track that emits no static-IR events — a sampled signal, a bare ref — has no
+ * `analyzeSong` lane, so its marks come from the evaluated haps (#865) and the
+ * scene could only APPEND its lane after the IR lanes. Written first, it then
+ * rendered last: `$: <signal>` + `$: s("bd sd hh")` produced lanes ["d2","d1"] —
+ * a lane labelled d2 above one labelled d1. Lane order is structure, and the IR
+ * knows it (it carries a Track node per statement even with zero events), so the
+ * scene now ranks IR-backed and eval-backed lanes together by the IR track list.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+const SIGNAL = 'note(sine.range(48,72).segment(8))'
+
+async function boot(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('stave:bottomPanel.height', '320')
+      localStorage.setItem('stave:bottomPanel.open', 'true')
+      localStorage.setItem('stave:bottomPanel.activeTabId', 'musical-timeline')
+    } catch {
+      /* ignore */
+    }
+  })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => {
+      const m = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+      return (m?.editor?.getEditors?.()?.length ?? 0) > 0
+    },
+    { timeout: 20_000 },
+  )
+  // #872 — the editor's content is a CONTROLLED value fed by the async project
+  // file load. Seeding before that lands lets it overwrite our code, and the app
+  // evaluates the STARTER example instead (silently: the spec still runs, just
+  // against the wrong song). Wait for the load: the model goes empty → file.
+  await page.waitForFunction(
+    () => {
+      const m = (window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getValue?: () => string } | null }> } } }).monaco
+      const eds = m?.editor?.getEditors?.() ?? []
+      return eds.some((e) => (e.getModel()?.getValue?.()?.length ?? 0) > 0)
+    },
+    { timeout: 20_000 },
+  )
+}
+
+async function evalCode(page: Page, code: string): Promise<void> {
+  const ok = await page.evaluate((c) => {
+    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+    const editors = (monaco?.editor?.getEditors?.() ?? []) as Array<{
+      getModel: () => { getLanguageId?: () => string; setValue: (s: string) => void } | null
+      focus: () => void
+    }>
+    const target = editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
+    if (!target) return false
+    target.getModel()?.setValue(c)
+    target.focus()
+    return true
+  }, code)
+  expect(ok).toBe(true)
+  await page.waitForTimeout(150)
+  await page.keyboard.press(`${MOD}+Enter`)
+}
+
+/** The rendered lane rows, top to bottom. */
+async function laneOrder(page: Page): Promise<Array<string | null>> {
+  const lanes = page.locator('[data-full-song-lane]')
+  const n = await lanes.count()
+  const out: Array<string | null> = []
+  for (let i = 0; i < n; i++) out.push(await lanes.nth(i).getAttribute('data-full-song-lane'))
+  return out
+}
+
+test('an eval-backed lane written FIRST renders first, not after the IR lanes', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  page.on('console', (m) => {
+    if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+  })
+
+  await boot(page)
+  await evalCode(page, `$: ${SIGNAL}\n$: s("bd sd hh")`)
+  await page.locator('[data-full-song="root"]').waitFor({ timeout: 10_000 })
+  await expect(page.locator('[data-full-song-lane]')).toHaveCount(2, { timeout: 10_000 })
+
+  // The signal is track 1 (d1), the drums track 2 (d2) — and that is the order
+  // they render in. Pre-fix this was ["d2","d1"].
+  expect(await laneOrder(page)).toEqual(['d1', 'd2'])
+  expect(errors).toEqual([])
+})
+
+test('the IR-first control is unchanged', async ({ page }) => {
+  await boot(page)
+  await evalCode(page, `$: s("bd sd hh")\n$: ${SIGNAL}`)
+  await page.locator('[data-full-song="root"]').waitFor({ timeout: 10_000 })
+  await expect(page.locator('[data-full-song-lane]')).toHaveCount(2, { timeout: 10_000 })
+
+  expect(await laneOrder(page)).toEqual(['d1', 'd2'])
+})
+
+test('named tracks keep source order too (the lane key is the label)', async ({ page }) => {
+  await boot(page)
+  await evalCode(page, `sig: ${SIGNAL}\ndrums: s("bd sd hh")`)
+  await page.locator('[data-full-song="root"]').waitFor({ timeout: 10_000 })
+  await expect(page.locator('[data-full-song-lane]')).toHaveCount(2, { timeout: 10_000 })
+
+  // Pre-fix: ["drums","sig"].
+  expect(await laneOrder(page)).toEqual(['sig', 'drums'])
+})

--- a/packages/app/tests/full-song-seek-marks.spec.ts
+++ b/packages/app/tests/full-song-seek-marks.spec.ts
@@ -39,6 +39,18 @@ async function boot(page: Page): Promise<void> {
     },
     { timeout: 20_000 },
   )
+  // #872 — the editor's content is a CONTROLLED value fed by the async project
+  // file load. Seeding before that lands lets it overwrite our code, and the app
+  // evaluates the STARTER example instead (silently: the spec still runs, just
+  // against the wrong song). Wait for the load: the model goes empty → file.
+  await page.waitForFunction(
+    () => {
+      const m = (window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getValue?: () => string } | null }> } } }).monaco
+      const eds = m?.editor?.getEditors?.() ?? []
+      return eds.some((e) => (e.getModel()?.getValue?.()?.length ?? 0) > 0)
+    },
+    { timeout: 20_000 },
+  )
 }
 
 async function evalCode(page: Page, code: string): Promise<void> {


### PR DESCRIPTION
Closes #871. Also fixes the spec race in #872 for the three specs touched here.

## Problem

A track that emits no static-IR events — a sampled signal, a bare ref — gets no lane from `analyzeSong` (which accumulates over **events**), so its marks come from the evaluated haps (#865) and the scene could only **append** its lane after every IR lane. Written first, it rendered last:

| source | lanes rendered (before) | after |
|---|---|---|
| `$: note(sine…segment(8))` · `$: s("bd sd hh")` | **`["d2","d1"]`** | `["d1","d2"]` |
| `$: s("bd sd hh")` · `$: note(sine…segment(8))` | `["d1","d2"]` | `["d1","d2"]` (control) |
| `sig: note(sine…segment(8))` · `drums: s("bd sd hh")` | **`["drums","sig"]`** | `["sig","drums"]` |

The anonymous case is self-evidently wrong: a row labelled `d2` sat above a row labelled `d1`.

## Fix

Lane order is **structure**, and structure is IR-owned. The IR already knows the answer — it carries a `Track` node per statement, keyed by the same `trackId` the lanes key on, *even when that track produces zero events*:

```
$: note(sine.range(48,72).segment(8))   → Track { trackId: "d1", loc.start: 0 }
$: s("bd sd hh")                        → Track { trackId: "d2", loc.start: 38 }
```

So `sourceTrackOrder` reads those ids off the IR, and the scene ranks IR-backed and eval-backed lanes **together** by that order rather than concatenating them. Display stays eval-backed; order stays IR-backed.

Degradation is deliberate: a lane whose key isn't a track id (hand-built IR, `s`-keyed fallback) has no source position, so it keeps its relative place at the end rather than being dropped or guessed at; with no order information the old appended behaviour stands. The sort is stable, so an IR-only song — whose analysis order already follows the IR — is untouched.

## A real flake found on the way (#872)

`full-song-eval-lanes` failed twice inside batch runs. It wasn't a settle race: it received **3** lanes, not 2 — the *starter example's* three. The specs seed code with `model.setValue()` right after boot, but the editor content is a controlled value fed by the async project file load; when the load lands after the seed it **overwrites the test's code and the app evaluates the starter**. The spec still runs — just against the wrong song, which is how a green assertion can mean nothing. (It also silently invalidated a manual before/after probe during #863.)

Second commit waits for the file to land before seeding. Batch runs: 1-in-3 failing → 3/3 green. The helper is copy-pasted across ~40 specs; lifting it into one guarded shared module is tracked in #872.

## Test plan

- Unit: `sourceTrackOrder` over the real parser's shapes (Stack root, single `Track` root, bare loop, named, trackless, dupes); scene ranking (eval lane first / between / IR-only unchanged / no-order fallback / unmatched lane last).
- Playwright: new `full-song-lane-source-order.spec.ts` — eval-first, IR-first control, named. **Fails on the pre-fix scene, passes here.**
- App 717 ✓ · 19-spec timeline sweep ✓ (3× clean batches).