### PR TITLE
🩹 fix(parity): make the fallback classifier tell the truth about cause (#897)

### DIFF
--- a/packages/app/tests/parity-corpus/_bakery-classify.spec.ts
+++ b/packages/app/tests/parity-corpus/_bakery-classify.spec.ts
@@ -17,6 +17,7 @@
 import { describe, it } from 'vitest'
 import fs from 'node:fs'
 import { parseStrudel } from '../../../editor/src/ir/parseStrudel'
+import { classifyFallback } from './classifyFallback'
 
 const SAMPLES = process.env.BAKERY_SAMPLES
 const RESULT = process.env.BAKERY_RESULT
@@ -40,26 +41,12 @@ function isCodeFallback(ir: unknown): boolean {
   return body.tag === 'Code' && (body as { via?: unknown }).via === undefined
 }
 
-/**
- * Coarse class label for a Code-fallback sample so NEW classes (beyond the
- * 6 just closed) surface for the backlog (D-03). Heuristic on the raw
- * source — deliberately shallow; the maintainer triages the printed list.
- */
-function classifyFallback(code: string): string {
-  const c = code
-  // Strip line comments so a class signature in a comment doesn't mis-bin.
-  const live = c.replace(/^\s*\/\/.*$/gm, '').trim()
-  if (/\$\{/.test(live)) return 'KNOWN ${} template-interpolation — D-04 correct Code-fallback (not a gap)'
-  if (/\btypeof\s+\w+\s*!==?\s*['"]undefined['"]\s*&&/.test(live)) return 'BACKLOG #143: guarded boot expr typeof X && X(...)'
-  if (/\bsamples\s*\(\s*\{/.test(live)) return 'BACKLOG #142: samples({...}) object-literal boot arg'
-  if (/^\s*\(\s*["'`]/.test(live) && /^\s*\./m.test(live)) return 'BACKLOG #144: parenthesized-root + leading-dot chain'
-  if (/\b(let|const|var)\s+[A-Za-z_$][\w$]*\s*=/.test(live)) return 'BACKLOG #141 (→#140): binding ref outside stack()-bare-arg'
-  if (/^\s*(import|export)\b/m.test(live)) return 'BACKLOG: ES module import/export at top level'
-  if (/=>/.test(live)) return 'KNOWN D-02: arrow-fn / functional shape — correct Code-fallback'
-  if (/\b(function|class)\b/.test(live)) return 'BACKLOG: function/class declaration'
-  if (live === '') return 'comment-only / empty program'
-  return 'NEW: uncategorised — needs manual triage (file an issue per AnviDev)'
-}
+// Cause attribution for a Code-fallback sample lives in `./classifyFallback`
+// (extracted + unit-tested in `classifyFallback.test.ts`). It previously
+// mis-attributed every binding-containing fallback to a phantom "#141 binding
+// ref" gap; the honest version detects the real causes (Hydra/DSP/lambda/def)
+// first and never claims binding resolution is the cause, because parseStrudel
+// resolves bindings. See that module's header for the full rationale.
 
 describe('bakery real-world classification (V-1, maintainer-driven)', () => {
   it(SAMPLES && RESULT ? 'classifies the fresh Supabase pull' : 'skipped (no BAKERY_SAMPLES env — CI inert)', () => {

--- a/packages/app/tests/parity-corpus/classifyFallback.test.ts
+++ b/packages/app/tests/parity-corpus/classifyFallback.test.ts
@@ -1,0 +1,91 @@
+/**
+ * classifyFallback.test.ts — the honesty gate for the parity backlog classifier.
+ *
+ * Every fixture is a REAL shape observed in the N≈360 Bakery sweep (the hashes
+ * are the actual samples), reduced to the smallest form that keeps its cause.
+ * The load-bearing assertions are the NEGATIVE ones: a Hydra sketch or a lambda
+ * that merely happens to contain a `let`/`const` must NOT be labelled a binding
+ * gap. Against the previous classifier (binding check ahead of Hydra/lambda/
+ * function detection) every one of these goes RED — which is the point.
+ *
+ * Pure string heuristic, no parser import → hermetic, runs in the CI gate.
+ */
+import { describe, it, expect } from 'vitest'
+import { classifyFallback } from './classifyFallback'
+
+describe('classifyFallback — honest cause attribution (#141 mis-attribution fix)', () => {
+  it('a Hydra sketch with a `let` is Hydra, NOT a binding gap (3LBt53ZvAcMz)', () => {
+    const code = `let randoming = slider(0.179,0,1)
+await initHydra()
+src(s2).thresh(0.6).scrollX(randoming).out()`
+    const cls = classifyFallback(code)
+    expect(cls).toContain('Hydra')
+    expect(cls).not.toMatch(/binding ref|#141/)
+  })
+
+  it('floatbeat DSP is DSP, not a binding gap (3HWHF_ZUbZD_)', () => {
+    const code = 'await dough`\nlet f\nlet dsp = (t) => f ? f(t)&255 : 0\n`\ns(cat("t>>6^t&t>>9"))'
+    const cls = classifyFallback(code)
+    expect(cls).toContain('DSP')
+    expect(cls).not.toMatch(/binding ref|#141/)
+  })
+
+  it('an arrow-fn/lambda pattern with a `const` is functional, NOT binding (3y6ivMTsJ5PA)', () => {
+    const code = `const setbpm = t => setcps(t/4/60)
+const tempo = 175
+setbpm(tempo)
+s("bd*4").sometimesBy(1/8, x => x.room(1.6))`
+    const cls = classifyFallback(code)
+    expect(cls).toMatch(/functional|lambda/)
+    expect(cls).not.toMatch(/binding ref|#141/)
+  })
+
+  it('a `function`/`register` definition is a definition, NOT binding (1rFTPRnSH8bN)', () => {
+    const code = `function arrangePrime(...parts) {
+  let offset = 0
+  return stack(...parts)
+}
+arrangePrime([1, s("bd")])`
+    const cls = classifyFallback(code)
+    expect(cls).toMatch(/function|register|definition/)
+    expect(cls).not.toMatch(/binding ref|#141/)
+  })
+
+  it('an unmodelled combinator with string bindings is a STRUCTURAL residual, not binding-ref (42r0gryaJB8N)', () => {
+    // stepcat is the real blocker; the `let measure1 = "…"` bindings resolve.
+    const code = `setcpm(60/5)
+let measure1 = "[c5]@2"
+let measure2 = "[d5]@2"
+let melody = note(stepcat(measure1, measure2)).pace(8)
+stack(melody, sound("hh!5"))`
+    const cls = classifyFallback(code)
+    // Must NOT claim binding resolution is the cause…
+    expect(cls).not.toMatch(/binding ref|#141/)
+    // …and must say bindings resolve, pointing at other structure.
+    expect(cls).toMatch(/bindings RESOLVE|structural residual/)
+  })
+
+  it('still catches the genuine boot-shape gaps', () => {
+    expect(classifyFallback('typeof foo !== "undefined" && foo()')).toContain('#143')
+    expect(classifyFallback('samples({ bd: "bd.wav" })\ns("bd")')).toContain('#142')
+  })
+
+  it('comment-only / empty program', () => {
+    expect(classifyFallback('// just a note\n/* nothing here */')).toMatch(/comment-only|empty/)
+  })
+
+  it('tiers every label as CORRECT-FALLBACK or GAP (no un-tiered leakage)', () => {
+    const samples = [
+      'await initHydra()\nosc(5).out()',
+      'await dough`let f`\ns("bd")',
+      'const f = x => x.fast(2)\ns("bd").apply(f)',
+      'function foo(){}\ns("bd")',
+      'typeof x !== "undefined" && x()',
+      'samples({ bd: "x" })\ns("bd")',
+      'let a = 1\nweirdCombinator(a)',
+    ]
+    for (const s of samples) {
+      expect(classifyFallback(s)).toMatch(/^(CORRECT-FALLBACK|GAP|comment-only)/)
+    }
+  })
+})

--- a/packages/app/tests/parity-corpus/classifyFallback.ts
+++ b/packages/app/tests/parity-corpus/classifyFallback.ts
@@ -1,0 +1,115 @@
+/**
+ * classifyFallback — honest cause attribution for a Code-fallback pattern.
+ *
+ * WHY THIS EXISTS AS ITS OWN MODULE (extracted from `_bakery-classify.spec.ts`):
+ * the parity sampler's backlog is only as trustworthy as this function, and the
+ * previous version silently mis-attributed. It ended with a last-resort arm
+ *
+ *     if (/\b(let|const|var)\s+…=/.test(live)) return '…binding ref outside stack…'
+ *
+ * that fired on ANY fallback merely *containing* a `const`/`let`/`var`. Reading
+ * the real patterns it bucketed (N≈360 sweep, 20 hits) showed the binding was
+ * incidental in every one: they fall back for Hydra visual code, floatbeat DSP,
+ * arrow-fn/lambda, `function`/`register` definitions, or an unmodelled combinator.
+ * And `parseStrudel` ALREADY resolves `const`/`let`/`var` bindings — transitive
+ * chains and refs in every position (receiver, numeric arg, whole-expr) included,
+ * directly verified. So a "binding ref" gap does not exist, and labelling one
+ * sent the roadmap chasing a phantom (the whole point of #874/#880's lesson: an
+ * instrument that lies is worse than no instrument).
+ *
+ * THE HONEST DESIGN:
+ *   1. Detect the CORRECT-BY-NATURE fallbacks first — patterns that have no
+ *      musical timeline to show at all (Hydra visual, DSP synthesis, lambdas,
+ *      function/class defs). These are not gaps; a better parser cannot "fix"
+ *      a pattern that isn't music. Recognising them is what stops them being
+ *      counted as addressable work.
+ *   2. Then the genuine, addressable GAPs (boot-shape fences #142/#143, module
+ *      syntax, parenthesised-root).
+ *   3. There is NO "binding ref" bucket. If a fallback still has a binding and
+ *      nothing above matched, it is a STRUCTURAL residual (e.g. an unmodelled
+ *      combinator like `stepcat`, or a side-effect statement before the
+ *      bindings) — labelled so it CANNOT be misread as a ref-resolution gap.
+ *
+ * Text-only heuristic by design (no parser dependency → hermetic, no gifenc
+ * barrel). It runs on already-known fallbacks, so it only has to name the cause,
+ * not decide the verdict. Precision over recall: a wrong label is worse than a
+ * `triage` label, because a wrong label becomes a roadmap item.
+ */
+
+/** Strip comments so a construct named in prose can't trip a detector. Removes
+ *  block comments and FULL-LINE `//` comments only — never inline `//`, which
+ *  would eat the `//` in a `https://…` URL that Hydra sketches routinely carry. */
+function stripComments(code: string): string {
+  return code
+    .replace(/\/\*[\s\S]*?\*\//g, '') // block comments
+    .replace(/^\s*\/\/.*$/gm, '') // full-line // comments
+    .trim()
+}
+
+/** Hydra visual code. `.out()` is the decisive tell — it is Hydra's render sink
+ *  and no Strudel pattern method; `initHydra` is the other unambiguous marker.
+ *  Either alone is conclusive, so we don't need the noisier `osc(`/`noise(`
+ *  (which collide with Strudel signal names). */
+function isHydra(live: string): boolean {
+  return /\binitHydra\b/.test(live) || /\.out\s*\(\s*\)/.test(live)
+}
+
+/** Floatbeat / bytebeat DSP: a raw sample-generating function fed to `dough`,
+ *  or a `Function(...)` built from a string. No note structure by construction. */
+function isDsp(live: string): boolean {
+  return /\bdough\s*`/.test(live) || /\bFunction\s*\(/.test(live)
+}
+
+/** Arrow function anywhere — a lambda has no view metaphor, so a pattern whose
+ *  musical body is a lambda is a correct fallback, not a gap. */
+function isLambda(live: string): boolean {
+  return /=>/.test(live)
+}
+
+/** A top-level `function`/`class` definition or a `register(...)` custom method. */
+function isDefinition(live: string): boolean {
+  return /\bfunction\b/.test(live) || /\bclass\b/.test(live) || /\bregister\s*\(/.test(live)
+}
+
+function hasBinding(live: string): boolean {
+  return /\b(?:let|const|var)\s+[A-Za-z_$][\w$]*\s*=/.test(live)
+}
+
+export function classifyFallback(code: string): string {
+  const live = stripComments(code)
+  if (live === '') return 'comment-only / empty program'
+
+  // ORDER: correct-by-nature BEFORE addressable gaps, deliberately. A pattern is
+  // only an "addressable gap" if the named fix would ACTUALLY recover it. A Hydra
+  // sketch that also happens to call `samples({…})` is not recovered by fixing
+  // #142 — it has no musical timeline regardless — so it belongs in the CORRECT
+  // tier, not counted as gap work. Attributing to the fundamental cause first is
+  // what keeps the GAP count honest (the inverse error of the old binding arm,
+  // which over-counted; this could under-count, so correct-by-nature must be a
+  // TRUE non-recoverable signal — Hydra `.out()`, a lambda body, raw DSP).
+
+  // --- CORRECT-BY-NATURE fallbacks (no musical timeline exists; not gaps) ---
+  if (isHydra(live)) return 'CORRECT-FALLBACK: Hydra/visual (no musical timeline by nature)'
+  if (isDsp(live)) return 'CORRECT-FALLBACK: DSP/floatbeat synthesis (no note structure)'
+  if (/\$\{/.test(live)) return 'CORRECT-FALLBACK: ${} template-interpolation'
+  if (isLambda(live)) return 'CORRECT-FALLBACK: functional/lambda (no view metaphor)'
+  if (isDefinition(live)) return 'CORRECT-FALLBACK: function/class/register definition'
+
+  // --- ADDRESSABLE GAPS (a better parser or a fence widening would recover) ---
+  if (/\btypeof\s+\w+\s*!==?\s*['"]undefined['"]\s*&&/.test(live))
+    return 'GAP #143: guarded boot expr typeof X && X(...)'
+  if (/\bsamples\s*\(\s*\{/.test(live)) return 'GAP #142: samples({...}) object-literal boot arg'
+  if (/^\s*(import|export)\b/m.test(live)) return 'GAP: ES module import/export at top level'
+  if (/^\s*\(\s*["'`]/.test(live) && /^\s*\./m.test(live))
+    return 'GAP #144: parenthesized-root + leading-dot chain'
+
+  // --- structural residual. NOT a binding-ref gap: parseStrudel resolves
+  // const/let/var + transitive chains + refs in every position (verified). A
+  // fallback that still has a binding fell back for OTHER structure — an
+  // unmodelled combinator (e.g. `stepcat`), a side-effect statement before the
+  // bindings, etc. Labelled so it can never be misread as ref-resolution work. ---
+  if (hasBinding(live))
+    return 'GAP: structural residual (bindings RESOLVE — real cause is other structure, e.g. unmodelled combinator; triage)'
+
+  return 'GAP: uncategorised — needs triage'
+}


### PR DESCRIPTION
Fixes the instrument this session kept getting misled by. Closes #897.

## The problem

The parity sampler's cause classifier (`_bakery-classify.spec.ts`) ended with a last-resort arm:

```js
if (/\b(let|const|var)\s+…=/.test(live)) return '…binding ref outside stack()-bare-arg'
```

It returned "binding ref" for **any** Code-fallback whose source merely *contained* a `let`/`const`/`var`. That made binding-ref look like the dominant real-world blocker (~59% of fallbacks) and pointed the roadmap at a fix that does nothing.

Two things make it a phantom:
- **`parseStrudel` already resolves bindings** — `const`/`let`/`var`, transitive 3-hop chains, method-ref chains, and refs in every position (receiver, numeric arg, whole-expr). Verified directly against the parser.
- **Reading the 20 patterns it bucketed as "binding"**, the binding was incidental in every one. They fall back for Hydra visual code (`initHydra`/`.out()`), floatbeat DSP (`` dough`…` ``/`Function(…)`), arrow-fn/lambda, `function`/`register` definitions, or an unmodelled combinator (`stepcat`).

## The fix

Extract `classifyFallback` into a hermetic module and attribute the **real** cause:

1. **Correct-by-nature fallbacks first** — Hydra, DSP, lambda, function/class/register. These have no musical timeline by nature; no parser work recovers them, so they are not gaps.
2. **Then the addressable gaps** — `#142` samples-objlit, `#143` guarded-boot, module syntax, paren-root.
3. **No "binding ref" bucket.** A fallback that still carries a binding is a *structural residual* whose label states plainly that the bindings resolve and the real cause is other structure.

Ordering is correct-by-nature-first on purpose: a gap only counts if the named fix would *actually* recover the pattern — which keeps the GAP tally from over-counting the way the binding arm did (the inverse of the old error).

## Verification

- **`classifyFallback.test.ts`** pins the honest labels against real observed shapes (the fixture hashes are the actual samples). Shown **RED against the old logic (7/8 fail) → GREEN (8/8)**. Hermetic (no parser import), so it runs in the CI gate — the classifier's honesty is now a permanent regression test.
- Parity CI suite **123 passed**; `tsc` clean.
- **Live N=360 sweep, before → after:**

| before (phantom) | after (honest) |
|---|---|
| #141 binding: **20/34 (#1)** | binding: **0** (bucket removed) |
| — | functional/lambda 12, Hydra 8, DSP 2 → **22/34 correct-by-nature** |
| — | 6 triage + 4 structural residual + 2 samples-objlit → **12/34 addressable** |

The headline the backlog now tells: ~65% of fallbacks are correct-by-nature (no timeline exists), and the addressable remainder is dominated by individual triage, **not** binding resolution. The metric no longer points at a wall that isn't there.
