### PR TITLE
🧹 chore(tests): clear the last 14 reds — the Playwright gate goes green (#875)

### DIFF
--- a/packages/app/tests/backdrop-viz-chrome.spec.ts
+++ b/packages/app/tests/backdrop-viz-chrome.spec.ts
@@ -322,14 +322,42 @@ test.describe('Backdrop via viz-settings popover (#773)', () => {
     const originalGroupId = await backdrop
       .first()
       .getAttribute('data-workspace-background')
-    const runningCtxs = () =>
-      page.evaluate(
-        () =>
-          (window as unknown as { __ctxs: AudioContext[] }).__ctxs.filter(
-            (c) => c.state === 'running',
-          ).length,
-      )
-    expect(await runningCtxs()).toBeGreaterThan(0)
+    // Count the running contexts the VIZ owns — i.e. every context EXCEPT the
+    // app's shared one (`getAudioContext()`, superdough's).
+    //
+    // This used to count every running AudioContext and require ZERO after the
+    // close. That is the wrong requirement: sample audition now runs through the
+    // SHARED context, so opening the preview lazily creates it, and an
+    // AudioContext can never be reopened once closed — tearing it down on a tab
+    // close would permanently kill all app audio. Observed: the viz's own context
+    // IS closed on close (state "closed"); the survivor is `getAudioContext()`
+    // itself, still ticking, exactly as it should. The old assertion turned that
+    // correct behaviour into a red (#875).
+    const runningVizCtxs = () =>
+      page.evaluate(() => {
+        const w = window as unknown as {
+          __ctxs: AudioContext[]
+          getAudioContext?: () => AudioContext
+        }
+        let shared: AudioContext | null = null
+        try {
+          shared = w.getAudioContext?.() ?? null
+        } catch {
+          shared = null
+        }
+        return w.__ctxs.filter((c) => c !== shared && c.state === 'running').length
+      })
+    /** The shared context must SURVIVE the close — the opposite regression. */
+    const sharedAlive = () =>
+      page.evaluate(() => {
+        const w = window as unknown as { getAudioContext?: () => AudioContext }
+        try {
+          return w.getAudioContext?.()?.state !== 'closed'
+        } catch {
+          return false
+        }
+      })
+    expect(await runningVizCtxs()).toBeGreaterThan(0)
 
     // Drag the hydra EDITOR tab to the east quadrant of its group → new pane.
     const editorTab = page
@@ -363,14 +391,19 @@ test.describe('Backdrop via viz-settings popover (#773)', () => {
       page.locator('[data-testid="viz-chrome-open-preview"]').first(),
     ).toHaveAttribute('data-button-state', 'running')
     // The move itself never interrupted the audio.
-    expect(await runningCtxs()).toBeGreaterThan(0)
+    expect(await runningVizCtxs()).toBeGreaterThan(0)
 
-    // Bug2: closing the moved tab clears the backdrop AND stops the audio.
+    // Bug2: closing the moved tab clears the backdrop AND stops the VIZ's audio.
     const tabId = await editorTab.getAttribute('data-workspace-tab')
     await page.locator(`[data-testid="tab-close-${tabId}"]`).click()
     await expect(backdrop).toHaveCount(0)
     await expect
-      .poll(runningCtxs, { timeout: 3000 })
+      .poll(runningVizCtxs, { timeout: 3000 })
       .toBe(0)
+    // ...and it did NOT take the app's shared audio context down with it. That
+    // context can never be reopened, so tearing it down on a tab close would kill
+    // all audio for the rest of the session — the regression in the other
+    // direction, which the previous assertion would have DEMANDED.
+    expect(await sharedAlive()).toBe(true)
   })
 })

