### PR TITLE
🐛 fix(tests): a shared guarded boot — and an oracle that can tell its own song (#872)

### DIFF
--- a/packages/app/tests/_appBoot.ts
+++ b/packages/app/tests/_appBoot.ts
@@ -1,0 +1,163 @@
+/**
+ * Shared boot / seed / transport helpers for the app's Playwright specs (#872).
+ *
+ * These existed as near-identical copies in ~95 spec files, and every copy carried
+ * the same two defects.
+ *
+ * ─── 1. Monaco EXISTING is not the editor being READY ───────────────────────────
+ * The editor's content is a CONTROLLED value fed by an ASYNC project-file load. A
+ * `boot()` that waits only for `monaco.editor.getEditors().length > 0` returns
+ * while the model is still EMPTY. A spec that then seeds its fixture is racing that
+ * load — and when the load lands second, it OVERWRITES the fixture and the app
+ * evaluates the STARTER instead.
+ *
+ * That does not merely make specs flaky. It makes them run against the WRONG SONG
+ * while still reporting a result. `full-song-timeline` asserted "≥ 2 lanes" from a
+ * fixture that can only ever produce ONE, and was green for its whole life because
+ * the 3-track starter kept satisfying it. A lost race is not a failure — it is a
+ * SILENT SUBSTITUTION OF THE ORACLE.
+ *
+ * So `bootApp` waits for the file load to actually LAND (model non-empty), and
+ * `seedCode` then asserts the model really HOLDS the fixture before returning.
+ * Order the load, then seed, then verify. Never assume what you typed arrived.
+ *
+ * ─── 2. Focus must arrive by GESTURE, not by `.focus()` ─────────────────────────
+ * A programmatic `editor.focus()` carries no user gesture, and the app then reaches
+ * a transport that reports PLAY with a NULL POSITION — the LCD prints `— —` and the
+ * playhead never renders (#885). Observed, arms interleaved: real click → playhead
+ * 5/5 with the position advancing; programmatic focus → 0/5, position frozen.
+ * A real user's focus always arrives by click or tab, so `evalCode` CLICKS.
+ */
+import { expect, type Page } from '@playwright/test'
+
+const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+const STORAGE = {
+  height: 'stave:bottomPanel.height',
+  open: 'stave:bottomPanel.open',
+  activeTabId: 'stave:bottomPanel.activeTabId',
+} as const
+
+export interface BootOptions {
+  /** open the bottom drawer at boot, on this tab (seeded into localStorage) */
+  readonly drawer?: { readonly tabId: string; readonly height?: number }
+  /** enable the `__stave*` E2E hooks (gated on this flag, set before mount) */
+  readonly e2eHooks?: boolean
+}
+
+/** The editor's model value — the single source of truth for "what will be evaluated". */
+export async function editorValue(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const m = (window as unknown as {
+      monaco?: {
+        editor?: {
+          getEditors?: () => Array<{
+            getModel: () => { getLanguageId?: () => string; getValue: () => string } | null
+          }>
+        }
+      }
+    }).monaco
+    const eds = m?.editor?.getEditors?.() ?? []
+    const strudel = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    return strudel?.getModel()?.getValue() ?? ''
+  })
+}
+
+/**
+ * Boot the app and wait until it is genuinely ready to be driven: the shell is up,
+ * Monaco exists, AND the project file has LANDED in the model. That last wait is the
+ * whole point — see the header.
+ */
+export async function bootApp(page: Page, opts: BootOptions = {}): Promise<void> {
+  if (opts.drawer || opts.e2eHooks) {
+    await page.addInitScript(
+      ([drawer, hooks, keys]: [
+        BootOptions['drawer'],
+        boolean,
+        typeof STORAGE,
+      ]) => {
+        if (hooks) (window as unknown as { __STAVE_E2E__?: boolean }).__STAVE_E2E__ = true
+        if (!drawer) return
+        try {
+          window.localStorage.setItem(keys.open, 'true')
+          window.localStorage.setItem(keys.activeTabId, drawer.tabId)
+          if (drawer.height != null) window.localStorage.setItem(keys.height, String(drawer.height))
+        } catch {
+          /* private mode — the drawer just starts closed */
+        }
+      },
+      [opts.drawer, Boolean(opts.e2eHooks), STORAGE] as [
+        BootOptions['drawer'],
+        boolean,
+        typeof STORAGE,
+      ],
+    )
+  }
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 30_000 })
+
+  // Monaco exists…
+  await page.waitForFunction(
+    () => {
+      const m = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
+      return (m?.editor?.getEditors?.()?.length ?? 0) > 0
+    },
+    { timeout: 30_000 },
+  )
+  // …and the project file has LANDED. Without this, a seed races the load (#872).
+  await page.waitForFunction(
+    () => {
+      const m = (window as unknown as {
+        monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getValue: () => string } | null }> } }
+      }).monaco
+      const eds = m?.editor?.getEditors?.() ?? []
+      return (eds[0]?.getModel()?.getValue() ?? '').trim().length > 0
+    },
+    { timeout: 30_000 },
+  )
+}
+
+/**
+ * Replace the editor's content with `code`, and PROVE it arrived.
+ *
+ * Writes the model rather than typing: `Cmd+A` + `type()` silently mangles
+ * multi-line text (the select-all races the typing — a swallowed newline and a
+ * stray character, observed). Then asserts the model holds exactly `code`, so a
+ * late file load cannot substitute the fixture behind the spec's back.
+ */
+export async function seedCode(page: Page, code: string): Promise<void> {
+  await page.evaluate((next) => {
+    const m = (window as unknown as {
+      monaco?: {
+        editor?: {
+          getEditors?: () => Array<{
+            getModel: () => { getLanguageId?: () => string; setValue: (v: string) => void } | null
+          }>
+        }
+      }
+    }).monaco
+    const eds = m?.editor?.getEditors?.() ?? []
+    const strudel = eds.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? eds[0]
+    strudel?.getModel()?.setValue(next)
+  }, code)
+
+  // The fixture is only seeded once the model actually HOLDS it.
+  await expect.poll(() => editorValue(page), { timeout: 10_000 }).toBe(code)
+}
+
+/**
+ * Evaluate + play, driven as a USER does — click into the editor, then the shortcut.
+ * The click is load-bearing: a programmatic focus yields PLAY with a null position
+ * and no playhead (#885).
+ */
+export async function evalCode(page: Page): Promise<void> {
+  await page.locator('.monaco-editor').first().click()
+  await page.keyboard.press(`${MOD}+Enter`)
+}
+
+/** Stop the transport (same gesture rule as {@link evalCode}). */
+export async function stopCode(page: Page): Promise<void> {
+  await page.locator('.monaco-editor').first().click()
+  await page.keyboard.press(`${MOD}+Period`)
+}

