### PR TITLE
🐛 fix(tests): drive the transport with a real gesture — #885 is the instrument, not the product

### DIFF
--- a/packages/app/tests/full-song-follow.spec.ts
+++ b/packages/app/tests/full-song-follow.spec.ts
@@ -54,16 +54,23 @@ async function bootShell(page: Page): Promise<void> {
   )
 }
 
+/**
+ * Focus the editor the way a USER does — by clicking it — then press play.
+ *
+ * This used to call `editor.focus()` through `page.evaluate`, and that is what made
+ * this spec "flaky" (#885). A programmatic focus carries no user gesture, and the
+ * app then reaches a state where the transport says PLAY but reports NO POSITION:
+ * the LCD prints `— —` and the playhead never renders, so the wait below times out.
+ * Observed, interleaved so both arms share the same machine load: real click →
+ * playhead 5/5 with the LCD position advancing; programmatic focus → playhead 0/5
+ * with the position frozen. A later click does not revive it.
+ *
+ * A real user cannot take the programmatic path: with no click at all the shortcut
+ * does nothing (the editor is not autofocused — LCD stays STOP), so focus always
+ * arrives by gesture. Drive it as a user does.
+ */
 async function evalStrudel(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
-    const editors = (monaco?.editor?.getEditors?.() ?? []) as Array<{
-      getModel: () => { getLanguageId?: () => string } | null
-      focus: () => void
-    }>
-    const target = editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
-    target?.focus()
-  })
+  await page.locator('.monaco-editor').first().click()
   await page.keyboard.press(`${MOD}+Enter`)
   await page.waitForTimeout(1800)
 }

--- a/packages/app/tests/full-song-live-overlay.spec.ts
+++ b/packages/app/tests/full-song-live-overlay.spec.ts
@@ -68,12 +68,10 @@ test('live overlay lights scene marks while playing, clears when stopped', async
   await boot(page)
 
   // Evaluate + play the starter song (multi-track $: synths + drum stack).
-  await page.evaluate(() => {
-    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string } | null; focus: () => void }> } } }).monaco
-    const eds = monaco?.editor?.getEditors?.() ?? []
-    const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
-    t?.focus()
-  })
+  // CLICK to focus — a programmatic `editor.focus()` carries no user gesture, and
+  // the app then reaches a transport that says PLAY but reports NO POSITION (LCD
+  // `— —`, no playhead), so nothing ever lights and this spec "flakes" (#885).
+  await page.locator('.monaco-editor').first().click()
   await page.keyboard.press(`${MOD}+Enter`)
 
   // Switch to the full-song view; the base + overlay canvases mount.
@@ -95,15 +93,10 @@ test('live overlay lights scene marks while playing, clears when stopped', async
   // marks under the playhead, overlay included.
   await page.screenshot({ path: 'test-results/full-song-live-overlay.png' })
 
-  // (3) Stopping clears the overlay — no playhead → nothing lit. Focus the
-  //     editor first so the transport stop shortcut lands (the timeline grid
-  //     had focus from the toggle/seek gestures).
-  await page.evaluate(() => {
-    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string } | null; focus: () => void }> } } }).monaco
-    const eds = monaco?.editor?.getEditors?.() ?? []
-    const t = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
-    t?.focus()
-  })
+  // (3) Stopping clears the overlay — no playhead → nothing lit. Click back into
+  //     the editor so the transport stop shortcut lands (the timeline grid had
+  //     focus from the toggle/seek gestures).
+  await page.locator('.monaco-editor').first().click()
   await page.keyboard.press(`${MOD}+Period`)
   await expect
     .poll(() => litPixelCount(page), {


### PR DESCRIPTION
Closes the #885 question. **It is not a product bug.** A user cannot reach the broken state; the two specs were reaching it themselves.

## What #885 looked like

`full-song-follow` and `full-song-live-overlay` intermittently timed out waiting for a playhead. The scary reading was "hit play, get no playhead."

## What it actually is

Both specs focused Monaco with a programmatic `editor.focus()` via `page.evaluate`, then pressed the play shortcut. That path carries **no user gesture**, and the app then lands in a state where the transport says **PLAY but reports no position** — the LCD prints `— —` and the playhead cannot render.

Observed with the arms **interleaved**, so both see the same machine load:

| focus method | playhead | transport | LCD position |
|---|---|---|---|
| real click | **5/5** | PLAY | `0.4 → 1.1` **advancing** |
| programmatic `.focus()` | **0/5** | PLAY | **`— —` frozen** |
| no focus at all | 0/5 | **STOP** | shortcut does nothing |

In every arm the song analyzes (3 lanes) and there are **zero console errors**. A later real click does **not** revive it.

The third row is the one that decides it: the editor is **not autofocused**, so a real user's focus always arrives by gesture (click or tab). The broken state is only reachable by a programmatic focus — something only a harness does.

## The fix

Click the editor, then press — drive it as a user does. Verified **both ways**: 3/3 red before, 3/3 green after, for both specs.

## A methodology note worth keeping

My first attempt at this A/B ran the two arms in **separate batches** and "proved" a clean 6/6 vs 0/6 — then the next batch flipped. Running arms sequentially compares across a *changing* environment (Next dev-server compile warmth), not across the variable. Interleaving them made the result stable and real. Same class of error as every other instrument bug in this gate: the measurement was the bug.

## What I am NOT claiming

There is still a real robustness gap on the record: **the transport can report PLAY while its position is null, and nothing recovers it.** I could not construct a user path that reaches it, so it is not urgent — but "unreachable today" is not "impossible", and a guard (never show PLAY without a position) would be cheap. Left in #885 rather than silently dropped.

## Gate

With this in, `full-song-follow` and `full-song-live-overlay` no longer appear. What remains is a **load-sensitive** family (`strudel-viz-methods` FFT, `stave:130` a11y, `viz-shared-pump-observe`) — each passes in isolation and fails only under parallel workers. That is resource contention, a different problem from correctness, and worth its own issue rather than being folded in here.

Refs #885.