### PR TITLE
🧹 chore(tests): re-point the lane specs at how tracks are actually identified (#875)

### DIFF
--- a/packages/app/tests/full-song-track-labels.spec.ts
+++ b/packages/app/tests/full-song-track-labels.spec.ts
@@ -50,8 +50,13 @@ const SONG = [
   '$: s("oh*2")',
 ].join('\n')
 
-// Track order (config excluded): bass(d1) $(d2) d3(d3) $(d4) lead(d5) $(d6).
-// Expected DISPLAY name per lane, in source order — named→label, anon→d{N}.
+// Track order (config excluded), in source order. A track's IDENTITY is its label
+// when it has one and `d{N}` (its position) when it doesn't — the engine emits
+// exactly that as the hap's `trackId` (#138), the Mixer uses it as the strip id,
+// and the Timeline keys the lane by it. So the lane KEY and the DISPLAY name are
+// the same string; there is no separate positional identity behind the label.
+// (This spec used to assert keys of `d1…d6` regardless of label — the model
+// before #138 gave named tracks a positional id too. It hasn't for a long time.)
 const EXPECTED_NAMES = ['bass', 'd2', 'd3', 'd4', 'lead', 'd6']
 
 test('Song Timeline shows track labels and matches the Mixer (named + anon)', async ({ page }) => {
@@ -78,9 +83,10 @@ test('Song Timeline shows track labels and matches the Mixer (named + anon)', as
     })),
   )
 
-  // Identity stays positional (drives the live overlay match) …
-  expect(timeline.map((l) => l.key)).toEqual(['d1', 'd2', 'd3', 'd4', 'd5', 'd6'])
-  // … while the DISPLAY name resolves to the label for named tracks.
+  // The lane KEY is the track's identity — the label for a named track, `d{N}` for
+  // an anonymous one — and it is what the live overlay matches haps on.
+  expect(timeline.map((l) => l.key)).toEqual(EXPECTED_NAMES)
+  // The DISPLAY name resolves to the same identity.
   expect(timeline.map((l) => l.name)).toEqual(EXPECTED_NAMES)
 
   // ── Mixer console: strip names + dot colours, in track order.

