### PR TITLE
📝 docs(tests): Ctrl+Enter while playing stops — it is not a no-op (#180)

### DIFF
--- a/packages/app/tests/perf-matrix.spec.ts
+++ b/packages/app/tests/perf-matrix.spec.ts
@@ -204,8 +204,9 @@ async function runCode(page: Page): Promise<void> {
 }
 
 // Ctrl/Cmd+. = stop (EditorView.tsx:356). MUST stop before re-evaluating —
-// Ctrl+Enter WHILE PLAYING is a no-op (#180), so without a stop every other
-// rung's eval is swallowed and measures the previous scene.
+// Ctrl+Enter WHILE PLAYING stops instead of evaluating (it is a Play/Stop
+// toggle, StrudelEditorClient.tsx:1316, #180). Without a stop, presses just
+// alternate play/stop and every other rung measures the previous scene.
 async function stopCode(page: Page): Promise<void> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   await page.evaluate(() => (window as any).monaco?.editor?.getEditors?.()?.[0]?.focus())

--- a/packages/app/tests/strudel-viz-methods.spec.ts
+++ b/packages/app/tests/strudel-viz-methods.spec.ts
@@ -94,9 +94,10 @@ test('removing the non-underscore method clears the backdrop (code is source of 
   await runCode(page)
   await expect(page.locator('[data-workspace-background]')).toHaveCount(1, { timeout: 6000 })
 
-  // Remove the .scope() call. Manual Ctrl+Enter while playing is a no-op
-  // in this codebase (re-eval comes from live mode or stop+play), so force
-  // a fresh evaluate via stop+play to verify the clear semantic.
+  // Remove the .scope() call, then force a fresh evaluate via stop+play. The
+  // stop is load-bearing: Ctrl+Enter while playing STOPS rather than
+  // re-evaluates — it is wired as a Play/Stop toggle (StrudelEditorClient.tsx
+  // :1316, #180). Re-eval while playing comes from live mode.
   await setCode(page, `$: note("c e g").s("sawtooth")`)
   await page.keyboard.press(`${MOD}+.`) // stop
   await page.waitForTimeout(500)


### PR DESCRIPTION
## Problem

Two spec comments record that `Ctrl+Enter` while playing is a **silent no-op**, citing #180:

- `strudel-viz-methods.spec.ts:97` — *"Manual Ctrl+Enter while playing is a no-op in this codebase"*
- `perf-matrix.spec.ts:207` — *"Ctrl+Enter WHILE PLAYING is a no-op (#180)"*

It is not a no-op. **It stops the transport** — the action is wired as a Play/Stop toggle (`StrudelEditorClient.tsx:1316`).

That distinction is not pedantic. #882 was written on the "no-op" premise and concluded that viz options were being dropped on re-evaluate. They are not: a gesture that silently *stops playback* looks exactly like an options bag arriving empty, because the sketch stops painting either way. With live mode on — the path that genuinely re-evaluates while playing — an edited option applies correctly (observed: red `0.655` → green `0.700`). #882 is closed as not-a-bug.

## Fix

Say what the gesture actually does, and why each spec's `stop+play` is load-bearing rather than incidental. Both workarounds were already correct and are unchanged — only the stated reason was wrong.

## Not in scope

The product behaviour is tracked in #180, which I've updated with the diagnosis and retitled (it also turns out to break the documented getting-started walkthrough at step 3). This PR only stops the false premise from being read as settled fact by the next person — it changes no behaviour and no assertions.

## Test plan

- [x] `strudel-viz-methods.spec.ts` — 26/26 green
- [x] Comment-only diff; no assertions, no product source touched