--- a/packages/app/tests/full-song-timeline.spec.ts
+++ b/packages/app/tests/full-song-timeline.spec.ts
@@ -30,73 +30,15 @@
  * capture). This spec observes structure + no-error; the audio half is a
  * manual user check (design §10).
  */
-import { test, expect, type Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
+import { bootApp, seedCode, evalCode } from './_appBoot'
 
-const MOD = process.platform === 'darwin' ? 'Meta' : 'Control'
-
-const STORAGE_KEYS = {
-  height: 'stave:bottomPanel.height',
-  open: 'stave:bottomPanel.open',
-  activeTabId: 'stave:bottomPanel.activeTabId',
-} as const
-
-async function preOpenDrawer(page: Page): Promise<void> {
-  await page.addInitScript(
-    ([heightKey, openKey, activeKey]: readonly string[]) => {
-      try {
-        window.localStorage.setItem(heightKey, '320')
-        window.localStorage.setItem(openKey, 'true')
-        window.localStorage.setItem(activeKey, 'musical-timeline')
-      } catch {
-        /* ignore */
-      }
-    },
-    [STORAGE_KEYS.height, STORAGE_KEYS.open, STORAGE_KEYS.activeTabId],
-  )
-}
-
-async function bootShell(page: Page): Promise<void> {
-  await page.goto('/', { waitUntil: 'domcontentloaded' })
-  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
-  await page.waitForFunction(
-    () => {
-      const m = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
-      return (m?.editor?.getEditors?.()?.length ?? 0) > 0
-    },
-    { timeout: 20_000 },
-  )
-}
-
-async function setStrudelCode(page: Page, code: string): Promise<void> {
-  const ok = await page.evaluate((c) => {
-    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
-    const editors = (monaco?.editor?.getEditors?.() ?? []) as Array<{
-      getModel: () => { getLanguageId?: () => string; setValue: (s: string) => void } | null
-      focus: () => void
-    }>
-    const target = editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
-    if (!target) return false
-    target.getModel()?.setValue(c)
-    target.focus()
-    return true
-  }, code)
-  expect(ok).toBe(true)
-  await page.waitForTimeout(150)
-}
-
-async function evalStrudel(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => unknown[] } } }).monaco
-    const editors = (monaco?.editor?.getEditors?.() ?? []) as Array<{
-      getModel: () => { getLanguageId?: () => string } | null
-      focus: () => void
-    }>
-    const target = editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
-    target?.focus()
-  })
-  await page.keyboard.press(`${MOD}+Enter`)
-  await page.waitForTimeout(1800)
-}
+/**
+ * Boot / seed / eval come from the SHARED helper (#872). The local copies this file
+ * used to carry waited only for Monaco to EXIST — so the seed raced the project file
+ * load, and when it lost, the app analyzed the 3-track STARTER instead. `bootApp`
+ * waits for the file to LAND and `seedCode` proves the model holds the fixture.
+ */
 
 test('full-song view: analysis renders, loop detected, ruler seek fires without error', async ({
   page,
@@ -107,22 +49,31 @@ test('full-song view: analysis renders, loop detected, ruler seek fires without 
     if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
   })
 
-  await preOpenDrawer(page)
-  await bootShell(page)
+  await bootApp(page, { drawer: { tabId: 'musical-timeline', height: 320 } })
 
   // Two explicit `$:` TRACKS — lanes are per-track, so this is a genuinely
   // multi-track song. (A bare `stack(a, b)` is a single anonymous track whose
   // voices render as sub-rows, not as lanes — see INPUT NOTE.)
-  await setStrudelCode(page, '$: s("bd hh bd hh")\n$: s("~ cp")')
-  await evalStrudel(page)
+  await seedCode(page, '$: s("bd hh bd hh")\n$: s("~ cp")')
+  await evalCode(page)
+  await page.waitForTimeout(1800)
 
   // The full-song canvas is the only timeline view now (#497/U5).
   await page.locator('[data-full-song="root"]').waitFor({ timeout: 10_000 })
 
-  // (1) Analysis renders lane rows from the real evaluated IR.
+  // (1) Analysis renders lane rows from the real evaluated IR — EXACTLY the two
+  //     tracks this spec seeded, identified by key.
+  //
+  //     The oracle is deliberately exact. `>= 2` was satisfiable by the 3-track
+  //     STARTER, so it could not tell its own fixture from the song the app
+  //     evaluates when a seed loses the #872 race — which is precisely how this
+  //     spec stayed green for years while never testing its own input. An
+  //     assertion that the fallback content also satisfies is not an oracle.
   await page.locator('[data-full-song-lane]').first().waitFor({ timeout: 10_000 })
-  const laneCount = await page.locator('[data-full-song-lane]').count()
-  expect(laneCount).toBeGreaterThanOrEqual(2)
+  const laneKeys = await page
+    .locator('[data-full-song-lane]')
+    .evaluateAll((els) => els.map((e) => e.getAttribute('data-full-song-lane')))
+  expect(laneKeys, 'the two seeded anonymous tracks, and only those').toEqual(['d1', 'd2'])
 
   // (2) The lane activity is drawn on the canvas (the per-cell DOM heatmap was
   //     replaced by SongTimelineCanvas in #419). Detailed canvas content/zoom
@@ -152,6 +103,6 @@ test('full-song view: analysis renders, loop detected, ruler seek fires without 
   await page.waitForTimeout(800)
 
   // Still coherent after the seek/re-eval.
-  expect(await page.locator('[data-full-song-lane]').count()).toBeGreaterThanOrEqual(2)
+  expect(await page.locator('[data-full-song-lane]').count()).toBe(2)
   expect(errors, `unexpected console/page errors:\n${errors.join('\n')}`).toEqual([])
 })


### PR DESCRIPTION
First half of #872: the shared guarded boot helper, plus the audit that says who the race had actually bitten.

## The race, restated

~95 specs each carry a private `boot()` that waits only for **Monaco to exist**. The editor's content is a controlled value fed by an **async file load**, so a spec that seeds a fixture is racing that load. When the load lands second it **overwrites the fixture** and the app evaluates the **starter**.

A lost race is not a failure. It is a **silent substitution of the oracle** — the spec still runs, and still reports a result, against a song it never chose.

## The audit: who was this actually hurting?

Rather than guess, I measured it. I ran the suite **seed-blind** — a hook that lets each spec's seed land and then restores the starter, exactly as a lost race does. **A spec that still passes was never testing its own fixture.**

**381 seed-blind tests → 313 correctly FAILED.** Those genuinely depend on their input; the race can only ever make them flaky, never dishonest.

Of the remainder, most were **instrument blind spots, not findings**, and I want to be explicit about that rather than inflate the result:

- Many seed by **typing**, not `setValue` — my hook only wraps `setValue`, so it never fired and they passed trivially. (`track-rename` says so in its own header: *"Typed (not setValue)"*.)
- Others are **content-independent by design** and legitimately so: COEP/SAB isolation, the commit store, the tokenizer, the preset store, profiler sections.

**One was real — and it was the spec I "fixed" two commits ago.** `full-song-timeline` asserted `laneCount >= 2`, which the **3-track starter satisfies**. I had given it a correct fixture and left an oracle that cannot distinguish its own song from the fallback. It would have gone right on passing for a song it never chose.

> An assertion that the fallback content also satisfies is not an oracle.

## The fix — both halves, because either alone is insufficient

1. **`tests/_appBoot.ts`** — the shared helper:
   - `bootApp` waits for the file to **land** (model non-empty), not merely for Monaco to exist.
   - `seedCode` writes the model and then **proves it holds the fixture** (`expect.poll`), so a late load cannot substitute it behind the spec's back. It writes rather than types — `Cmd+A` + `type()` silently mangles multi-line text.
   - `evalCode` / `stopCode` **click** to focus: a programmatic focus yields PLAY with a null position and no playhead (#885).
2. **The lane oracle is now exact** — `['d1','d2']`, the two tracks it seeded.

The guard stops the race; the exact oracle means that if the race ever *does* slip through, the spec **fails loudly instead of passing quietly**. Belt and braces, deliberately.

## Verified both ways

- Guarded spec: **5/5 green**.
- **Seed-blind: it now FAILS** — where before this change it passed. The instrument can finally detect the substitution it exists to catch.
- It also caught a **real lost race mid-verification**: one run came back with a third lane (the starter), which `>= 2` would have swallowed in silence.
- Full gate: 402 passed / 131 skipped / 1 failed — that one is `mixer-strips:995`, an audio-meter measurement that passes in isolation (the #887 contention family, unrelated).

## What's left

The remaining ~94 specs still carry their private `boot()`. Migration is mechanical and follows in a second PR — this one lands the helper, the audit, and the single spec whose oracle was provably blind. Worth doing incrementally rather than in one 95-file sweep.

Refs #872.