--- a/packages/app/tests/timeline-caret-lane-select.spec.ts
+++ b/packages/app/tests/timeline-caret-lane-select.spec.ts
@@ -70,15 +70,18 @@ test('the editor caret selects the matching Song Timeline lane', async ({ page }
   await page.locator('[data-full-song="root"]').waitFor({ timeout: 10_000 })
   await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
 
-  // Caret in each track's line selects exactly that one lane. Named tracks keep
-  // the positional laneKey d{N} (#579 STEP 2): bass=d1, lead=d2, hh=d3.
+  // Caret in each track's line selects exactly that one lane. A track's laneKey is
+  // its IDENTITY — the label when it has one, `d{N}` (its position) when it doesn't
+  // (#138): bass=bass, lead=lead, and the anonymous third track=d3. (This spec used
+  // to expect `d1`/`d2` for the named tracks — the pre-#138 model, where a named
+  // track carried a positional id as well as its label.)
   await caretToLine(page, 1)
   expect(await page.locator('[data-full-song-lane-selected]').count()).toBe(1)
-  expect(await selectedLaneKey(page)).toBe('d1')
+  expect(await selectedLaneKey(page)).toBe('bass')
 
   await caretToLine(page, 2)
   expect(await page.locator('[data-full-song-lane-selected]').count()).toBe(1)
-  expect(await selectedLaneKey(page)).toBe('d2')
+  expect(await selectedLaneKey(page)).toBe('lead')
 
   await caretToLine(page, 3)
   expect(await selectedLaneKey(page)).toBe('d3')
@@ -98,15 +101,15 @@ test('clicking a timeline lane moves the caret, which selects that lane (bidirec
   await typeSongAndEval(page, SONG)
   await page.locator('[data-full-song="root"]').waitFor({ timeout: 10_000 })
 
-  // Start with the caret on line 1 → d1 selected.
+  // Start with the caret on line 1 → the `bass` lane selected.
   await caretToLine(page, 1)
-  expect(await selectedLaneKey(page)).toBe('d1')
+  expect(await selectedLaneKey(page)).toBe('bass')
 
   // Selecting a DIFFERENT track's header must MOVE the selection (not leave the
   // original stuck): each header click reveals its code (moves the caret) and the
   // header click also sets the selection directly. Exactly one lane stays
   // selected, and it's the clicked one.
-  for (const key of ['d2', 'd3', 'd1', 'd2']) {
+  for (const key of ['lead', 'd3', 'bass', 'lead']) {
     await page.locator(`[data-full-song-lane-select="${key}"]`).click()
     await page.waitForTimeout(150)
     expect(await page.locator('[data-full-song-lane-selected]').count()).toBe(1)

--- a/packages/app/tests/track-custom-color.spec.ts
+++ b/packages/app/tests/track-custom-color.spec.ts
@@ -45,7 +45,47 @@ function hexToRgb(hex: string): string {
   return `rgb(${(n >> 16) & 255}, ${(n >> 8) & 255}, ${n & 255})`
 }
 
-/** A mixed doc: `bass:` (named → display `bass`/lane `d1`) + `$:` (anon → `d2`). */
+/**
+ * Reload, then wait until the editor actually HOLDS `expected` before evaluating.
+ *
+ * The editor's content is a controlled value fed by an ASYNC file load, while the
+ * boot only waits for monaco to EXIST — so pressing Cmd+Enter right after boot can
+ * evaluate whatever is in the model at that instant (the starter, or an empty doc)
+ * instead of the document under test (#872). Here that made the prune test flaky:
+ * the per-eval override prune (#583) only drops the orphaned `bass` colour if the
+ * eval it fires on is the DELETED program. Miss that, and the override survives and
+ * "resurrects" on the re-add — a false red, 1 run in 3.
+ */
+async function reloadAndEval(page: Page, expected: string): Promise<void> {
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => ((window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco?.editor?.getEditors?.()?.length ?? 0) > 0,
+    { timeout: 20_000 },
+  )
+  await page.waitForFunction(
+    (want) => {
+      const eds = ((window as unknown as {
+        monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string; getValue: () => string } | null }> } }
+      }).monaco?.editor?.getEditors?.()) ?? []
+      const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+      return t?.getModel()?.getValue() === want
+    },
+    expected,
+    { timeout: 20_000 },
+  )
+  await page.locator('.monaco-editor').first().click()
+  await page.keyboard.press(`${MOD}+Enter`)
+  await page.waitForTimeout(2200)
+}
+
+/**
+ * A mixed doc: `bass:` (named → lane keyed by its LABEL, `bass`) + `$:` (anonymous
+ * → keyed by position, `d2`). A track's identity IS its label when it has one
+ * (#138); only unnamed tracks are positional. This spec used to address the named
+ * track's lane as `d1` — the pre-#138 model — so its locators never matched and it
+ * timed out at boot, before exercising a single colour.
+ */
 const SONG = 'bass: s("bd*4")\n$: s("hh*8")'
 
 async function openMixerTab(page: Page): Promise<void> {
@@ -67,8 +107,8 @@ test('a custom colour overrides the palette in BOTH the Timeline and the Mixer (
   await bootShell(page, 'musical-timeline')
   await typeSongAndEval(page, SONG)
 
-  // The named track's lane (identity stays d1; display name = `bass`).
-  const laneDot = page.locator('[data-full-song-lane-dot="d1"]')
+  // The named track's lane — keyed by its label.
+  const laneDot = page.locator('[data-full-song-lane-dot="bass"]')
   await laneDot.waitFor({ timeout: 10_000 })
   const defaultRgb = await laneDot.evaluate((el) => getComputedStyle(el).backgroundColor)
   expect(defaultRgb).toMatch(/^rgb/)
@@ -125,7 +165,7 @@ test('the custom colour persists across a reload (per-file Yjs)', async ({ page 
   await bootShell(page, 'musical-timeline')
   await typeSongAndEval(page, SONG)
 
-  const laneDot = page.locator('[data-full-song-lane-dot="d1"]')
+  const laneDot = page.locator('[data-full-song-lane-dot="bass"]')
   await laneDot.waitFor({ timeout: 10_000 })
   const defaultRgb = await laneDot.evaluate((el) => getComputedStyle(el).backgroundColor)
 
@@ -144,17 +184,9 @@ test('the custom colour persists across a reload (per-file Yjs)', async ({ page 
 
   // Reload — the doc + the override both live in the per-file Yjs doc (persisted
   // to IndexedDB). Re-eval so the timeline re-analyses, then the colour is back.
-  await page.reload({ waitUntil: 'domcontentloaded' })
-  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
-  await page.waitForFunction(
-    () => ((window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco?.editor?.getEditors?.()?.length ?? 0) > 0,
-    { timeout: 20_000 },
-  )
-  await page.locator('.monaco-editor').first().click()
-  await page.keyboard.press(`${MOD}+Enter`)
-  await page.waitForTimeout(2200)
+  await reloadAndEval(page, SONG)
 
-  const laneDotAfter = page.locator('[data-full-song-lane-dot="d1"]')
+  const laneDotAfter = page.locator('[data-full-song-lane-dot="bass"]')
   await laneDotAfter.waitFor({ timeout: 10_000 })
   await expect
     .poll(() => laneDotAfter.evaluate((el) => getComputedStyle(el).backgroundColor))
@@ -165,7 +197,7 @@ test('renaming a coloured track carries the colour forward (override migrates)',
   await bootShell(page, 'musical-timeline')
   await typeSongAndEval(page, SONG)
 
-  const laneDot = page.locator('[data-full-song-lane-dot="d1"]')
+  const laneDot = page.locator('[data-full-song-lane-dot="bass"]')
   await laneDot.waitFor({ timeout: 10_000 })
   const defaultRgb = await laneDot.evaluate((el) => getComputedStyle(el).backgroundColor)
 
@@ -184,25 +216,33 @@ test('renaming a coloured track carries the colour forward (override migrates)',
     .toBe(chosenRgb)
 
   // Rename `bass` → `kick` from the Timeline lane.
-  await page.locator('[data-full-song-lane="d1"] span').last().dblclick()
-  const input = page.locator('[data-full-song-lane-rename="d1"]')
+  await page.locator('[data-full-song-lane="bass"] span').last().dblclick()
+  const input = page.locator('[data-full-song-lane-rename="bass"]')
   await input.waitFor({ timeout: 5000 })
   await input.fill('kick')
   await input.press('Enter')
   await page.waitForTimeout(2000)
 
   // The lane is now `kick` AND keeps the chosen colour (migrated old→new key).
-  await expect(page.locator('[data-full-song-lane="d1"] span').last()).toHaveText('kick')
+  // The rename RE-KEYS the lane — a track's identity IS its label — so the colour
+  // must be read from the NEW key. That is precisely what "the override migrates"
+  // means: the override is keyed by display name, and the rename changes it, so an
+  // un-migrated override would leave `kick` on the palette default instead.
+  await expect(page.locator('[data-full-song-lane="kick"] span').last()).toHaveText('kick')
+  const renamedDot = page.locator('[data-full-song-lane-dot="kick"]')
+  await renamedDot.waitFor({ timeout: 10_000 })
   await expect
-    .poll(() => laneDot.evaluate((el) => getComputedStyle(el).backgroundColor))
+    .poll(() => renamedDot.evaluate((el) => getComputedStyle(el).backgroundColor))
     .toBe(chosenRgb)
+  // …and the old key is gone entirely (no orphan lane left behind).
+  await expect(page.locator('[data-full-song-lane-dot="bass"]')).toHaveCount(0)
 })
 
 test('deleting a coloured track prunes its override — re-adding it does NOT resurrect the colour (#583)', async ({ page }) => {
   await bootShell(page, 'musical-timeline')
   await typeSongAndEval(page, SONG)
 
-  const laneDot = page.locator('[data-full-song-lane-dot="d1"]')
+  const laneDot = page.locator('[data-full-song-lane-dot="bass"]')
   await laneDot.waitFor({ timeout: 10_000 })
   const defaultRgb = await laneDot.evaluate((el) => getComputedStyle(el).backgroundColor)
 
@@ -215,7 +255,7 @@ test('deleting a coloured track prunes its override — re-adding it does NOT re
   const colors = await popover
     .locator('[data-musical-timeline="swatch-cell"]')
     .evaluateAll((els) => els.map((e) => (e as HTMLElement).getAttribute('data-color') ?? ''))
-  const positionalRgb = hexToRgb(colors[0]) // colorForTrack('d1') fallback
+  const positionalRgb = hexToRgb(colors[0]) // the positional `d{N}` palette fallback
   const chosenHex = colors.find(
     (c) => hexToRgb(c) !== defaultRgb && hexToRgb(c) !== positionalRgb,
   )!
@@ -233,15 +273,10 @@ test('deleting a coloured track prunes its override — re-adding it does NOT re
 
   // Reload → cold-load `$: s("hh*8")` from IndexedDB → eval it. That clean eval
   // fires onEvaluateSuccess with the deleted program, so the per-eval prune
-  // (#583) drops the now-orphaned `bass` override.
-  await page.reload({ waitUntil: 'domcontentloaded' })
-  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
-  await page.waitForFunction(
-    () => ((window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco?.editor?.getEditors?.()?.length ?? 0) > 0,
-    { timeout: 20_000 },
-  )
-  await page.locator('.monaco-editor').first().click()
-  await page.keyboard.press(`${MOD}+Enter`)
+  // (#583) drops the now-orphaned `bass` override. The eval MUST see the deleted
+  // program — evaluating anything else (a not-yet-loaded model, the starter) skips
+  // the prune and the override survives to "resurrect" on the re-add (#872).
+  await reloadAndEval(page, '$: s("hh*8")')
   await expect(page.locator('[data-full-song-lane-dot="d1"]')).toHaveCount(1, { timeout: 10_000 })
   // Only one lane now (the `$` track) — the deleted program is live.
   await expect(page.locator('[data-full-song-lane-dot="d2"]')).toHaveCount(0, { timeout: 10_000 })
@@ -252,7 +287,7 @@ test('deleting a coloured track prunes its override — re-adding it does NOT re
   // default — label resolution on a re-add can briefly show the positional
   // `d{N}` colour, which is orthogonal to the prune this test proves).
   await typeSongAndEval(page, SONG)
-  const laneDotAgain = page.locator('[data-full-song-lane-dot="d1"]')
+  const laneDotAgain = page.locator('[data-full-song-lane-dot="bass"]')
   await laneDotAgain.waitFor({ timeout: 10_000 })
   await page.waitForTimeout(800) // settle the re-eval
   const afterRgb = await laneDotAgain.evaluate((el) => getComputedStyle(el).backgroundColor)

--- a/packages/app/tests/wave-delta-gate.spec.ts
+++ b/packages/app/tests/wave-delta-gate.spec.ts
@@ -83,47 +83,41 @@ interface PageState {
   rowCount: number
   labels: string[]
   dotColors: string[]
-  noteColorsByRow: Record<string, string[]>
   consoleErrors: string[]
 }
 
+/**
+ * Read the Song Timeline's LANES.
+ *
+ * This used to read `[data-musical-timeline-track-row]` / `-track-label` / `-note` —
+ * the DOM live-view that was RETIRED when the timeline became a canvas. Every one of
+ * those selectors matched nothing, which is why the file had rotted into a gate that
+ * guards nothing: two fixtures failed on the dead selectors, and three could not fail
+ * at ALL (two had no `expect` — they `console.error`/`console.log`ed a mismatch and
+ * passed anyway; the third asserted `rowCount <= 1`, which `0` satisfies).
+ *
+ * A lane's KEY is the track's identity — its label when it has one, `d{N}` when it
+ * doesn't — which is exactly what the old `track-label` carried, so the fixtures'
+ * claims survive the move. What does NOT survive is per-NOTE colour: notes are canvas
+ * pixels now, with no DOM to read (see FIXTURE D).
+ */
 async function snapshotState(
   page: Page,
   consoleErrors: string[],
 ): Promise<PageState> {
   return await page.evaluate(
     (errors) => {
-      const labels = Array.from(
-        document.querySelectorAll('[data-musical-timeline-track-label]'),
-      ).map((el) => el.getAttribute('data-musical-timeline-track-label') ?? '')
-
-      // 20-11 DOM used `track-dot`; 20-12 chrome refactor (header rail +
-      // swatch popover) renamed it to `track-swatch`. Probe both so the
-      // spec runs against either branch state.
-      const dotEls = document.querySelectorAll(
-        '[data-musical-timeline="track-dot"], [data-musical-timeline="track-swatch"]',
-      )
-      const dotColors = Array.from(dotEls).map((el) => {
-        const inline = (el as HTMLElement).style.background
-        if (inline) return inline
-        const computed = window.getComputedStyle(el as HTMLElement)
-        return computed.background || computed.backgroundColor || ''
-      })
-
-      const rows = document.querySelectorAll('[data-musical-timeline-track-row]')
-      const noteColorsByRow: Record<string, string[]> = {}
-      rows.forEach((row) => {
-        const id = row.getAttribute('data-musical-timeline-track-row') ?? '?'
-        noteColorsByRow[id] = Array.from(
-          row.querySelectorAll('[data-musical-timeline-note]'),
-        ).map((n) => (n as HTMLElement).style.background)
+      const lanes = Array.from(document.querySelectorAll('[data-full-song-lane]'))
+      const labels = lanes.map((el) => el.getAttribute('data-full-song-lane') ?? '')
+      const dotColors = lanes.map((el) => {
+        const d = el.querySelector('[data-full-song-lane-dot]') as HTMLElement | null
+        return d ? window.getComputedStyle(d).backgroundColor : ''
       })
 
       return {
-        rowCount: rows.length,
+        rowCount: lanes.length,
         labels,
         dotColors,
-        noteColorsByRow,
         consoleErrors: errors.slice(),
       }
     },
@@ -214,11 +208,9 @@ test.describe('Phase 20-11 wave-δ — γ-7 gate', () => {
       consoleMessages.filter((m) => m.type === 'warning' || m.type === 'error' || m.type === 'pageerror'),
     )
 
-    if (state.labels.length !== 1 || state.labels[0] !== 'kick') {
-      console.error(
-        `WAVE-δ FIXTURE B FAILED: expected ['kick'], got ${JSON.stringify(state.labels)}`,
-      )
-    }
+    // This used to `console.error` a mismatch and PASS regardless — there was no
+    // assertion here at all, so the fixture could not fail.
+    expect(state.labels).toEqual(['kick'])
 
     await stopStrudel(page)
   })
@@ -244,11 +236,12 @@ test.describe('Phase 20-11 wave-δ — γ-7 gate', () => {
     const state = await snapshotState(page, consoleErrors)
     console.log('FIXTURE C state (Trap G probe):', JSON.stringify(state, null, 2))
 
-    // Trap G blocking condition: rows > 1 for single-expression input.
-    expect(state.rowCount).toBeLessThanOrEqual(1)
-    if (state.rowCount === 1) {
-      expect(state.labels).toEqual(['d1'])
-    }
+    // Trap G blocking condition: a single bare expression must produce exactly ONE
+    // lane, never more. (This asserted `rowCount <= 1` — which the dead selector
+    // satisfied with 0, so it passed while measuring nothing. A bare expression is
+    // wrapped as a track, so the honest expectation is exactly one lane, named `d1`.)
+    expect(state.rowCount).toBe(1)
+    expect(state.labels).toEqual(['d1'])
 
     await stopStrudel(page)
   })
@@ -291,36 +284,16 @@ test.describe('Phase 20-11 wave-δ — γ-7 gate', () => {
     await stopStrudel(page)
   })
 
-  test('FIXTURE D — .color("red") preserved over palette', async ({
-    page,
-  }) => {
-    const consoleErrors: string[] = []
-    page.on('console', (msg) => {
-      if (msg.type() === 'error') consoleErrors.push(msg.text())
-    })
-    page.on('pageerror', (err) => {
-      consoleErrors.push(`pageerror: ${err.message}`)
-    })
-
+  // FIXTURE D asserted that `.color("red")` beats the palette by reading each NOTE's
+  // background off the DOM. Notes are canvas pixels now — there is no per-note DOM to
+  // read, and no equivalent oracle short of pixel-sampling the canvas. Rather than
+  // leave it "passing" (it computed `hasRed` and only console.logged it — it had no
+  // assertion and could never fail), it is SKIPPED with its reason recorded: the
+  // capability it guards is unverified, not proven. Same class as the note-level
+  // click-to-source gap (#874) — a canvas view that lost its DOM oracle.
+  test.skip('FIXTURE D — .color("red") preserved over palette', async ({ page }) => {
     await setStrudelCode(page, 's("c d e g").note().color("red")')
     await evalStrudel(page)
-    await page.waitForTimeout(1500)
-
-    await page.screenshot({
-      path: path.join(SCREENSHOT_DIR, 'fixtureD.png'),
-      fullPage: true,
-    })
-
-    const state = await snapshotState(page, consoleErrors)
-    console.log('FIXTURE D state:', JSON.stringify(state, null, 2))
-
-    // Look for red color in note backgrounds.
-    const allNoteColors = Object.values(state.noteColorsByRow).flat()
-    const hasRed = allNoteColors.some(
-      (c) => /red|#ff0000|rgb\(255, ?0, ?0\)/i.test(c),
-    )
-    console.log(`FIXTURE D — note colors: ${JSON.stringify(allNoteColors)}; hasRed: ${hasRed}`)
-
     await stopStrudel(page)
   })
 })


### PR DESCRIPTION
Clears the **lane key/label cluster** of #875 — nine failures. None were product bugs, but the rot was hiding real questions, and three "passing" tests turned out to guard nothing.

## Two roots

**1. A superseded identity model (7 failures).** Several specs address a *named* track's timeline lane as `d1`. A track's identity is its **label** when it has one, and `d{N}` only when it doesn't — the engine emits exactly that as the hap's `trackId`, the Mixer uses it as the strip id, and the Timeline keys the lane by it. That's been true since #138 (phase 20-15); these specs encode the model from *before* it. Observed directly:

```
bass: s("bd*4")
$: s("hh*8")
→ lanes: [{key: "bass"}, {key: "d2"}]
```

So the locators matched nothing and the specs timed out at boot, before exercising a single colour, caret or label. Re-pointed at the identity the app actually uses.

Care was needed where `d1` *legitimately* still means an anonymous track: in the prune test, after `bass` is deleted the remaining `$:` track really **is** `d1`. Not a find-and-replace.

**2. A retired DOM view (2 failures).** `wave-delta-gate` reads `data-musical-timeline-track-row|-label|-note` — the DOM live-view retired when the timeline became a canvas. Re-pointed at the lane DOM, where its claims all still hold: duplicate `$:` → 2 lanes, `.p("kick")` labels the track and doesn't crash on either quote style, a bare expression yields exactly one lane.

## Three fixtures could not fail

While re-pointing that file:

- **FIXTURE B** — `console.error`s a mismatch and passes anyway. No assertion.
- **FIXTURE D** — computes `hasRed`, `console.log`s it. No assertion.
- **FIXTURE C** — asserts `rowCount <= 1`, which the dead selector satisfies with `0`.

B and C now assert. **D is skipped, not fixed**: it read per-*note* colour off the DOM, and notes are canvas pixels now — there's no oracle short of pixel-sampling. Skipped with its reason recorded rather than left falsely green (the #874 class: a canvas view that lost its DOM oracle).

## A flake that was really the #872 race

Once its locators were fixed, the #583 prune test started *actually running* — and failed 1 run in 3. It reloads and evaluates as soon as monaco **exists**, but the editor's content is a controlled value fed by an **async file load**. So the eval could fire on a not-yet-loaded document, skip the per-eval override prune, and let the deleted colour "resurrect" on the re-add. That's #872 producing a false **red** (it usually produces false greens).

Guarded: wait for the editor to actually hold the document under test before evaluating. **5/5 green**, and the prune behaviour itself is confirmed correct — no product bug.

## Test plan

Cluster + neighbours: **22 passed / 1 skipped / 0 failed** — `track-custom-color`, `timeline-caret-lane-select`, `full-song-track-labels`, `wave-delta-gate`, `full-song-live-overlay`, `track-rename`, `full-song-lane-source-order`.

Tests only — no product code changes. Part of #875; the remaining clusters are the 15 canvas `getContext` InvalidStateError failures and the 12 singles.