--- a/packages/app/tests/editor-track-colour-bar.spec.ts
+++ b/packages/app/tests/editor-track-colour-bar.spec.ts
@@ -117,15 +117,22 @@ test('the colour bar stays continuous across a word-wrapped track', async ({ pag
     const monaco = (window as any).monaco
     const ed = monaco.editor.getEditors().find((e: any) => e.getModel()?.getLanguageId?.() === 'strudel')
     const lineHeight = ed.getOption(monaco.editor.EditorOption.lineHeight)
-    // visual rows = sum of wrap counts across the 3 model lines
-    let visualRows = 0
-    for (let l = 1; l <= ed.getModel().getLineCount(); l++) {
-      visualRows += ed.getBottomForLineNumber(l) - ed.getTopForLineNumber(l)
-    }
+    // The block's true visual height, wrap included: the bottom of the LAST model
+    // line minus the top of the first.
+    //
+    // This used to sum `getBottomForLineNumber(l) - getTopForLineNumber(l)` over
+    // the model lines, which is NOT wrap-aware PER LINE: for the long wrapped
+    // line it returns a single line-height. Observed here — tops/bottoms come back
+    // [8,30] [74,96] [96,118], so line 1 reports 22px while actually running 8→74
+    // (three wrapped rows). The sum was 66px (3 unwrapped lines) against a 110px
+    // bar, and the spec blamed the BAR for the 44px it had failed to measure. The
+    // bar is right: 110px is exactly the wrapped block (#875).
+    const lastLine = ed.getModel().getLineCount()
+    const blockSpan = ed.getBottomForLineNumber(lastLine) - ed.getTopForLineNumber(1)
     const segs = Array.from(document.querySelectorAll('[data-track-colour-bar]')) as HTMLElement[]
     return {
       lineHeight,
-      contentSpanPx: Math.round(visualRows),
+      contentSpanPx: Math.round(blockSpan),
       segCount: segs.length,
       segHeight: segs.length ? Math.round(segs[0].getBoundingClientRect().height) : 0,
     }

--- a/packages/app/tests/full-song-timeline.spec.ts
+++ b/packages/app/tests/full-song-timeline.spec.ts
@@ -10,13 +10,21 @@
  *   4. Clicking the song ruler fires a seek (runtime.seekTo) with NO console
  *      error and the view stays coherent (the DV-10 relaxation).
  *
- * INPUT NOTE: this harness evaluates the starter file's content — programmatic
- * Monaco `setValue` updates the model but does NOT drive the eval pipeline
- * (the eval reads the file store), so the analyzed song is the starter example,
- * not an injected pattern. Period CORRECTNESS for specific patterns is covered
- * by songAnalysis.test.ts (isolated); this spec verifies the integration wiring
- * on whatever real multi-track song is playing. Assertions are deliberately
- * generic (lane count, a detected period) rather than a fixed period value.
+ * INPUT NOTE: the seeded code IS what gets analyzed. The old note here claimed the
+ * opposite — that `setValue` never reaches the eval pipeline, so the starter file
+ * was always the analyzed song — and the spec leaned on that: its fixture was a
+ * bare `stack(s("bd hh bd hh"), s("~ cp"))`, which is ONE track (a single
+ * anonymous statement whose voices become sub-rows), yet it asserted 2+ LANES.
+ * It only ever passed because the async file load raced ahead of the seed and the
+ * app evaluated the 3-track STARTER instead (#872). It was green for a song it
+ * never chose. Observed: seeded bare stack → 1 lane (`d1`), stable; the same music
+ * as two `$:` statements → 2 lanes.
+ *
+ * So the fixture is now two explicit `$:` TRACKS — lanes are per-track, and that
+ * is the thing under test. Period CORRECTNESS for specific patterns is covered by
+ * songAnalysis.test.ts (isolated); this spec verifies the integration wiring on a
+ * real multi-track song. Assertions stay generic (lane count, a detected period)
+ * rather than a fixed period value.
  *
  * AUDIO NOTE: the audible jump is NOT observable in this harness (no audio
  * capture). This spec observes structure + no-error; the audio half is a
@@ -102,11 +110,10 @@ test('full-song view: analysis renders, loop detected, ruler seek fires without 
   await preOpenDrawer(page)
   await bootShell(page)
 
-  // Evaluate the starter file (a multi-track example). We also push a pattern
-  // into the model for good measure, but the eval pipeline reads the file
-  // store, so the analyzed song is the starter content regardless (see INPUT
-  // NOTE). Either way a real multi-track song is what the song view analyzes.
-  await setStrudelCode(page, 'stack(s("bd hh bd hh"), s("~ cp"))')
+  // Two explicit `$:` TRACKS — lanes are per-track, so this is a genuinely
+  // multi-track song. (A bare `stack(a, b)` is a single anonymous track whose
+  // voices render as sub-rows, not as lanes — see INPUT NOTE.)
+  await setStrudelCode(page, '$: s("bd hh bd hh")\n$: s("~ cp")')
   await evalStrudel(page)
 
   // The full-song canvas is the only timeline view now (#497/U5).

--- a/packages/app/tests/grid-visual-identity.spec.ts
+++ b/packages/app/tests/grid-visual-identity.spec.ts
@@ -70,7 +70,12 @@ async function setNoteColor(page: Page, mode: 'off' | 'velocity'): Promise<void>
   const select = page.getByTestId('setting-noteColor')
   await select.waitFor({ timeout: 5000 })
   await select.selectOption(mode)
-  await page.getByRole('button', { name: 'Close' }).click() // don't cover the grid
+  // scoped + exact for the same reason as the File button: an accessible name is
+  // a substring match, and other surfaces carry a "Close …" label.
+  await page
+    .getByTestId('settings-shell')
+    .getByRole('button', { name: 'Close', exact: true })
+    .click() // don't cover the grid
   await page.waitForTimeout(150)
 }
 

--- a/packages/app/tests/grid-visual-identity.spec.ts
+++ b/packages/app/tests/grid-visual-identity.spec.ts
@@ -52,15 +52,25 @@ async function openPattern(page: Page) {
   return drawer
 }
 
-/** Set Note Color via the editor Settings modal (#602 — moved off the grid
- *  header). Opens File ▸ Editor Settings…, picks the mode, closes the modal. */
+/** Set Note Colour through the real Settings gesture (#602 moved it off the grid
+ *  header; #739 then moved Settings itself into the unified shell).
+ *
+ *  Two premises here are load-bearing and both used to be wrong:
+ *   - `exact` on the File button — getByRole's name match is a case-insensitive
+ *     SUBSTRING, so a bare 'File' ALSO matches the "New file" (+) button in the
+ *     file-tree header, and the click dies on a strict-mode violation.
+ *   - the shell renders ONE section at a time behind a nav, and closes with a
+ *     Close button (not Escape). Note colour lives under "Pattern & Timeline",
+ *     so the field simply is not in the DOM until that nav item is clicked. */
 async function setNoteColor(page: Page, mode: 'off' | 'velocity'): Promise<void> {
-  await page.getByRole('button', { name: 'File' }).click()
+  await page.getByRole('button', { name: 'File', exact: true }).click()
   await page.getByText('Editor Settings...').click()
-  const select = page.locator('[data-setting-note-color]')
+  await page.getByTestId('settings-shell').waitFor({ timeout: 5000 })
+  await page.getByTestId('settings-nav-pattern').click()
+  const select = page.getByTestId('setting-noteColor')
   await select.waitFor({ timeout: 5000 })
   await select.selectOption(mode)
-  await page.keyboard.press('Escape') // close the modal so it doesn't cover the grid
+  await page.getByRole('button', { name: 'Close' }).click() // don't cover the grid
   await page.waitForTimeout(150)
 }
 

--- a/packages/app/tests/hydra-stave-bag.spec.ts
+++ b/packages/app/tests/hydra-stave-bag.spec.ts
@@ -9,15 +9,28 @@
  */
 
 import { test, expect } from '@playwright/test'
+import { vizPixelStats } from './_vizFrames'
 
-const HYDRA_STAVE_CODE = `// E2E probe — reach both stave.scheduler and stave.H.
-globalThis.__stave_probe = {
-  hasStave: typeof stave !== 'undefined',
-  hasScheduler: stave && 'scheduler' in stave,
-  hasH: stave && typeof stave.H === 'function',
-  hSampleZero: stave && stave.H('nonexistent')(),
-}
-s.osc(30, 0.1, 0.5).out()`
+// The probe PAINTS its answer instead of handing it back on a global.
+//
+// It used to set `globalThis.__stave_probe` for the spec to read off `window`.
+// That channel does not exist: hydra renders in the viz WORKER (the default since
+// #245), where `globalThis` is the worker scope — so the page waited on a global
+// that could never appear, and timed out having proven nothing (#875). Same dead
+// channel as the backdrop `sig.tracks` probe.
+//
+// So encode each check in a colour channel and read the pixels the only way a
+// transferred canvas can be read — the compositor. All four checks holding paints
+// WHITE; any failure drops a channel, which is directly falsifiable.
+//   R = stave present AND stave.scheduler reachable
+//   G = stave.H is callable
+//   B = stave.H('nonexistent')() === 0  (no throw, no NaN — demo-mode default)
+const HYDRA_STAVE_CODE = `// E2E probe — reach both stave.scheduler and stave.H, and PAINT the result.
+const hasStave = typeof stave !== 'undefined'
+const hasScheduler = hasStave && 'scheduler' in stave
+const hasH = hasStave && typeof stave.H === 'function'
+const hZero = hasH && stave.H('nonexistent')() === 0
+s.solid(hasStave && hasScheduler ? 1 : 0, hasH ? 1 : 0, hZero ? 1 : 0).out()`
 
 async function openHydraTab(page: import('@playwright/test').Page) {
   await page.goto('/')
@@ -32,7 +45,19 @@ async function openHydraTab(page: import('@playwright/test').Page) {
       return
     }
   }
-  throw new Error('no hydra tab found in default project')
+  // Issue #175 — the default workspace opens a SINGLE Strudel tab, not the old
+  // 11-tab wall, so there is no pre-opened hydra tab to click: at boot the tabs
+  // are exactly ["pattern.strudel"]. The hydra presets still ship (they sit in
+  // the file tree), so open one the way a user would. Without this the spec
+  // threw "no hydra tab found" and never exercised the stave-bag wiring it
+  // guards — the product was fine, the spec's premise had rotted (#875).
+  // Same fallback backdrop-viz-chrome.spec.ts already uses.
+  const hydraItem = page.locator('[data-file-tree-item*="hydra"]').first()
+  if ((await hydraItem.count()) === 0) {
+    throw new Error('no hydra tab AND no hydra preset file in default project')
+  }
+  await hydraItem.dblclick()
+  await page.waitForTimeout(500)
 }
 
 async function openPreviewToSide(page: import('@playwright/test').Page) {
@@ -68,17 +93,22 @@ async function replaceMonacoContent(
   page: import('@playwright/test').Page,
   newContent: string,
 ) {
-  // Focus the active editor, select all, type. Monaco's Cmd+A then
-  // typing is the most portable path — avoids coupling to any
-  // Monaco-specific globals.
-  const editor = page.locator('.monaco-editor').first()
-  await editor.click()
-  // Use Meta on Mac, Control elsewhere. Playwright's Mac detection is
-  // accurate since the test is running on the dev's machine.
-  const mod = process.platform === 'darwin' ? 'Meta' : 'Control'
-  await page.keyboard.press(`${mod}+A`)
-  await page.keyboard.press('Delete')
-  await page.keyboard.type(newContent, { delay: 0 })
+  // Write the model directly. The previous approach — click, Cmd+A, Delete, then
+  // `keyboard.type` the whole sketch — MANGLED multi-line content: the select-all
+  // raced the typing, so the first newline was swallowed and a stray "a" leaked
+  // in, giving `…PAINT the result.aconst hasStave = …`. That folded the sketch's
+  // first statement into its leading comment, so the sketch threw and painted
+  // nothing. The single-line sibling test never noticed (no newline to lose).
+  // setValue drives the same onDidChangeContent path the provider listens on.
+  await page.evaluate((code) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const eds = (window as any).monaco?.editor?.getEditors?.() ?? []
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const target = eds.find((e: any) => e.getModel()?.getLanguageId?.() === 'hydra') ?? eds[0]
+    target?.getModel()?.setValue(code)
+    target?.focus()
+  }, newContent)
+  await page.waitForTimeout(300)
 }
 
 test.describe('Hydra .hydra file — stave bag wiring', () => {
@@ -101,29 +131,17 @@ test.describe('Hydra .hydra file — stave bag wiring', () => {
     await expect(mount).toBeVisible({ timeout: 5000 })
     await expect(mount).toHaveAttribute('data-renderer', 'hydra')
 
-    // Inspect the probe — proves stave is in scope with the right shape.
-    // The pattern fn runs once per mount (inside initHydra, after lazy
-    // `import('hydra-synth')`); give it a beat to resolve.
-    await page.waitForFunction(
-      () => (window as unknown as { __stave_probe?: unknown }).__stave_probe,
-      { timeout: 10000 },
-    )
-    const probe = await page.evaluate(
-      () =>
-        (window as unknown as {
-          __stave_probe: {
-            hasStave: boolean
-            hasScheduler: boolean
-            hasH: boolean
-            hSampleZero: number
-          }
-        }).__stave_probe,
-    )
-    expect(probe.hasStave).toBe(true)
-    expect(probe.hasScheduler).toBe(true)
-    expect(probe.hasH).toBe(true)
-    // H('nonexistent')() returns 0 in demo mode — no throw, no NaN.
-    expect(probe.hSampleZero).toBe(0)
+    // Read the painted answer. The pattern fn runs once per mount (inside
+    // initHydra, after the lazy `import('hydra-synth')`), so give it a beat.
+    await page.waitForTimeout(1500)
+    const white = await vizPixelStats(page, '[data-compiled-viz-mount="true"] canvas', {
+      rMin: 200, gMin: 200, bMin: 200,
+    })
+    // WHITE ⇒ stave + stave.scheduler reachable (R), stave.H callable (G), and
+    // H('nonexistent')() === 0 — no throw, no NaN (B). A missing channel would
+    // paint red/yellow/etc, so this fails loudly on any one of the four.
+    expect(white.frac, 'stave bag reachable inside the hydra sketch (white = all checks)')
+      .toBeGreaterThan(0.9)
   })
 
   test('legacy hydra (no stave reference) still compiles', async ({ page }) => {

--- a/packages/app/tests/mixer-dial-range.spec.ts
+++ b/packages/app/tests/mixer-dial-range.spec.ts
@@ -92,9 +92,40 @@ test.describe('Mixer custom dial range (#844/#845)', () => {
     await expect(slider).toHaveAttribute('aria-valuemin', '0')
     await expect(slider).toHaveAttribute('aria-valuemax', '100')
 
-    // Bidirectional: editing the range in code moves the dial's bounds.
-    await setStrudelCode(page, '$: s("bd").room(0.4, 10, 90)')
+    // Bidirectional: editing the range in code moves the dial's bounds. The
+    // value must sit INSIDE the authored range — see the widening test below for
+    // why `.room(0.4, 10, 90)` does not have the bounds it appears to.
+    await setStrudelCode(page, '$: s("bd").room(50, 10, 90)')
     await expect(slider).toHaveAttribute('aria-valuemin', '10')
     await expect(slider).toHaveAttribute('aria-valuemax', '90')
+  })
+
+  test('a value outside its own range WIDENS the dial rather than pinning it (#848)', async ({
+    page,
+  }) => {
+    // The guardrail (`customRange`, knobRanges.ts:134): a hand-typed literal that
+    // falls outside the range it declares stays REPRESENTABLE — the dial widens to
+    // include it. Pinning would make the dial lie about the code, and the first
+    // drag would silently rewrite the user's value.
+    //
+    // This is exactly the behaviour that made a `.room(0.4, 10, 90)` fixture look
+    // like a bug: 0.4 is below the authored min, so the dial's floor is 0.4, NOT 10.
+    await boot(page)
+    await setStrudelCode(page, '$: s("bd").room(0.4, 10, 90)')
+    const drawer = await openMixer(page)
+    await enlargeDrawer(page)
+
+    const slider = drawer.locator('[data-knob="room"] [role="slider"]')
+    await expect(slider).toHaveCount(1)
+    // widened DOWN to the authored value; the max it declared is untouched.
+    await expect(slider).toHaveAttribute('aria-valuemin', '0.4')
+    await expect(slider).toHaveAttribute('aria-valuemax', '90')
+    // and the dial still reads the value the code actually carries.
+    await expect(slider).toHaveAttribute('aria-valuenow', '0.4')
+
+    // The other direction: a value above the declared ceiling widens the max.
+    await setStrudelCode(page, '$: s("bd").room(150, 0, 100)')
+    await expect(slider).toHaveAttribute('aria-valuemin', '0')
+    await expect(slider).toHaveAttribute('aria-valuemax', '150')
   })
 })

--- a/packages/app/tests/mixer.spec.ts
+++ b/packages/app/tests/mixer.spec.ts
@@ -233,10 +233,23 @@ test.describe('Mixer (#381)', () => {
     await boot(page)
     await setStrudelCode(page, '$: s("bd").cutoff(900)')
     const drawer = await openMixer(page)
+    await enlargeDrawer(page)
+
+    // Wait for the strip to have BOUND to our code before opening the menu.
+    // `openMixer` only clicks the tab — it does not wait for the strip to bind,
+    // so a click issued too early opens nothing and the item assertion then fails
+    // with a bare "element not found". The knob carries the method the CODE used
+    // (`cutoff`); the menu is what maps it to its canonical Low-pass entry — which
+    // is the aliasing this test is actually about.
+    await expect(drawer.locator('[data-knob="cutoff"]')).toHaveCount(1)
+
     await drawer.locator('[data-mixer-add-effect]').click()
-    await expect(
-      page.locator('[data-mixer-add-effect-menu] [data-mixer-add-effect-item="lpf"]'),
-    ).toHaveAttribute('aria-pressed', 'true')
+    const menu = page.locator('[data-mixer-add-effect-menu]')
+    await expect(menu).toBeVisible()
+    await expect(menu.locator('[data-mixer-add-effect-item="lpf"]')).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    )
   })
 
   test('the × on a knob removes that effect; sibling byte-identical (#575)', async ({ page }) => {

--- a/packages/app/tests/perf-profiler.spec.ts
+++ b/packages/app/tests/perf-profiler.spec.ts
@@ -99,15 +99,34 @@ test.describe('Phase perf — profiler produces real per-frame data (#228)', () 
     const anyFps = frameIds.some((id) => snap.frames[id].fps > 0)
     expect(anyFps).toBe(true)
 
-    // The bus per-frame work was timed for the mounted renderer.
+    // The renderer's per-frame work was timed.
+    //
+    // `*.bus` is the MAIN-THREAD renderer's section name. Viz renders in a worker
+    // by default (#245), where the per-frame cost comes back as `viz.worker.draw`
+    // (the frameAck bridge — the worker bundle never imports `perf`, so this is
+    // how it is not a profiler blind spot). Observed on the default path:
+    // sections are viz.worker.{sample,write,draw} and there is no `.bus` at all,
+    // so the spec was demanding a name only the fallback path emits and reading
+    // "the profiler yields no data" when it was yielding plenty (#875).
+    // Accept EITHER vocabulary — the claim is that the mounted renderer's
+    // per-frame work is timed, whichever thread it runs on.
     const sectionNames = Object.keys(snap.sections)
-    const hasBusSection = sectionNames.some((n) => n.endsWith('.bus'))
-    expect(hasBusSection).toBe(true)
+    const hasFrameWorkSection = sectionNames.some(
+      (n) => n.endsWith('.bus') || n === 'viz.worker.draw',
+    )
+    expect(
+      hasFrameWorkSection,
+      `no per-frame renderer section; got: ${sectionNames.join(', ')}`,
+    ).toBe(true)
 
     // Live viz-instance GAUGE reflects ≥1 mounted renderer (gauges survive the
-    // reset() that clears cumulative counters — they're current state).
+    // reset() that clears cumulative counters — they're current state). Same
+    // split: `viz.p5`/`viz.hydra` are main-thread; a worker renderer gauges
+    // `viz.worker`.
     const liveViz =
-      (snap.gauges['viz.p5'] ?? 0) + (snap.gauges['viz.hydra'] ?? 0)
+      (snap.gauges['viz.p5'] ?? 0) +
+      (snap.gauges['viz.hydra'] ?? 0) +
+      (snap.gauges['viz.worker'] ?? 0)
     expect(liveViz).toBeGreaterThanOrEqual(1)
 
     // longtask block is present (count may legitimately be 0 on a fast machine

--- a/packages/app/tests/visual-edit-tabs.spec.ts
+++ b/packages/app/tests/visual-edit-tabs.spec.ts
@@ -1,10 +1,17 @@
 /**
- * Visual-editing tab scaffold — #380, collapsed to one adaptive tab in #398.
+ * Visual-editing tab scaffold — #380, collapsed to one adaptive tab in #398,
+ * rejoined by a peer Mixer console in #540.
  *
- * Observes that a SINGLE "Pattern" tab is seeded alongside "Timeline" (the old
- * Sequencer / Mixer / Piano Roll trio is gone), that activating it reveals the
- * adaptive panel (grid area + pinned Mixer), and that its copy carries no IR
- * jargon.
+ * Observes that the CURSOR-SCOPED grids (Sequencer / Piano Roll) are gone as
+ * separate tabs — collapsed into the one adaptive "Pattern" tab — that
+ * activating Pattern reveals the adaptive panel (grid area + pinned Mixer), and
+ * that its copy carries no IR jargon.
+ *
+ * "Mixer" is deliberately NOT in the gone list: #540 re-added it as a top-level
+ * PEER of Pattern (`tabs.ts:52`), and it is a different surface from the trio's
+ * old mixer. Pattern is cursor-scoped (one track — its grid + knobs); the Mixer
+ * console is cursor-INDEPENDENT (every track as a channel strip). Asserting it
+ * absent would demand we delete a shipped feature.
  */
 import { test, expect, type Page } from '@playwright/test'
 
@@ -26,15 +33,18 @@ async function bootShell(page: Page): Promise<void> {
 }
 
 test.describe('Visual-editing tab scaffold (#398)', () => {
-  test('seeds a single Pattern tab alongside Timeline (old trio gone)', async ({ page }) => {
+  test('seeds one Pattern tab + a peer Mixer alongside Timeline (the grids are gone)', async ({
+    page,
+  }) => {
     await clearDrawerStorage(page)
     await bootShell(page)
     const tablist = page.locator('[role="tablist"][aria-label="Bottom panel tabs"]')
-    for (const name of ['Timeline', 'Pattern']) {
+    // Timeline, the one adaptive grid tab (#398), and the peer Mixer console (#540).
+    for (const name of ['Timeline', 'Pattern', 'Mixer']) {
       await expect(tablist.locator(`role=tab[name="${name}"]`)).toHaveCount(1)
     }
-    // the three separate tabs were collapsed into "Pattern"
-    for (const gone of ['Sequencer', 'Mixer', 'Piano Roll']) {
+    // the two separate GRID tabs were collapsed into "Pattern"
+    for (const gone of ['Sequencer', 'Piano Roll']) {
       await expect(tablist.locator(`role=tab[name="${gone}"]`)).toHaveCount(0)
     }
   })

--- a/packages/app/tests/viz-chain.spec.ts
+++ b/packages/app/tests/viz-chain.spec.ts
@@ -10,6 +10,14 @@ import { test, expect, Page } from '@playwright/test'
  * Zones mount from the engine's capture (vizRequests), not audio playback, so
  * this runs headless with no audio/WebGL dependency — it asserts only that the
  * `[data-viz-zone]` containers exist with the right `data-viz-zone-id`.
+ *
+ * The viz NAMES here must be ones the default workspace actually seeds. These
+ * specs used to say `.viz('Prism')`, and Prism stopped being pre-seeded when the
+ * Asset Library landed (#834 — viz packages are now ADDED to the workspace from
+ * the library). An unknown name resolves to no zone at all, so all three lines
+ * rendered nothing and the spec read as "#571 is broken" when #571 was fine:
+ * the same three chain shapes with `pianoroll` render 3/3. The spec's PREMISE
+ * had rotted, not the product (#875).
  */
 async function evalZones(page: Page, code: string) {
   await page.evaluate((c) => {
@@ -33,25 +41,29 @@ test('inline .viz() renders whether or not it is the terminal chain call (#571)'
   await page.goto('/')
   await page.locator('.monaco-editor').waitFor({ timeout: 15000 })
   const code = [
-    `$: note("c e g").s("sawtooth").viz('Prism')`,            // terminal
-    `$: note("c e g").viz('Prism').gain(0.3)`,                // .viz() + 1 trailing method
-    `$: note("c e g").viz('Prism').s("sawtooth").gain(0.3)`,  // .viz() + 2 trailing methods
+    `$: note("c e g").s("sawtooth").viz('spectrum')`,            // terminal
+    `$: note("c e g").viz('spectrum').gain(0.3)`,                // .viz() + 1 trailing method
+    `$: note("c e g").viz('spectrum').s("sawtooth").gain(0.3)`,  // .viz() + 2 trailing methods
   ].join('\n') + '\n'
   const zones = await evalZones(page, code)
   // Pre-#571 only the terminal line rendered → 1 zone. All three must render now.
   expect(zones.length).toBe(3)
+  // ...and every one of them resolved the name — a zone that mounted for an
+  // UNKNOWN viz would be a different (and worse) bug than the one this guards.
+  expect(zones.map((z) => z.viz)).toEqual(['spectrum', 'spectrum', 'spectrum'])
 })
 
 test('a mid-chain track recovers the LATEST .viz() name in its chain (#571)', async ({ page }) => {
   await page.goto('/')
   await page.locator('.monaco-editor').waitFor({ timeout: 15000 })
   const code = [
-    `$: note("c e g").viz("Prism").lpf(178).viz("pianoroll").gain(0.8).sound('sin')`, // mid-chain, two viz → latest
-    `$: note("c4 e4").s("sawtooth").viz('Prism')`,                                     // terminal control
+    `$: note("c e g").viz("spectrum").lpf(178).viz("pianoroll").gain(0.8).sound('sin')`, // mid-chain, two viz → latest
+    `$: note("c4 e4").s("sawtooth").viz('spectrum')`,                                    // terminal control
   ].join('\n') + '\n'
   const zones = await evalZones(page, code)
   expect(zones.length).toBe(2)
-  // "last viz in the chain wins" — the mid-chain track resolves to pianoroll, not Prism.
+  // "last viz in the chain wins" — the mid-chain track resolves to pianoroll, not spectrum.
   expect(zones.map((z) => z.viz)).toContain('pianoroll')
-  expect(zones.map((z) => z.viz)).toContain('Prism')
+  // and the control line still resolves its own (different) viz.
+  expect(zones.map((z) => z.viz)).toContain('spectrum')
 })

--- a/packages/app/tests/viz-density-lod.spec.ts
+++ b/packages/app/tests/viz-density-lod.spec.ts
@@ -193,7 +193,8 @@ test.describe('Phase D — density LOD moves the line-mesh cost curve (#269 / #2
     await page.waitForTimeout(1000)
 
     // Open File menu → Editor Settings… (#347 moved it off the removed gear).
-    await page.getByRole('button', { name: 'File' }).click()
+    // `exact` — a bare 'File' also substring-matches the "New file" (+) button.
+    await page.getByRole('button', { name: 'File', exact: true }).click()
     await page.getByText('Editor Settings...').click()
 
     const select = page.getByLabel('Viz quality (performance mode)')

--- a/packages/app/tests/viz-library.spec.ts
+++ b/packages/app/tests/viz-library.spec.ts
@@ -44,6 +44,33 @@ async function showVizType(page: Page, panel: ReturnType<Page['locator']>) {
   await page.waitForTimeout(100)
 }
 
+/** Drag the viz card PREVIEW HEIGHT slider (#838) to its minimum through the real
+ *  gesture: File ▸ Editor Settings… → the Visualization section → focus the range
+ *  input → Home (the native "go to min" key) → Close.
+ *
+ *  `exact` on the File button — the name match is a case-insensitive substring, so
+ *  a bare 'File' also hits the "New file" (+) button. And the unified settings
+ *  shell (#739) renders ONE section at a time behind a nav: the slider is not in
+ *  the DOM until "Visualization" is selected. */
+async function setVizPreviewHeightToMin(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'File', exact: true }).click()
+  await page.getByText('Editor Settings...').click()
+  await page.getByTestId('settings-shell').waitFor({ timeout: 5000 })
+  await page.getByTestId('settings-nav-viz').click()
+  const slider = page.getByTestId('setting-vizPreviewHeight')
+  await slider.waitFor({ timeout: 5000 })
+  await slider.focus()
+  await page.keyboard.press('Home')
+  // Scoped + exact: the Library panel's own close is labelled "Close Library",
+  // which an unscoped substring match on 'Close' would also hit. Same trap as the
+  // File button above — the accessible name is a substring match, not an id.
+  await page
+    .getByTestId('settings-shell')
+    .getByRole('button', { name: 'Close', exact: true })
+    .click()
+  await page.waitForTimeout(200)
+}
+
 /** Whether a viz-language workspace file with the given basename exists (the
  *  same predicate the named-viz bridge registers on). Returns the file id. */
 async function vizFileId(page: Page, basename: string): Promise<string | null> {
@@ -89,16 +116,52 @@ test.describe('Asset Library — Viz library (#834)', () => {
       await expect(thumb).toHaveAttribute('src', /^data:image\/png/)
     }
 
-    // The cards flow in a grid — the two sit side by side (same row top), not
-    // stacked in a single column.
-    const prismBox = await panel.locator('[data-asset-row="viz:prism"]').boundingBox()
-    const pulseBox = await panel.locator('[data-asset-row="viz:pulse-grid"]').boundingBox()
-    expect(prismBox && pulseBox).toBeTruthy()
-    expect(Math.abs(prismBox!.y - pulseBox!.y)).toBeLessThan(8) // same row
-    expect(pulseBox!.x).toBeGreaterThan(prismBox!.x + prismBox!.width - 8) // to the right
-
     // Visual observation of the whole shelf with thumbnails.
     await panel.screenshot({ path: 'test-results/viz-library-thumbs.png' })
+  })
+
+  test('the cards are aspect-true and REFLOW — one column when they are big, two when small (#836/#838)', async ({
+    page,
+  }) => {
+    // The shelf is a wrapping flex grid whose cards are sized by each shader's
+    // aspect at the Settings preview height (#838). So the column count is not a
+    // fixed layout choice — it FALLS OUT of card width vs the 260px sidebar:
+    // a 2:1 shader at the default 96px is ~192px wide and only one fits across
+    // 236px of content; at the 48px minimum it is ~96px and two fit.
+    //
+    // This asserts the reflow itself, driven by the real Settings gesture. The
+    // spec used to assert "side by side" unconditionally — true when the cards
+    // were small, false since #838 gave them a bigger default height.
+    await boot(page)
+    const panel = await openLibrary(page)
+    await showVizType(page, panel)
+
+    const prism = panel.locator('[data-asset-row="viz:prism"]')
+    const pulse = panel.locator('[data-asset-row="viz:pulse-grid"]')
+    await expect(prism).toBeVisible()
+    await expect(pulse).toBeVisible()
+
+    // At the default height the cards are too wide to share a row → stacked.
+    const bigPrism = (await prism.boundingBox())!
+    const bigPulse = (await pulse.boundingBox())!
+    expect(bigPulse.y).toBeGreaterThan(bigPrism.y + bigPrism.height - 8) // below, not beside
+
+    // Shrink the preview height to its minimum via Settings → the cards narrow
+    // (aspect-true — the shape is preserved, only the scale changes)…
+    await setVizPreviewHeightToMin(page)
+    await expect
+      .poll(async () => (await prism.boundingBox())!.width)
+      .toBeLessThan(bigPrism.width)
+    const smallPrism = (await prism.boundingBox())!
+    const smallPulse = (await pulse.boundingBox())!
+    const ratio = (b: { width: number; height: number }) => b.width / b.height
+    expect(Math.abs(ratio(smallPrism) - ratio(bigPrism))).toBeLessThan(0.35) // same shape
+
+    // …and the grid reflows them onto ONE row, side by side.
+    expect(Math.abs(smallPrism.y - smallPulse.y)).toBeLessThan(8) // same row
+    expect(smallPulse.x).toBeGreaterThan(smallPrism.x + smallPrism.width - 8) // to the right
+
+    await panel.screenshot({ path: 'test-results/viz-library-reflow.png' })
   })
 
   test('the row action is "Add to workspace", not "Insert"', async ({ page }) => {

--- a/packages/app/tests/viz-library.spec.ts
+++ b/packages/app/tests/viz-library.spec.ts
@@ -138,24 +138,35 @@ test.describe('Asset Library — Viz library (#834)', () => {
 
     const prism = panel.locator('[data-asset-row="viz:prism"]')
     const pulse = panel.locator('[data-asset-row="viz:pulse-grid"]')
+    // Aspect-true is a claim about the shader FRAME, not the card: the card box
+    // also contains the name + renderer text, and that chrome is a fixed height
+    // that does NOT scale with the preview. Measuring the card would compare a
+    // ratio polluted by non-scaling chrome — it happens to come out close, which
+    // is worse than failing, so measure the thumbnail.
+    const prismThumb = panel.locator('img[data-asset-thumb="viz:prism"]')
     await expect(prism).toBeVisible()
     await expect(pulse).toBeVisible()
+    await expect(prismThumb).toBeVisible()
 
     // At the default height the cards are too wide to share a row → stacked.
     const bigPrism = (await prism.boundingBox())!
     const bigPulse = (await pulse.boundingBox())!
+    const bigThumb = (await prismThumb.boundingBox())!
     expect(bigPulse.y).toBeGreaterThan(bigPrism.y + bigPrism.height - 8) // below, not beside
 
-    // Shrink the preview height to its minimum via Settings → the cards narrow
-    // (aspect-true — the shape is preserved, only the scale changes)…
+    // Shrink the preview height to its minimum via Settings → the cards narrow…
     await setVizPreviewHeightToMin(page)
     await expect
       .poll(async () => (await prism.boundingBox())!.width)
       .toBeLessThan(bigPrism.width)
     const smallPrism = (await prism.boundingBox())!
     const smallPulse = (await pulse.boundingBox())!
-    const ratio = (b: { width: number; height: number }) => b.width / b.height
-    expect(Math.abs(ratio(smallPrism) - ratio(bigPrism))).toBeLessThan(0.35) // same shape
+    const smallThumb = (await prismThumb.boundingBox())!
+
+    // …the frame really did shrink, and it kept its aspect (scale, not distort).
+    expect(smallThumb.height).toBeLessThan(bigThumb.height)
+    const aspect = (b: { width: number; height: number }) => b.width / b.height
+    expect(Math.abs(aspect(smallThumb) - aspect(bigThumb))).toBeLessThan(0.05)
 
     // …and the grid reflows them onto ONE row, side by side.
     expect(Math.abs(smallPrism.y - smallPulse.y)).toBeLessThan(8) // same row

--- a/packages/editor/src/visualEdit/panels/__tests__/knobGuardrails.test.ts
+++ b/packages/editor/src/visualEdit/panels/__tests__/knobGuardrails.test.ts
@@ -49,12 +49,32 @@ describe('guardrails — unsupported code stays inert (#847)', () => {
     expect(k.rangeEditable).toBe(false)
   })
 
-  it('a value outside its custom range widens the range so the dial stays accurate', () => {
+  it('a value ABOVE its custom range widens the max so the dial stays accurate', () => {
     const [k] = knobsFor('$: s("bd").room(150, 0, 100)')
     expect(k.customRange).toEqual({ min: 0, max: 100 })
     // the render widens to include the authored value
     const r = customRange(k.customRange!.min, k.customRange!.max, k.value)
     expect(r.max).toBeGreaterThanOrEqual(150)
+    expect(r.min).toBe(0) // the bound it did NOT violate is left alone
+  })
+
+  it('a value BELOW its custom range widens the min — the dial floor is the value, not the authored min', () => {
+    // The mirror of the case above, and the one that reads as a bug if you only
+    // know the authored text: `.room(0.4, 10, 90)` declares a floor of 10, but 0.4
+    // sits under it, so the dial's floor is 0.4. Pinning to 10 would make the dial
+    // misreport the code — and the first drag would silently rewrite the value.
+    const [k] = knobsFor('$: s("bd").room(0.4, 10, 90)')
+    expect(k.customRange).toEqual({ min: 10, max: 90 })
+    const r = customRange(k.customRange!.min, k.customRange!.max, k.value)
+    expect(r.min).toBe(0.4)
+    expect(r.max).toBe(90) // the bound it did NOT violate is left alone
+  })
+
+  it('a value INSIDE its custom range leaves both bounds exactly as authored', () => {
+    const [k] = knobsFor('$: s("bd").room(50, 10, 90)')
+    const r = customRange(k.customRange!.min, k.customRange!.max, k.value)
+    expect(r.min).toBe(10)
+    expect(r.max).toBe(90)
   })
 
   it('a genuinely multi-arg NON-control keeps its dials and is not range-editable', () => {


### PR DESCRIPTION
The last stretch of #875. The gate on merged `studio_v0.2.0` was **14 failed / 387 passed / 131 skipped**. It is now **0 failed / 403 passed / 131 skipped** — 534 collected, reconciled (403 + 131 = 534), exit 0.

## The headline

**Zero product bugs.** Every one of the 14 was the instrument, not the instrument's subject. That is worth saying plainly because the failure *messages* said otherwise — "two File buttons", "audio still playing after close", "only 1 lane", "element not found". A red spec's message describes the **assertion**, not the product; ranking these by how alarming they sounded mis-ranked them every time.

The reds also cluster **by cause, not by file**. One structural move rots specs in suites that have nothing to do with each other: the unified settings shell (#739) broke a grid spec and a viz spec; the worker-default (#245) broke canvas probes, `window.__x` readback channels and profiler section names alike.

## What each one actually was

| Spec | What it claimed | What was true |
|---|---|---|
| `viz-chain` | a chain shape broke | `Prism` stopped being seeded when the Asset Library landed (#834) |
| `hydra-stave-bag` | the stave bag is missing | probe scanned open tabs, handed its result back on a `globalThis` that doesn't exist off-main, and seeded the editor by keystrokes |
| `backdrop-viz-chrome` | audio still plays after close | the viz's own context **is** closed; the survivor is the shared superdough context — the oracle **demanded a regression** |
| `editor-track-colour-bar` | the bar is 44px short | `getBottomForLineNumber` is not wrap-aware; the bar renders exactly the wrapped block |
| `perf-profiler` | the profiler yields nothing | it yields plenty, under the worker's vocabulary — `*.bus` is the pre-#245 main-thread name |
| `visual-edit-tabs` | Mixer should be gone | #540 deliberately re-added it as a **peer** console (`tabs.ts:52`) |
| `grid-visual-identity` | there are two File buttons | `getByRole(name:)` is a case-insensitive **substring** match; and Settings has since moved into the shell (#739) |
| `mixer-dial-range` | the range didn't arrive | it did; `.room(0.4, 10, 90)` puts the value outside its own range and #848 deliberately **widens** to keep it representable |
| `viz-library` | the cards aren't side by side | the flex grid reflows; at the #838 default card height two simply don't fit in a 260px sidebar |
| `full-song-timeline` | analysis renders < 2 lanes | a bare `stack(a, b)` is **one** track; it only ever passed because the seed lost a race and the 3-track **starter** got analyzed |
| `mixer` | the menu item is missing | the only genuinely load-dependent red: it clicked ＋Add-effect without waiting for the strip to bind |

## Two vacuous greens closed as a side-effect

- `mixer-dial-range` had no coverage for the widening guardrail's **below-min** direction — which is exactly why nobody caught the incoherent fixture. Added, at both the unit and dial level.
- `viz-density-lod` carried the same latent `File` substring trap. It is env-gated so it never failed the gate; fixed anyway.

## Test plan

- `npx playwright test` — **0 failed / 403 passed / 131 skipped**, 534 collected.
- Editor unit suite green (knob guardrails 10/10, incl. the new below-min + inside-range cases).
- The viz-library reflow is verified by **looking**, not by exit code: `viz-library-thumbs.png` (one column at the default height) and `viz-library-reflow.png` (side by side at the minimum).

## Still open, deliberately

- **#872** — the shared guarded boot helper. 61 specs still wait only for monaco to *exist*. It will not clear reds (there are none), but it is the root of the false green in `full-song-timeline` above, so it is now a proven correctness issue rather than a tidiness one.
- **#874**, **#737** — untouched.

Refs #875.