### PR TITLE
✨ feat(timeline): let a note remember where it came from (#874 phase 1)

### DIFF
--- a/packages/app/src/components/__tests__/drawTimeline.barscale.test.ts
+++ b/packages/app/src/components/__tests__/drawTimeline.barscale.test.ts
@@ -40,7 +40,7 @@ function scene(): TimelineScene {
   return {
     lanes: [{
       laneKey: 'd1', displayName: 'd1', color: '#7af', density: [1],
-      notes: [{ cycle: 0.1, end: 0.2, pitch: null, gain: 1 }],
+      notes: [{ cycle: 0.1, end: 0.2, pitch: null, gain: 1, sourceOffset: null }],
       pitchMin: null, pitchMax: null, voices: [],
       clips: [{ armIndex: -1, startCycle: 0, endCycle: 1, label: null }],
       sourceOffset: null, arrangeOffset: null, labelOffset: null,

--- a/packages/app/src/components/musicalTimeline/__tests__/collectNoteMarks.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/collectNoteMarks.test.ts
@@ -131,3 +131,142 @@ describe('collectNoteMarks — eval-backed marks (#861)', () => {
     expect(marks.labelOffsetByLane.get('d2')).toBe(30)
   })
 })
+
+/**
+ * `sourceOffset` — the note's link back to its own source token (#874 phase 1).
+ *
+ * A `SceneNote` is a PROJECTION of an `IREvent`. In the retired DOM live view a
+ * drawn note WAS its event, so `evt.loc[0].start` was always in hand and
+ * click-to-source came free from identity; the canvas projection kept geometry
+ * and dropped the link, which is how the gesture vanished with no commit that
+ * removed it. These tests hold the link that restores it.
+ *
+ * Phase 1 is DATA ONLY — nothing renders or clicks differently yet. What is
+ * asserted here is exactly what phase 2's hit-test will read.
+ */
+describe('collectNoteMarks — sourceOffset (#874)', () => {
+  it('carries each IR mark’s own source offset (pre-eval fallback)', () => {
+    // No eval events → IR path. d1's event is located at char 10, d2's at 40.
+    const marks = collectNoteMarks(null, { fake: true } as never, 4)
+
+    expect(marks.marksByLane.get('d1')![0].sourceOffset).toBe(10)
+    expect(marks.marksByLane.get('d2')![0].sourceOffset).toBe(40)
+  })
+
+  it('carries each eval hap’s own source offset', () => {
+    const haps = [
+      { begin: 0, end: 0.5, trackId: '$0', note: 'C3', gain: 1, loc: [{ start: 12, end: 14 }] },
+      { begin: 0.5, end: 1, trackId: '$1', note: 'E3', gain: 1, loc: [{ start: 42, end: 44 }] },
+    ] as unknown as Parameters<typeof collectNoteMarks>[0]
+
+    const marks = collectNoteMarks(haps, { fake: true } as never, 4)
+
+    expect(marks.marksByLane.get('d1')![0].sourceOffset).toBe(12)
+    expect(marks.marksByLane.get('d2')![0].sourceOffset).toBe(42)
+  })
+
+  it('gives each note its OWN offset, not its lane’s shared anchor', () => {
+    // The discriminating case, and the reason the feature exists: two haps on
+    // ONE lane, at DIFFERENT source tokens. A per-LANE offset (which already
+    // exists as `sourceByLane`, anchored at char 10 for d1) would collapse both
+    // notes to one destination — clicking either note would jump to the same
+    // place, which is the lane-level behaviour we already have. Per-NOTE offsets
+    // are the whole point of #874, so assert they DIVERGE from the anchor and
+    // from each other.
+    const haps = [
+      { begin: 0, end: 0.5, trackId: '$0', note: 'C3', gain: 1, loc: [{ start: 12, end: 14 }] },
+      { begin: 0.5, end: 1, trackId: '$0', note: 'E3', gain: 1, loc: [{ start: 16, end: 18 }] },
+    ] as unknown as Parameters<typeof collectNoteMarks>[0]
+
+    const marks = collectNoteMarks(haps, { fake: true } as never, 4)
+
+    const d1 = marks.marksByLane.get('d1')!
+    expect(d1.map((n) => n.sourceOffset)).toEqual([12, 16])
+    // Both notes live on the lane whose anchor is 10 — neither reports it.
+    expect(marks.sourceByLane.get('d1')).toBe(10)
+  })
+
+  it('takes loc[0] when the leaf token leads — `s("bd*2")` shape', () => {
+    // A REAL shape, observed through the transpiler: one mini string contributes
+    // its locations in SOURCE order, so the note's token leads and its operator
+    // (`*2`) follows. loc[0] is the token — the case phase 1 targets.
+    //   s("bd*2") → locations: [ "bd"[3,5], "2"[6,7] ]
+    const haps = [
+      {
+        begin: 0,
+        end: 0.5,
+        trackId: '$0',
+        s: 'bd',
+        gain: 1,
+        loc: [{ start: 3, end: 5 }, { start: 6, end: 7 }],
+      },
+    ] as unknown as Parameters<typeof collectNoteMarks>[0]
+
+    const marks = collectNoteMarks(haps, { fake: true } as never, 4)
+
+    expect(marks.marksByLane.get('d1')![0].sourceOffset).toBe(3)
+  })
+
+  it('KNOWN RESIDUAL: a mini-string transform arg displaces the note token off loc[0]', () => {
+    // Pins OBSERVED reality so phase 2 inherits a fact, not an assumption. A
+    // transform whose arg is a MINI STRING contributes its locations FIRST, so
+    // the note's own token lands LAST:
+    //   n("0 2 4").scale("C:major") → [ "major"[20,25], "C"[18,19], "0"[3,4] ]
+    // Carrying loc[0] therefore gives every note on the track the SAME offset —
+    // the scale argument — while each note's degree token sits at the end.
+    //
+    // This test asserts what the code DOES, not what #874 ultimately wants: it
+    // documents the gap rather than hiding it. Phase 2 must decide which element
+    // to read, and when it changes this expectation SHOULD flip — that is the
+    // point. (The degrees below differ per note, so a correct phase-2 rule yields
+    // 3 DISTINCT offsets where today all three are 20.)
+    const scaleHap = (note: string, degreeStart: number) => ({
+      begin: 0,
+      end: 0.5,
+      trackId: '$0',
+      note,
+      gain: 1,
+      loc: [
+        { start: 20, end: 25 }, // "major" — the transform's own mini-string arg
+        { start: 18, end: 19 }, // "C"
+        { start: degreeStart, end: degreeStart + 1 }, // the note's OWN degree token
+      ],
+    })
+    const haps = [
+      scaleHap('C3', 3),
+      scaleHap('E3', 5),
+      scaleHap('G3', 7),
+    ] as unknown as Parameters<typeof collectNoteMarks>[0]
+
+    const marks = collectNoteMarks(haps, { fake: true } as never, 4)
+
+    // All three collapse onto the scale arg — the residual, made visible.
+    expect(marks.marksByLane.get('d1')!.map((n) => n.sourceOffset)).toEqual([20, 20, 20])
+  })
+
+  it('reports null for a loc-less hap rather than inventing an offset', () => {
+    // A sampled/continuous signal hap carries no `loc` (P274/#864) — there is no
+    // source token to point at. null is a PRINCIPLED residual: phase 3 falls back
+    // to the existing lane-level jump. Guessing the lane's anchor here would send
+    // a click somewhere the note did not come from.
+    const haps = [
+      { begin: 0, end: 1, trackId: '$1', note: 'C3', gain: 1 },
+    ] as unknown as Parameters<typeof collectNoteMarks>[0]
+
+    const marks = collectNoteMarks(haps, { fake: true } as never, 4)
+
+    expect(marks.marksByLane.get('d2')![0].sourceOffset).toBeNull()
+  })
+
+  it('reports null for a non-finite offset rather than passing it through', () => {
+    // A garbage `loc` must not become a NaN cursor position downstream.
+    const haps = [
+      { begin: 0, end: 1, trackId: '$0', note: 'C3', gain: 1, loc: [{ start: NaN, end: 14 }] },
+    ] as unknown as Parameters<typeof collectNoteMarks>[0]
+
+    const marks = collectNoteMarks(haps, { fake: true } as never, 4)
+
+    // Un-attributable by containment (NaN) → its own eval lane, offset null.
+    expect(marks.marksByLane.get('d1')![0].sourceOffset).toBeNull()
+  })
+})

--- a/packages/app/src/components/musicalTimeline/__tests__/downsampleMarks.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/downsampleMarks.test.ts
@@ -7,7 +7,7 @@ function denseLane(cycles: number, perCycle: number): SceneNote[] {
   const out: SceneNote[] = []
   for (let c = 0; c < cycles; c++) {
     for (let k = 0; k < perCycle; k++) {
-      out.push({ cycle: c + k / perCycle, end: c + k / perCycle, pitch: null, gain: 1 })
+      out.push({ cycle: c + k / perCycle, end: c + k / perCycle, pitch: null, gain: 1, sourceOffset: null })
     }
   }
   return out
@@ -49,7 +49,7 @@ describe('downsampleMarksToCap — span-preserving note-mark cap (#714)', () => 
   test('output length never exceeds cap across a range of sizes', () => {
     for (const len of [1999, 2000, 2001, 4000, 4001, 8960, 100000]) {
       const marks = Array.from({ length: len }, (_, i) => ({
-        cycle: i, end: i, pitch: null, gain: 1,
+        cycle: i, end: i, pitch: null, gain: 1, sourceOffset: null,
       })) as SceneNote[]
       const { marks: out } = downsampleMarksToCap(marks, 2000)
       expect(out.length).toBeLessThanOrEqual(2000)

--- a/packages/app/src/components/musicalTimeline/__tests__/drawLiveOverlay.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/drawLiveOverlay.test.ts
@@ -38,8 +38,8 @@ const THEME: LiveOverlayTheme = { lit: '#fff', litGlow: '#88f' }
 /** One lane, one melodic voice with two pitched notes. */
 function sceneFixture(): TimelineScene {
   const notes: SceneNote[] = [
-    { cycle: 1, end: 1.5, pitch: 60, gain: 1, voice: 'saw' },
-    { cycle: 2, end: 2.5, pitch: 67, gain: 0.5, voice: 'saw' },
+    { cycle: 1, end: 1.5, pitch: 60, gain: 1, voice: 'saw', sourceOffset: null },
+    { cycle: 2, end: 2.5, pitch: 67, gain: 0.5, voice: 'saw', sourceOffset: null },
   ]
   return {
     lanes: [
@@ -83,7 +83,7 @@ describe('markSig', () => {
 })
 
 describe('pickLitNotes (#507 nearest-occurrence)', () => {
-  const note: SceneNote = { cycle: 1, end: 1.5, pitch: 60, gain: 1, voice: 'saw' }
+  const note: SceneNote = { cycle: 1, end: 1.5, pitch: 60, gain: 1, voice: 'saw', sourceOffset: null }
   const active = new Set(['saw|60'])
 
   it('lights a note inside its window when the sig is firing', () => {
@@ -100,26 +100,26 @@ describe('pickLitNotes (#507 nearest-occurrence)', () => {
     expect(pickLitNotes([note], 1.2, new Set(['bd|'])).size).toBe(0)
   })
   it('picks the occurrence of a sig NEAREST the playhead (disambiguates repeats)', () => {
-    const near: SceneNote = { cycle: 4, end: 4.06, pitch: 60, gain: 1, voice: 'saw' }
-    const far: SceneNote = { cycle: 0, end: 0.06, pitch: 60, gain: 1, voice: 'saw' }
+    const near: SceneNote = { cycle: 4, end: 4.06, pitch: 60, gain: 1, voice: 'saw', sourceOffset: null }
+    const far: SceneNote = { cycle: 0, end: 0.06, pitch: 60, gain: 1, voice: 'saw', sourceOffset: null }
     const lit = pickLitNotes([far, near], 4.0, active)
     expect(lit.has(near)).toBe(true)
     expect(lit.has(far)).toBe(false)
     expect(lit.size).toBe(1)
   })
   it('does not light a stale occurrence beyond MAX_LIT_DISTANCE_CYCLES', () => {
-    const far: SceneNote = { cycle: 0, end: 0.06, pitch: 60, gain: 1, voice: 'saw' }
+    const far: SceneNote = { cycle: 0, end: 0.06, pitch: 60, gain: 1, voice: 'saw', sourceOffset: null }
     expect(pickLitNotes([far], far.cycle + MAX_LIT_DISTANCE_CYCLES + 0.2, active).size).toBe(0)
   })
   it('a zero-duration trigger still lights near its onset', () => {
-    const hit: SceneNote = { cycle: 2, end: 2, pitch: null, gain: 1, voice: 'bd' }
+    const hit: SceneNote = { cycle: 2, end: 2, pitch: null, gain: 1, voice: 'bd', sourceOffset: null }
     const drums = new Set(['bd|'])
     expect(pickLitNotes([hit], 2, drums).has(hit)).toBe(true)
     expect(pickLitNotes([hit], 2 + MIN_LIT_CYCLES / 2, drums).has(hit)).toBe(true)
   })
   it('lights one occurrence per active sig (distinct sigs each light)', () => {
-    const a: SceneNote = { cycle: 1, end: 1.5, pitch: 60, gain: 1, voice: 'saw' }
-    const b: SceneNote = { cycle: 1.1, end: 1.6, pitch: 67, gain: 1, voice: 'saw' }
+    const a: SceneNote = { cycle: 1, end: 1.5, pitch: 60, gain: 1, voice: 'saw', sourceOffset: null }
+    const b: SceneNote = { cycle: 1.1, end: 1.6, pitch: 67, gain: 1, voice: 'saw', sourceOffset: null }
     const lit = pickLitNotes([a, b], 1.2, new Set(['saw|60', 'saw|67']))
     expect(lit.size).toBe(2)
   })

--- a/packages/app/src/components/musicalTimeline/__tests__/drawTimeline.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/drawTimeline.test.ts
@@ -43,9 +43,9 @@ const scene: TimelineScene = {
       color: '#0af',
       density: [1, 0, 2, 0], // onsets at integer cycles 0 and 2
       notes: [
-        { cycle: 0, end: 0.25, pitch: 60, gain: 1 },
-        { cycle: 2, end: 2.25, pitch: 72, gain: 0.5 },
-        { cycle: 2.5, end: 2.75, pitch: 64, gain: 0.8 }, // fractional → only marks render here
+        { cycle: 0, end: 0.25, pitch: 60, gain: 1, sourceOffset: null },
+        { cycle: 2, end: 2.25, pitch: 72, gain: 0.5, sourceOffset: null },
+        { cycle: 2.5, end: 2.75, pitch: 64, gain: 0.8, sourceOffset: null }, // fractional → only marks render here
       ],
       pitchMin: 60,
       pitchMax: 72,
@@ -150,8 +150,8 @@ describe('drawTimeline', () => {
         {
           ...scene.lanes[0],
           notes: [
-            { cycle: 0, end: 0, pitch: 60, gain: 1 }, // zero-duration trigger → MIN_MARK_W
-            { cycle: 1, end: 2, pitch: 64, gain: 1 }, // a whole cycle long
+            { cycle: 0, end: 0, pitch: 60, gain: 1, sourceOffset: null }, // zero-duration trigger → MIN_MARK_W
+            { cycle: 1, end: 2, pitch: 64, gain: 1, sourceOffset: null }, // a whole cycle long
           ],
         },
       ],
@@ -180,8 +180,8 @@ describe('drawTimeline', () => {
           color: '#fa0',
           density: [2, 0, 0, 0],
           notes: [
-            { cycle: 0, end: 0.25, pitch: null, gain: 1, voice: 'bd' },
-            { cycle: 0, end: 0.25, pitch: null, gain: 1, voice: 'sd' },
+            { cycle: 0, end: 0.25, pitch: null, gain: 1, voice: 'bd', sourceOffset: null },
+            { cycle: 0, end: 0.25, pitch: null, gain: 1, voice: 'sd', sourceOffset: null },
           ],
           pitchMin: null,
           pitchMax: null,

--- a/packages/app/src/components/musicalTimeline/__tests__/stableVoiceOrder.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/stableVoiceOrder.test.ts
@@ -33,6 +33,8 @@ const note = (cycle: number, voice: string): SceneNote => ({
   pitch: null,
   gain: 1,
   voice,
+  // Voice ORDER is what's under test; a note's source link is irrelevant here.
+  sourceOffset: null,
 })
 
 // The #480 repro: `arrange([2, s('bd*4')], [2, s('hh*8')], …)`. bd's first mark

--- a/packages/app/src/components/musicalTimeline/__tests__/timelineScene.test.ts
+++ b/packages/app/src/components/musicalTimeline/__tests__/timelineScene.test.ts
@@ -68,11 +68,11 @@ describe('buildTimelineScene', () => {
     const scene = buildTimelineScene(
       analysisFixture,
       marks({
-        bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1 }], // percussive → no pitch range
+        bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1, sourceOffset: null }], // percussive → no pitch range
         lead: [
-          { cycle: 0, end: 0.5, pitch: 60, gain: 0.5 },
-          { cycle: 1, end: 1.5, pitch: 72, gain: 1 },
-          { cycle: 2, end: 2.5, pitch: 64, gain: 0.8 },
+          { cycle: 0, end: 0.5, pitch: 60, gain: 0.5, sourceOffset: null },
+          { cycle: 1, end: 1.5, pitch: 72, gain: 1, sourceOffset: null },
+          { cycle: 2, end: 2.5, pitch: 64, gain: 0.8, sourceOffset: null },
         ],
       }),
     )
@@ -87,7 +87,7 @@ describe('buildTimelineScene', () => {
   })
 
   it('assigns a stable color per lane and leaves note-less lanes empty', () => {
-    const scene = buildTimelineScene(analysisFixture, marks({ bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1 }] }))
+    const scene = buildTimelineScene(analysisFixture, marks({ bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1, sourceOffset: null }] }))
     expect(typeof scene.lanes[0].color).toBe('string')
     expect(scene.lanes[0].color.length).toBeGreaterThan(0)
     const lead = scene.lanes.find((l) => l.laneKey === 'lead')!
@@ -207,10 +207,10 @@ describe('buildTimelineScene', () => {
       marks({
         // 'bd' lane carries a $: drum stack: distinct s per voice, percussive.
         bd: [
-          { cycle: 0, end: 0.25, pitch: null, gain: 1, voice: 'bd' },
-          { cycle: 0.5, end: 0.75, pitch: null, gain: 1, voice: 'hh' },
-          { cycle: 1, end: 1.25, pitch: null, gain: 1, voice: 'bd' }, // bd again
-          { cycle: 1.5, end: 1.75, pitch: null, gain: 1, voice: 'sd' },
+          { cycle: 0, end: 0.25, pitch: null, gain: 1, voice: 'bd', sourceOffset: null },
+          { cycle: 0.5, end: 0.75, pitch: null, gain: 1, voice: 'hh', sourceOffset: null },
+          { cycle: 1, end: 1.25, pitch: null, gain: 1, voice: 'bd', sourceOffset: null }, // bd again
+          { cycle: 1.5, end: 1.75, pitch: null, gain: 1, voice: 'sd', sourceOffset: null },
         ],
       }),
     )
@@ -226,8 +226,8 @@ describe('buildTimelineScene', () => {
       analysisFixture,
       marks({
         lead: [
-          { cycle: 0, end: 0.5, pitch: 60, gain: 1, voice: 'square' },
-          { cycle: 1, end: 1.5, pitch: 67, gain: 1, voice: 'square' },
+          { cycle: 0, end: 0.5, pitch: 60, gain: 1, voice: 'square', sourceOffset: null },
+          { cycle: 1, end: 1.5, pitch: 67, gain: 1, voice: 'square', sourceOffset: null },
         ],
       }),
     )
@@ -241,8 +241,8 @@ describe('buildTimelineScene', () => {
       analysisFixture,
       marks({
         lead: [
-          { cycle: 0, end: 0.5, pitch: 60, gain: 1 }, // no voice → NO_VOICE group
-          { cycle: 1, end: 1.5, pitch: 64, gain: 1 },
+          { cycle: 0, end: 0.5, pitch: 60, gain: 1, sourceOffset: null }, // no voice → NO_VOICE group
+          { cycle: 1, end: 1.5, pitch: 64, gain: 1, sourceOffset: null },
         ],
       }),
     )
@@ -313,11 +313,11 @@ describe('eval-backed lanes (#864 / P1b)', () => {
     const scene = buildTimelineScene(
       analysisFixture,
       marks({
-        bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1 }],
+        bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1, sourceOffset: null }],
         d2: [
-          { cycle: 0, end: 0.5, pitch: 48, gain: 1 },
-          { cycle: 0, end: 0.5, pitch: 52, gain: 1 },
-          { cycle: 2, end: 2.5, pitch: 55, gain: 1 },
+          { cycle: 0, end: 0.5, pitch: 48, gain: 1, sourceOffset: null },
+          { cycle: 0, end: 0.5, pitch: 52, gain: 1, sourceOffset: null },
+          { cycle: 2, end: 2.5, pitch: 55, gain: 1, sourceOffset: null },
         ],
       }),
     )
@@ -339,10 +339,10 @@ describe('eval-backed lanes (#864 / P1b)', () => {
       analysisFixture, // IR peak is 3 (bd cell)
       marks({
         d2: [
-          { cycle: 1, end: 1.5, pitch: 60, gain: 1 },
-          { cycle: 1, end: 1.5, pitch: 62, gain: 1 },
-          { cycle: 1, end: 1.5, pitch: 64, gain: 1 },
-          { cycle: 1, end: 1.5, pitch: 65, gain: 1 }, // 4 onsets in cycle 1
+          { cycle: 1, end: 1.5, pitch: 60, gain: 1, sourceOffset: null },
+          { cycle: 1, end: 1.5, pitch: 62, gain: 1, sourceOffset: null },
+          { cycle: 1, end: 1.5, pitch: 64, gain: 1, sourceOffset: null },
+          { cycle: 1, end: 1.5, pitch: 65, gain: 1, sourceOffset: null }, // 4 onsets in cycle 1
         ],
       }),
     )
@@ -352,7 +352,7 @@ describe('eval-backed lanes (#864 / P1b)', () => {
   it('adds no lanes when every marks key is an IR lane (no regression)', () => {
     const scene = buildTimelineScene(
       analysisFixture,
-      marks({ bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1 }] }),
+      marks({ bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1, sourceOffset: null }] }),
     )
     expect(scene.lanes.map((l) => l.laneKey)).toEqual(['bd', 'lead'])
   })
@@ -363,9 +363,9 @@ describe('source lane order (#871)', () => {
   // source order the scene can only append it after them (the default above).
   const evalFirst = () =>
     marks({
-      sig: [{ cycle: 0, end: 0.5, pitch: 48, gain: 1 }],
-      bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1 }],
-      lead: [{ cycle: 0, end: 0.5, pitch: 60, gain: 1 }],
+      sig: [{ cycle: 0, end: 0.5, pitch: 48, gain: 1, sourceOffset: null }],
+      bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1, sourceOffset: null }],
+      lead: [{ cycle: 0, end: 0.5, pitch: 60, gain: 1, sourceOffset: null }],
     })
 
   const keys = (analysis: SongAnalysis, order?: readonly string[]) =>
@@ -382,7 +382,7 @@ describe('source lane order (#871)', () => {
   })
 
   it('leaves an IR-only song untouched (its analysis order already follows the IR)', () => {
-    const irOnly = marks({ bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1 }] })
+    const irOnly = marks({ bd: [{ cycle: 0, end: 0.5, pitch: null, gain: 1, sourceOffset: null }] })
     const scene = buildTimelineScene(analysisFixture, irOnly, undefined, undefined, undefined, [
       'bd',
       'lead',

--- a/packages/app/src/components/musicalTimeline/timelineMarks.ts
+++ b/packages/app/src/components/musicalTimeline/timelineMarks.ts
@@ -30,6 +30,47 @@ function clamp01(n: number): number {
 }
 
 /**
+ * The note's link back to its source: a char offset into the evaluated source
+ * (#874). Phase 1 carries `loc[0].start` — the same expression and finite-guard
+ * as the per-lane `sourceByLane` anchor below, deliberately: both answer "where
+ * in the source is this?", and reading the offset two different ways would be
+ * two sources of truth for one question. Absent/garbage `loc` → null (a loc-less
+ * signal hap — P274/#864), a principled residual, not a gap.
+ *
+ * `[0]` IS NOT UNIVERSALLY THE NOTE'S OWN TOKEN, and the difference is not
+ * theoretical. OBSERVED against the real transpiler (evaluate(code, transpiler),
+ * the engine's own call shape — StrudelEngine.ts:329/608), reading
+ * `hap.context.locations` in order:
+ *
+ *   note("c3 e3 g3")            → ["c3"]                    [0] = the token ✓
+ *   s("bd*2")                   → ["bd", "2"]               [0] = the token ✓
+ *   .add(12) / .fast(2) / .rev()→ ["c3"]                    [0] = the token ✓
+ *   note("c3 e3").add("<12 7>") → ["12", "c3"]              [0] = the ARG ✗
+ *   n("0 2 4").scale("C:major") → ["major", "C", "0"]       [0] = the ARG ✗
+ *
+ * A transform whose argument is a MINI STRING contributes its own locations and
+ * they land FIRST; the note's own token is then LAST. Within a single mini string
+ * the order is source order (`bd` before its `*2`). So for `.scale(…)`/`.add("…")`
+ * chains every note on the track reports the SAME offset — the transform's arg —
+ * and the per-note token, though present at the end of the array, is not what is
+ * carried here.
+ *
+ * This is deliberate for phase 1 and MUST be revisited in phase 2 (#874), where
+ * the hit-test makes the choice observable end-to-end: picking the wrong element
+ * means clicking any note of `n("0 2 4").scale("C:major")` reveals `major`. It is
+ * kept at `[0]` for now because that is what the filed plan specifies, it is
+ * correct for that plan's three acceptance cases, and it matches what
+ * `sourceByLane` already ships — which also means `sourceByLane` anchors a scaled
+ * track at its scale argument today (a pre-existing latent bug in expand-to-bind,
+ * #422, with this same root). Phase 1 changes no behaviour either way: nothing
+ * reads this field yet.
+ */
+function sourceOffsetOf(ev: IREvent): number | null {
+  const start = ev.loc?.[0]?.start
+  return typeof start === 'number' && Number.isFinite(start) ? start : null
+}
+
+/**
  * Collect read-only mini-note marks for the display span by querying the IR
  * directly (`collectCycles`), grouped by the SAME `laneKeyOf` identity the
  * analysis lanes use, capped per lane. `null` IR / non-positive span → empty.
@@ -165,6 +206,7 @@ export function collectNoteMarks(
         pitch: extractPitch(ev)?.midi ?? null,
         gain: clamp01(ev.gain ?? 1),
         voice: ev.s ?? null,
+        sourceOffset: sourceOffsetOf(ev),
       })
     }
   }
@@ -268,7 +310,7 @@ function collectHapMarks(
   const anchors = [...labelOffsetByLane].sort((a, b) => a[1] - b[1])
   // Containment hit (an IR lane), or undefined when the hap's source start lands
   // before every lane's statement (or it has no `loc`).
-  const irLaneFor = (start: number | undefined): string | undefined => {
+  const irLaneFor = (start: number | null | undefined): string | undefined => {
     if (typeof start !== 'number' || !Number.isFinite(start)) return undefined
     let hit: string | undefined
     for (const [key, pos] of anchors) {
@@ -280,9 +322,15 @@ function collectHapMarks(
   for (const ev of events) {
     const cycle = ev.begin
     if (!Number.isFinite(cycle) || cycle < 0 || cycle >= displayCycles) continue
+    // The hap's source offset, read ONCE and used for both of the questions it
+    // answers: which lane owns this note (containment, below) and where its
+    // source token is (`sourceOffset`, #874). This path already computed the
+    // very same expression for attribution and dropped it on the floor — the
+    // note's link to its code was in hand at the push site all along.
+    const sourceOffset = sourceOffsetOf(ev)
     // Containment first (keeps a hap on its named/positional IR lane); else an
     // eval-backed lane keyed by the hap's own producer id (#864 / P1b).
-    const key = irLaneFor(ev.loc?.[0]?.start) ?? evalTrackIdToLaneKey(ev.trackId)
+    const key = irLaneFor(sourceOffset) ?? evalTrackIdToLaneKey(ev.trackId)
     let arr = out.get(key)
     if (!arr) {
       arr = []
@@ -295,6 +343,7 @@ function collectHapMarks(
       pitch: extractPitch(ev)?.midi ?? null,
       gain: clamp01(ev.gain ?? 1),
       voice: ev.s ?? null,
+      sourceOffset,
     })
   }
   return out

--- a/packages/app/src/components/musicalTimeline/timelineScene.ts
+++ b/packages/app/src/components/musicalTimeline/timelineScene.ts
@@ -45,6 +45,29 @@ export interface SceneNote {
    *  in the runtime walk (`timelineMarks`), so this pure module never reads the
    *  editor IR. Optional so hand-built fixtures stay terse (treated as null). */
   readonly voice?: string | null
+  /** Char offset of this note's onset token in the evaluated source (`ev.loc[0]
+   *  .start`), or null when the event carries no location.
+   *
+   *  This is the note's link back to the code that produced it (#874). In the
+   *  retired DOM live view a drawn note WAS its `IREvent`, so `evt.loc[0].start`
+   *  was always in hand and click-to-source came free from identity. A
+   *  `SceneNote` is a PROJECTION — geometry kept, identity discarded — so the
+   *  link only exists if it is carried here ON PURPOSE. The offset is already in
+   *  scope at both push sites (the eval path reads the very same expression for
+   *  lane attribution), so this costs one field and nothing else.
+   *
+   *  REQUIRED, not optional like `voice`, and the difference is deliberate. A
+   *  missing `voice` has a benign meaning (group under `NO_VOICE`); a missing
+   *  `sourceOffset` silently re-drops the capability this field exists to
+   *  restore, which is precisely how it was lost the first time. Requiring it
+   *  means a future mark source CANNOT omit it without the compiler objecting —
+   *  the guarantee is structural rather than a convention that fails by absence.
+   *  Fixtures that don't care state `null`, which honestly says "no source".
+   *
+   *  null is a PRINCIPLED residual, not a gap: continuous/sampled signal haps
+   *  carry no `loc` (P274/#864), so they have no source token to point at and
+   *  fall back to lane-level jump. */
+  readonly sourceOffset: number | null
 }
 
 /**


### PR DESCRIPTION
Phase 1 of the three-phase plan filed on #874. Pure data — **nothing renders or clicks differently yet.** Phases 2 (the hit-test) and 3 (the wiring + un-skipping the spec) follow separately; this is deliberately the boring one.

## The problem

Clicking a note on the Song timeline used to jump the editor to that note's source. It stopped working when the live view moved from DOM to canvas, and no commit removed it — `git log -S` finds nothing to find.

In the DOM view a drawn note **was** its `IREvent`, so `evt.loc[0].start` was always in hand and click-to-source came free from identity. The canvas draws a `SceneNote` — a projection that kept the geometry and dropped the link. Nobody forgot the constraint; it was free under the old representation, so it was never a constraint at all.

The offset was never actually missing: `timelineMarks` holds the event at **both** push sites, and the eval path already reads `ev.loc?.[0]?.start` twenty lines later to attribute the note to a lane. It was computed, used, and thrown away.

## The fix

Carry it. `SceneNote.sourceOffset` is set from the event's location at both push sites, and the eval path now reads that offset **once** for the two questions it answers — which lane owns this note, and where its source is — instead of computing the same expression twice.

**The field is required, not optional like `voice`.** That difference is the point. A missing `voice` means something harmless (group under `NO_VOICE`); a missing `sourceOffset` silently re-drops the exact capability this field exists to restore. Required means a future mark source can't omit it without the compiler objecting — a guarantee that holds for someone who never read any of this. Fixtures that don't care say `null`, which honestly states "no source". The compiler also confirmed the enumeration was complete: every one of the 45 resulting errors was in a test, so those two push sites really are the only places production builds a `SceneNote`.

## Observed, not assumed

Evaluating through the **real transpiler** (the engine's own call shape) rather than reading the code:

```
note("c3 e3 g3")  → c3@[6,8]="c3"  e3@[9,11]="e3"  g3@[12,14]="g3"
stack(\n note("c3 e3"),\n s("bd*2")\n) → c3@[15,17]  e3@[18,20]  bd@[29,31]
```

Each hap's `loc[0]` lands exactly on its own token, in document coordinates, correctly across lines. (A first probe called `@strudel/core`'s bare `evaluate` and got mini-string-relative offsets — `[1,3]` → `"ot"` — which would have "proved" the offsets were garbage. The transpiler does the shifting; the instrument was wrong, not the data.)

## A residual worth knowing before phase 2

That same observation turned up something the plan didn't anticipate, and it **falsifies the "`[0]` is the innermost token" premise** I had started to write into the code:

| pattern | `locations` in order | note's own token |
|---|---|---|
| `note("c3 e3 g3")` | `"c3"` | `[0]` ✓ |
| `s("bd*2")` | `"bd"`, `"2"` | `[0]` ✓ |
| `.add(12)` / `.fast(2)` / `.rev()` | `"c3"` | `[0]` ✓ |
| `.add("<12 7>")` | **`"12"`**, `"c3"` | `[LAST]` ✗ |
| `n("0 2 4").scale("C:major")` | **`"major"`**, `"C"`, `"0"` | `[LAST]` ✗ |

A transform whose argument is a **mini string** contributes its own locations and they land first, so the note's token goes last. For `n("0 2 4").scale("C:major")` — a canonical idiom — all three notes report the same offset, the scale argument. The degree token each note wants is in the array, at the end.

`loc[0]` is kept here because it's what the filed plan specifies, it's correct for that plan's three acceptance cases, and it matches what `sourceByLane` already ships. That last point cuts both ways: **a scaled track's expand-to-bind (#422) anchors on its scale argument today**, same root, pre-existing.

Phase 2 has to decide which element to read — that's where the hit-test makes the choice observable end-to-end. A test pins the current behaviour explicitly as a known residual so that decision starts from a fact instead of an assumption; **it is meant to flip** when phase 2 picks a rule.

## Test plan

7 new tests, **each shown red before green** — this repo has shipped greens that couldn't fail, so every one was falsified:

- **Neuter both push sites to `null`** → 4 (now 5) fail; zero pre-existing tests break, so the arm isolates the field alone.
- **Invent an offset (`0`) instead of reporting `null`** → the two null-residual tests fail. They can't be caught by the arm above, so they get their own.
- **Read the outermost loc instead of `[0]`** → exactly 1 fails.

The load-bearing one asserts each note gets its **own** offset, diverging from its lane's shared anchor — a per-lane value would collapse every note to one destination, which is just the lane-level jump we already have.

- App suite: **724 passed** (717 + 7, reconciled)
- `tsc` clean; editor package untouched, so no dist rebuild
- Fixture edits are mechanical `sourceOffset: null` additions at compiler-flagged lines

Part of #874 (phase 1 of 3) — does not close it.
