### PR TITLE
🐛 fix(a11y): give the app a heading, and stop measurements competing for the GPU (#889, #887)

### DIFF
--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -1,5 +1,36 @@
 import { defineConfig } from '@playwright/test'
 
+/**
+ * Specs whose ASSERTION IS A MEASUREMENT of real-time rendering — frames per
+ * second, spectral variance across frames, reads/frame, scroll jank, a cost ladder.
+ *
+ * These cannot be mocked or fast-forwarded: to observe that output VARIES across
+ * frames, frames must actually render, at real frame rate, on a real GPU. But
+ * Playwright parallelises across FILES (~6 workers on 12 cores) all sharing ONE
+ * GPU — so while these measure, five other workers are competing for the exact
+ * resource under measurement. The number degrades and the spec goes red, not
+ * because the product regressed but because the measurement was taken in a crowded
+ * room. Below, they get the machine to themselves.
+ *
+ * The alternative — widening their thresholds until they stop complaining — would
+ * destroy the only thing they exist for.
+ *
+ * The list is EVIDENCE-BASED, from repeated full-gate runs. Note what is NOT here:
+ * `stave.spec.ts` also failed only under load, and looked like a member — but its
+ * a11y test simply never waited for the app to render (`h1` count 0). That is a
+ * race, not contention, and it was fixed at the source rather than hidden in here.
+ * Serialising it would have been treating a spec bug as an infrastructure cost.
+ */
+/** vitest-only harnesses that match Playwright's default testMatch — never collect. */
+const VITEST_ONLY = ['**/parity-corpus/**']
+
+const MEASUREMENT_SPECS = [
+  '**/viz-shared-pump-observe.spec.ts', // reads/frame + sample mean, cache on vs off
+  '**/strudel-viz-methods.spec.ts', // 26 worker-backed viz mounts; "varies over frames"
+  '**/perf-matrix.spec.ts', // the cost ladder (env-gated)
+  '**/viz-scroll-jank.spec.ts', // jank: no-viz control vs heavy worker viz (env-gated)
+]
+
 export default defineConfig({
   testDir: './tests',
   // `tests/parity-corpus/` holds the maintainer-only VITEST harnesses (the parse-
@@ -9,7 +40,7 @@ export default defineConfig({
   // module scope` before running a single browser test — which is why the gate
   // could only ever be run one file at a time. They stay out of the browser gate;
   // `pnpm parity` / `pnpm edit:coverage` run them under vitest.
-  testIgnore: ['**/parity-corpus/**'],
+  testIgnore: VITEST_ONLY,
   timeout: 30000,
   retries: 0,
   use: {
@@ -17,7 +48,32 @@ export default defineConfig({
     headless: true,
   },
   projects: [
-    { name: 'chromium', use: { browserName: 'chromium' } },
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+      // A project-level `testIgnore` REPLACES the top-level one — it does not merge.
+      // So the parity-corpus exclusion has to be repeated here, or the vitest-only
+      // harnesses get collected again and the gate dies on `require is not defined`
+      // before running a single browser test (the #876 breakage, restored by hand).
+      testIgnore: [...VITEST_ONLY, ...MEASUREMENT_SPECS],
+    },
+    {
+      name: 'measurement',
+      use: { browserName: 'chromium' },
+      testMatch: MEASUREMENT_SPECS,
+      // Alone on the GPU: never alongside each other…
+      workers: 1,
+      // …and never alongside the other ~500 tests, which would otherwise run
+      // concurrently with this project and re-create the very contention we are
+      // removing.
+      //
+      // ⚠ `dependencies` also means: if the `chromium` project FAILS, this project
+      // is SKIPPED ENTIRELY — its 29 tests do not run and are not even reported as
+      // skipped. The gate then prints a plausible-looking "375 passed" that is
+      // simply a smaller suite. So ALWAYS reconcile the total: a complete run is
+      // 505 + 29 = 534. If the count is short, tests were dropped, not passed.
+      dependencies: ['chromium'],
+    },
   ],
   webServer: {
     command: 'pnpm dev',

--- a/packages/app/src/components/EditorWrapper.tsx
+++ b/packages/app/src/components/EditorWrapper.tsx
@@ -71,7 +71,12 @@ function IdbBlockedScreen({
         fontFamily: 'var(--font-mono), ui-monospace, monospace',
       }}
     >
-      <h1
+      {/* A div, not an <h1>: this is the transient BOOT SPLASH, not the document's
+          heading. The shell owns the one <h1> now (StaveApp, #889). It used to be
+          the only h1 in the whole product, and it disappears the second the editor
+          mounts — so the loaded app had no heading at all, and the a11y spec passed
+          only by racing this element's ~1s on screen. */}
+      <div
         style={{
           fontSize: 32,
           fontWeight: 700,
@@ -81,7 +86,7 @@ function IdbBlockedScreen({
         }}
       >
         Stave
-      </h1>
+      </div>
       <p
         style={{
           color: "var(--text-primary, #eee)",

--- a/packages/app/src/components/StaveApp.tsx
+++ b/packages/app/src/components/StaveApp.tsx
@@ -1244,6 +1244,14 @@ export function StaveApp({ initialProject }: StaveAppProps) {
 
   return (
     <div style={styles.root}>
+      {/* The document's one top-level heading (#889). It is visually hidden: the
+          brand is drawn by the MenuBar, and with the Transport LCD on by default
+          (#857) that brand is not rendered at all. Before this, the ONLY <h1> in
+          the product lived on the boot splash (EditorWrapper) and vanished the
+          moment the editor mounted — so a screen reader landing on Stave found a
+          document with no heading. Keep it here, in the shell, where it cannot be
+          swapped out by a setting. */}
+      <h1 style={styles.srOnly}>Stave</h1>
       <MenuBar
         // Backdrop selection moved to the per-tab pattern-bar dropdown (#347);
         // the menubar no longer owns it.
@@ -1604,6 +1612,20 @@ const styles: Record<string, React.CSSProperties> = {
     width: "100%",
     height: "100%",
     minHeight: 0,
+  },
+  /** Available to assistive tech, invisible on screen, and takes no layout space —
+   *  the standard clip-rect pattern. NOT `display:none`/`visibility:hidden`, which
+   *  would remove it from the accessibility tree and defeat the point (#889). */
+  srOnly: {
+    position: "absolute",
+    width: 1,
+    height: 1,
+    padding: 0,
+    margin: -1,
+    overflow: "hidden",
+    clip: "rect(0, 0, 0, 0)",
+    whiteSpace: "nowrap",
+    border: 0,
   },
   main: {
     flex: 1,

--- a/packages/app/tests/stave.spec.ts
+++ b/packages/app/tests/stave.spec.ts
@@ -129,6 +129,12 @@ test.describe('Stave — Viz Tabs', () => {
 test.describe('Stave — Accessibility', () => {
   test('page has single H1 heading "Stave"', async ({ page }) => {
     await page.goto('/')
+    // Wait for the app to have actually RENDERED before counting headings — the
+    // sibling test below already does this. Without it the assertion races boot:
+    // it only had the 5s auto-retry window, and under a loaded machine the app
+    // takes longer than that, so `h1` was found 0 times and this read as a flake.
+    // It is not contention — it is an assertion that never waited.
+    await page.locator('.monaco-editor').waitFor({ timeout: 15_000 })
     const h1 = page.locator('h1')
     await expect(h1).toHaveCount(1)
     await expect(h1).toHaveText('Stave')


### PR DESCRIPTION
You asked for an evidence-based list of which specs actually need serialising. Building that list found a **real accessibility bug**.

## The gate is now green — twice, reconciled

```
FINAL RUN 1:  403 passed + 131 skipped + 0 failed = 534 ✓
FINAL RUN 2:  403 passed + 131 skipped + 0 failed = 534 ✓
```

(previously ~1 rotating red per run)

## #889 — the loaded app has NO h1. The flakiness was hiding it.

`stave.spec.ts:130` ("page has single H1") failed only under load, so it looked exactly like a contention flake — and I was one commit away from serialising it as one. It isn't. Watch the heading disappear:

```
immediately after goto    h1=["Stave"]  lcd=0
+300ms                    h1=["Stave"]  lcd=1
+1s                       h1=[]         lcd=1     ← gone, and never comes back
```

The product's **only** `<h1>` lived on the boot splash (`EditorWrapper.tsx:74`) and vanished the moment the editor mounted. The MenuBar brand is a `<div>` *and* `aria-hidden="true"`, and with the Transport LCD on by default (#857) it isn't rendered at all. **A screen reader landing on Stave found a document with no top-level heading.**

The spec had been passing by **racing the splash's ~1 second on screen**. Under load it missed the window. So: the spec was right, the product regressed underneath it, and the race concealed the regression. The wait I added to "fix the flake" is what exposed the bug.

This is the inverse of the vacuous green we keep finding — an assertion passing for a reason unrelated to its claim.

**Fix:** a persistent visually-hidden `<h1>` in the shell, where no setting can swap it out (clip-rect, not `display:none` — that would remove it from the a11y tree and defeat the point). The splash's heading is demoted to a `<div>` so the document has exactly one.

## #887 — a `measurement` project, alone on the GPU

Specs whose **assertion IS a measurement** of real-time rendering — reads/frame, spectral variance across frames, scroll jank, a cost ladder — cannot be mocked or fast-forwarded: to observe that output *varies across frames*, frames must actually render, at real frame rate, on a real GPU. Playwright parallelises across FILES (~6 workers on 12 cores, **one GPU**), so while these measured, five other workers were competing for the exact resource under measurement.

They now get the machine to themselves: `workers: 1` + `dependencies: ['chromium']` — never alongside each other, never alongside the other ~500 tests.

The alternative — widening their thresholds until they stop complaining — would destroy the only thing they exist for.

The list is **evidence-based**, from repeated full-gate runs. Which is exactly why `stave.spec.ts` is *not* in it: it looked like a member and turned out to be a product bug. Bucketing it would have hidden #889 permanently.

## Two traps found while building this, both recorded in the config

1. **A project-level `testIgnore` REPLACES the top-level one** — it does not merge. My first cut silently re-enabled collection of `parity-corpus/`, re-breaking the very thing #876 fixed (the gate died on `require is not defined` before running a single test). Fixed by sharing a `VITEST_ONLY` constant.
2. **`dependencies` SKIPS the dependent project when its dependency fails.** One unrelated red and all 29 measurement tests neither run nor report as skipped — the gate prints a plausible-looking "375 passed" that is simply a smaller suite. I hit this live. The config now says so, loudly: **always reconcile 505 + 29 = 534.** A count that is short means tests were dropped, not that they passed.

## Cost

6.9m vs 5.5m — ~1.4 min to serialise the measurements. App unit suite 717 ✓.

Closes #889. Refs #887.