### PR TITLE
🐛 fix(ci): stop Turbo replaying the build Vercel needs to actually run (#909)

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,41 @@
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**", "!.next/cache/**"]
     },
+    // The app's build is the one Vercel hooks, and it must NOT be cached.
+    //
+    // Vercel's Next.js integration injects `onBuildComplete` into the running
+    // `next build` to collect output into /vercel/output. Our deploy runs
+    // `turbo run build --filter=@stave/app` (packages/app/vercel.json), and on
+    // a cache hit Turbo REPLAYS the recorded log text instead of executing the
+    // task — so `Running onBuildComplete from Vercel` is PRINTED while the hook
+    // never fires. No output is collected and the deploy errors, after emitting
+    // a log that reads, end to end, like a success (#909).
+    //
+    // Measured here, same inputs, twice in a row:
+    //   run 1  cache miss, executing  -> 33s
+    //   run 2  cache hit, replaying   -> 25ms >>> FULL TURBO
+    // A 33-second build does not happen in 25ms. Nothing ran.
+    //
+    // It bites MERGES specifically: a squash-merge lands content Vercel already
+    // built on the PR branch, so the hash matches, the cache hits, and the
+    // deploy dies — which is why studio went red about half the time while the
+    // code was fine.
+    //
+    // `dependsOn` is REPEATED here on purpose. A package-specific task REPLACES
+    // the base config rather than merging into it — verified: a bare
+    // `{ "cache": false }` runs "Tasks: 1 successful, 1 total" (the editor never
+    // builds) instead of 2, which would quietly ship the app against a stale
+    // @stave/editor dist. Do not drop this line.
+    //
+    // `outputs` is intentionally absent: with caching off there is nothing to
+    // save or restore, so listing them would only imply otherwise.
+    //
+    // The cost is the ~1m this cache was "saving" while producing broken
+    // deploys. The editor's build stays cached — it is not what Vercel hooks.
+    "@stave/app#build": {
+      "dependsOn": ["^build"],
+      "cache": false
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
Closes #909. Off `studio_v0.2.0` — independent of the notation stack (#906/#908).

#909 diagnosed this precisely and marked the fixes **unverified**. I verified the mechanism, took fix (1) — and found a trap in it that would have shipped a second, quieter bug.

## The mechanism, reproduced locally

Same inputs, twice in a row, no Vercel involved:

| run | `@stave/app:build` | time |
|---|---|---|
| 1 | `cache miss, executing` | **33s** |
| 2 | `cache hit, replaying logs` | **25ms** `>>> FULL TURBO` |

A 33-second build does not happen in 25ms. **Nothing ran.** Turbo replays the recorded log text, so `Running onBuildComplete from Vercel` gets *printed* while the hook never *fires* — Vercel collects no output and the deploy errors, after emitting a log that reads end-to-end like a success.

## The fix — and the trap inside it

`@stave/app#build` → `"cache": false`. The app's build is the one Vercel hooks; it must execute. The editor's build stays cached (it isn't hooked), so it keeps its ~30s.

**But `dependsOn: ["^build"]` has to be repeated on the override**, and this is load-bearing rather than cosmetic. A package-specific task **replaces** the base config instead of merging into it. Verified by running the literal suggestion:

```
@stave/app#build: { "cache": false }     →  Tasks: 1 successful, 1 total
```

**One task, not two — the editor never builds.** Applied as written, fix (1) would have quietly shipped the app against a stale `@stave/editor` dist. The committed override repeats `dependsOn` and says why, at the site.

`outputs` is omitted deliberately: with caching off there is nothing to save or restore, so listing them would only imply otherwise.

## Verification

With the fix and a deliberately **warm** cache — the exact condition that breaks merges:

```
@stave/app:build    cache bypass, force executing    →  30s
@stave/editor:build cache hit, replaying logs            (still cached, as intended)
Tasks: 2 successful, 2 total                             (dependsOn preserved)
```

**Armed both ways:** reverting the override with the same warm cache brings `cache hit, replaying logs` straight back; restoring it returns `cache bypass`. The revert run also shows the mechanism in the act — it prints `> next build` while executing nothing, which is exactly what makes the broken deploy look green.

### Scope of this proof, stated plainly

What is verified here is the **Turbo half**: the task now executes where it used to be replayed. The **Vercel half** — that `onBuildComplete` fires when the task actually runs — rests on the 4/4 correlation recorded in #909 (cache hit → Error, cache miss → Ready, with controls both ways and nothing else differing). I can't deploy from here. **The real proof is the next deploy**, and I'd rather say that than imply I tested it.

## Two corrections to #909

1. **The assertion string in the issue won't match.** #909 says to check for `@stave/app:build: cache miss, executing`. `cache: false` produces **`cache bypass, force executing`** — a different string. Anyone verifying against the issue's text would conclude the fix didn't work.
2. Its fix (1), taken literally, drops `dependsOn` (above).

Both are worth knowing because #909's own advice is right about the important part: **do not assert on a green build log.** A green log is exactly what the broken deploy already prints. The honest signals are the duration and the cache line.

## Note on the merge gate

Per #909: a red Vercel on a PR does **not** reliably mean the PR is broken, and #906's genuinely-broken deploy looked identical from the outside. That ambiguity is the real cost here, and it's why **#908 is currently blocked on a false red** — this should unblock it.

## Not in this PR

The working tree carries an unrelated `turbo.json` edit from another session (adding `docs-dist/**` to `build.outputs`) and a `.gitignore` change. **Neither is included** — this commit touches only the `@stave/app#build` key. Flagging it because we're editing the same file and a merge should expect it.
