### PR TITLE
✅ test(notation): pin the round-trip law and the notation it loses today (#903)

### DIFF
--- a/packages/app/tests/parity-corpus/__snapshots__/round-trip.test.ts.snap
+++ b/packages/app/tests/parity-corpus/__snapshots__/round-trip.test.ts.snap
@@ -1,0 +1,1630 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`round-trip — an unedited open→write must not change the text > grid: KNOWN RESIDUAL — these are rewritten today and MUST flip (#903 A2) > grid-rewritten-residual 1`] = `
+[
+  ""  [ a4 ~ ~ a4] [ a4 ~ a4 ~]  [ a4 ~ ~ a4 ]  [ a4 ~ a4 a4 ]*2 "
+  -> "a4 ~ ~ ~ ~ ~ a4 ~ a4 ~ ~ ~ a4 ~ ~ ~ a4 ~ ~ ~ ~ ~ a4 ~ a4 ~ a4 a4 a4 ~ a4 a4"",
+  "" <c2*2 g2*5 [a g]>"
+  -> "<[c2 ~ ~ ~ ~ c2 ~ ~ ~ ~] [g2 ~ g2 ~ g2 ~ g2 ~ g2 ~] [a ~ ~ ~ ~ g ~ ~ ~ ~]>"",
+  "" bd hh*2 sd cp "
+  -> "bd ~ hh hh sd ~ cp ~"",
+  "" d - d e f - d - d e f - a - a b c4 - a - c4 b "
+  -> "d ~ d e f ~ d ~ d e f ~ a ~ a b c4 ~ a ~ c4 b"",
+  ""- - - - - - - oh - oh - - - - - - "
+  -> "~ ~ ~ ~ ~ ~ ~ oh ~ oh ~ ~ ~ ~ ~ ~"",
+  ""- - - [timp timp]"
+  -> "~ ~ ~ ~ ~ ~ timp timp"",
+  ""- - f*2 - -"
+  -> "~ ~ ~ ~ f f ~ ~ ~ ~"",
+  ""- cp"
+  -> "~ cp"",
+  ""- hh - sd"
+  -> "~ hh ~ sd"",
+  ""- move"
+  -> "~ move"",
+  ""- move*2"
+  -> "~ ~ move move"",
+  ""- rim - rim"
+  -> "~ rim ~ rim"",
+  ""- sd"
+  -> "~ sd"",
+  ""- sd - sd"
+  -> "~ sd ~ sd"",
+  ""- sd:2"
+  -> "~ sd:2"",
+  ""- you_can_say_anything_you_want"
+  -> "~ you_can_say_anything_you_want"",
+  ""< [g6, e6] [f6, d6] [e6, c6] [a5, b5] >"
+  -> "<[g6,e6] [f6,d6] [e6,c6] [a5,b5]>"",
+  ""< passerine_basse:2 [~ passerine_basse:2 passerine_basse:2 ~ ~ ~ passerine_basse:3 ~] >"
+  -> "<[passerine_basse:2 ~ ~ ~ ~ ~ ~ ~] [~ passerine_basse:2 passerine_basse:2 ~ ~ ~ passerine_basse:3 ~]>"",
+  ""< passerine_kick [~ passerine_kick passerine_kick ~ ~ ~ passerine_kick ~] >"
+  -> "<[passerine_kick ~ ~ ~ ~ ~ ~ ~] [~ passerine_kick passerine_kick ~ ~ ~ passerine_kick ~]>"",
+  ""< sawtooth square sawtooth triangle >"
+  -> "<sawtooth square sawtooth triangle>"",
+  ""<- - dog - -!24>"
+  -> "<~ ~ dog ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~>"",
+  ""<- c5>"
+  -> "<~ c5>"",
+  ""<- cp:1>"
+  -> "<~ cp:1>"",
+  ""<- sd>"
+  -> "<~ sd>"",
+  ""<- white - [- white]>"
+  -> "<~ [white ~] ~ [~ white]>"",
+  ""<G#2!3 C2>"
+  -> "<G#2 G#2 G#2 C2>"",
+  ""<[A2, C#3, E3] A3 G#3 G3 [D3, F#3] B3 C#3 E3 D#3>"
+  -> "<[A2,C#3,E3] A3 G#3 G3 [D3,F#3] B3 C#3 E3 D#3>"",
+  ""<[b2 b3]*4 [a2 a3]*4 >"
+  -> "<[b2 b3 b2 b3 b2 b3 b2 b3] [a2 a3 a2 a3 a2 a3 a2 a3]>"",
+  ""<[c2 c3]*4 [bb1 bb2]*2 [f2 f3]*4 [eb2 eb3]*2>"
+  -> "<[c2 c3 c2 c3 c2 c3 c2 c3] [bb1 ~ bb2 ~ bb1 ~ bb2 ~] [f2 f3 f2 f3 f2 f3 f2 f3] [eb2 ~ eb3 ~ eb2 ~ eb3 ~]>"",
+  ""<[c2 c3]*4 [bb1 bb2]*4 [f2 f3]*4 [eb2 eb3]*2>"
+  -> "<[c2 c3 c2 c3 c2 c3 c2 c3] [bb1 bb2 bb1 bb2 bb1 bb2 bb1 bb2] [f2 f3 f2 f3 f2 f3 f2 f3] [eb2 ~ eb3 ~ eb2 ~ eb3 ~]>"",
+  ""<[c2 c3]*4 [bb1 bb2]*4 [f2 f3]*4 [eb2 eb3]*4>"
+  -> "<[c2 c3 c2 c3 c2 c3 c2 c3] [bb1 bb2 bb1 bb2 bb1 bb2 bb1 bb2] [f2 f3 f2 f3 f2 f3 f2 f3] [eb2 eb3 eb2 eb3 eb2 eb3 eb2 eb3]>"",
+  ""<[c2,e2] [a1,d2] [g1,c2] [f1,a1]>"
+  -> "<[c2,e2] [a1,d2] [c2,g1] [a1,f1]>"",
+  ""<[c3,eb3,g3] [g2,bb2,d3] [ab2,c3,eb3] [f2,ab2,c3]>"
+  -> "<[c3,eb3,g3] [g2,bb2,d3] [c3,eb3,ab2] [c3,ab2,f2]>"",
+  ""<[c3,g3,e4] [bb2,f3,d4] [a2,f3,c4] [bb2,g3,eb4]>"
+  -> "<[c3,g3,e4] [bb2,f3,d4] [f3,a2,c4] [g3,bb2,eb4]>"",
+  ""<[c4,e4,g4] [a3,d4,f4] [g3,c4,e4] [f3,a3,c4]>"
+  -> "<[c4,e4,g4] [a3,d4,f4] [c4,e4,g3] [c4,a3,f3]>"",
+  ""<[c5, e5] [d5, f5] [e5, g5] [f5, a5]>"
+  -> "<[c5,e5] [d5,f5] [e5,g5] [f5,a5]>"",
+  ""<[d4,f4,bb4] [f4,bb4,d5] [c4,f4,ab4] [eb4,ab4,c5]>"
+  -> "<[d4,f4,bb4] [f4,bb4,d5] [f4,c4,ab4] [ab4,eb4,c5]>"",
+  ""<[ht bd~][ht bd~][ht bd~]>"
+  -> "<[ht bd~] [ht bd~] [ht bd~]>"",
+  ""<bd sd bd sd bd sd [bd bd] sd>"
+  -> "<[bd ~] [sd ~] [bd ~] [sd ~] [bd ~] [sd ~] [bd bd] [sd ~]>"",
+  ""<bd*4 [bd cp]*4>"
+  -> "<[bd ~ bd ~ bd ~ bd ~] [bd cp bd cp bd cp bd cp]>"",
+  ""<c4 ->"
+  -> "<c4 ~>"",
+  ""<eb*3 c*3>"
+  -> "<[eb eb eb] [c c c]>"",
+  ""<eb2*3 a2*3 c2*3 a2*3 >"
+  -> "<[eb2 eb2 eb2] [a2 a2 a2] [c2 c2 c2] [a2 a2 a2]>"",
+  ""<ethnic_st:2!3 ethnic_st:1>"
+  -> "<ethnic_st:2 ethnic_st:2 ethnic_st:2 ethnic_st:1>"",
+  ""<gm_sitar>"
+  -> "gm_sitar"",
+  ""<lp:1!8 - lp:11!8>"
+  -> "<lp:1 lp:1 lp:1 lp:1 lp:1 lp:1 lp:1 lp:1 ~ lp:11 lp:11 lp:11 lp:11 lp:11 lp:11 lp:11 lp:11>"",
+  ""<o1>"
+  -> "o1"",
+  ""<o3 o4!8>"
+  -> "<o3 o4 o4 o4 o4 o4 o4 o4 o4>"",
+  ""<rim>"
+  -> "rim"",
+  ""<sawtooth!16 pulse!8>"
+  -> "<sawtooth sawtooth sawtooth sawtooth sawtooth sawtooth sawtooth sawtooth sawtooth sawtooth sawtooth sawtooth sawtooth sawtooth sawtooth sawtooth pulse pulse pulse pulse pulse pulse pulse pulse>"",
+  ""<sawtooth(3,8)  sine(5,8)>"
+  -> "<[sawtooth ~ ~ sawtooth ~ ~ sawtooth ~] [sine ~ sine sine ~ sine sine ~]>"",
+  ""<sawtooth>"
+  -> "sawtooth"",
+  ""<sine>"
+  -> "sine"",
+  ""<triangle>"
+  -> "triangle"",
+  ""<water>"
+  -> "water"",
+  ""<yoda>"
+  -> "yoda"",
+  ""<~ ~ [~ cp]*2 [~ cp]*2 cp*4 [~ cp]*2>"
+  -> "<~ ~ [~ cp ~ cp] [~ cp ~ cp] [cp cp cp cp] [~ cp ~ cp]>"",
+  ""<~ ~ hh ~ hh*2 hh*4>"
+  -> "<~ ~ [hh ~ ~ ~] ~ [hh ~ hh ~] [hh hh hh hh]>"",
+  ""A1 A1 [A1 ~ ~ A1] [~ ~ A1 ~]"
+  -> "A1 ~ ~ ~ A1 ~ ~ ~ A1 ~ ~ A1 ~ ~ A1 ~"",
+  ""A1!4"
+  -> "A1 A1 A1 A1"",
+  ""A1!8"
+  -> "A1 A1 A1 A1 A1 A1 A1 A1"",
+  ""A2 A2, A1 A1, E2, E1"
+  -> "A2 A2, A1 A1, E2 ~, E1 ~"",
+  ""A3 C4 -"
+  -> "A3 C4 ~"",
+  ""E3 E3 [E3 f3] E3 "
+  -> "E3 ~ E3 ~ E3 f3 E3 ~"",
+  ""F [D F A] [C E A]"
+  -> "F ~ ~ D F A C E A"",
+  ""G1 [G1 D2] C1 C1 G1 G1 A1 [D1 F#1]"
+  -> "G1 ~ G1 D2 C1 ~ C1 ~ G1 ~ G1 ~ A1 ~ D1 F#1"",
+  ""YamahaRY30_bd:2*4"
+  -> "YamahaRY30_bd:2 YamahaRY30_bd:2 YamahaRY30_bd:2 YamahaRY30_bd:2"",
+  ""[ ~  ~ [a4,c5,e5] ~ ] [ ~  ~ [a4,c5,e5] ~ ] [ ~  ~ [a4,c5,e5] ~ ]  [ ~ ~ ~ [g4,c5,e5]]"
+  -> "~ ~ [a4,c5,e5] ~ ~ ~ [a4,c5,e5] ~ ~ ~ [a4,c5,e5] ~ ~ ~ ~ [c5,e5,g4]"",
+  ""[ ~ ~ [a4,c5,e5] ~]  [ ~ ~ [a4,c5,e5] ~]  [ ~ ~ [a4,c5,e5] ~] [ ~ ~ ~ [g4,c5,e5]]"
+  -> "~ ~ [a4,c5,e5] ~ ~ ~ [a4,c5,e5] ~ ~ ~ [a4,c5,e5] ~ ~ ~ ~ [c5,e5,g4]"",
+  ""[- - sd -]*2"
+  -> "~ ~ sd ~ ~ ~ sd ~"",
+  ""[- cp]*2"
+  -> "~ cp ~ cp"",
+  ""[- crate_hh]*2"
+  -> "~ crate_hh ~ crate_hh"",
+  ""[- oh:4]*4"
+  -> "~ oh:4 ~ oh:4 ~ oh:4 ~ oh:4"",
+  ""[- sd]*2"
+  -> "~ sd ~ sd"",
+  ""[A0 E0] [C1 E0] [D1 E1] ~"
+  -> "A0 E0 C1 E0 D1 E1 ~ ~"",
+  ""[A1 E1] [C2 E1] [D2 E2] [Cb2 C2]"
+  -> "A1 E1 C2 E1 D2 E2 Cb2 C2"",
+  ""[B3] [E3] [B3] [A3], ~ E2 ~ E2"
+  -> "B3 E3 B3 A3, ~ E2 ~ E2"",
+  ""[C Eb] [G Bb] [D2 F A]"
+  -> "C ~ ~ Eb ~ ~ G ~ ~ Bb ~ ~ D2 ~ F ~ A ~"",
+  ""[C2 ~ ~ G1]"
+  -> "C2 ~ ~ G1"",
+  ""[G4, C4] [G4, Eb4] [F4, A3, Eb4]"
+  -> "[G4,C4] [G4,Eb4] [Eb4,F4,A3]"",
+  ""[a1][a1][e1][fs1] [d1][fs1][d1][e1]"
+  -> "a1 a1 e1 fs1 d1 fs1 d1 e1"",
+  ""[a2, e3, cs3][a2, e3, c3][e2, g3, b3][fs2, cs3, as3]  [d2, f3, a3][fs2, cs3, as3][d2, f3, a3][e2, gs3, b3, d3]"
+  -> "[a2,e3,cs3] [a2,e3,c3] [e2,g3,b3] [cs3,fs2,as3] [d2,f3,a3] [cs3,fs2,as3] [d2,f3,a3] [e2,b3,gs3,d3]"",
+  ""[a3:0.7 a3:0.3] ~ [a3:0.7 a3:0.3] ~"
+  -> "a3:0.7 a3:0.3 ~ ~ a3:0.7 a3:0.3 ~ ~"",
+  ""[a4, f#4, d4, b3, g3][b4, g#4, e4, c#4, a3][c5, a4, f4, d4, bb3][b4, g#4, e4, c#4, a3, e3]"
+  -> "[a4,f#4,d4,b3,g3] [b4,g#4,e4,c#4,a3] [a4,d4,c5,f4,bb3] [b4,g#4,e4,c#4,a3,e3]"",
+  ""[a4,c#4,e4,g#4,c#5],[~ f#6 e6]"
+  -> "[a4,c#4,e4,g#4,c#5] ~ ~, ~ f#6 e6"",
+  ""[a4,c#4,e4,g#4,c#5],c#6"
+  -> "[a4,c#4,e4,g#4,c#5], c#6"",
+  ""[b4,d4,f#4],b5*3 c#6*2"
+  -> "[b4,d4,f#4] ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~, b5 ~ b5 ~ b5 ~ c#6 ~ ~ c#6 ~ ~"",
+  ""[bd -  -  bd -  -  bd -  ]*2"
+  -> "bd ~ ~ bd ~ ~ bd ~ bd ~ ~ bd ~ ~ bd ~"",
+  ""[bd bd] [bd bd] [bd bd] [bd bd]"
+  -> "bd bd bd bd bd bd bd bd"",
+  ""[bd hh]*4"
+  -> "bd hh bd hh bd hh bd hh"",
+  ""[bd ~]*2"
+  -> "bd ~ bd ~"",
+  ""[bd ~]*2, [~ hh]*2, ~ sd"
+  -> "bd ~ bd ~, ~ hh ~ hh, ~ ~ sd ~"",
+  ""[bd,fx]*4"
+  -> "[bd,fx] [bd,fx] [bd,fx] [bd,fx]"",
+  ""[c#4 d4 d4 c#4]"
+  -> "c#4 d4 d4 c#4"",
+  ""[c4,e4,g4,b4][g#4,c4,d#4,g4][g4,b4,d4,f4][c4,e4,g4,c4]"
+  -> "[c4,e4,g4,b4] [c4,g4,g#4,d#4] [g4,b4,d4,f4] [c4,e4,g4]"",
+  ""[c4,e4,g4,c5]*2"
+  -> "[c4,e4,g4,c5] [c4,e4,g4,c5]"",
+  ""[c5 d5 e5 g5]"
+  -> "c5 d5 e5 g5"",
+  ""[c5 d5 f5 g#5 a5 g#5 f5]*2"
+  -> "c5 d5 f5 g#5 a5 g#5 f5 c5 d5 f5 g#5 a5 g#5 f5"",
+  ""[c5 f#5 a5 g5]*2"
+  -> "c5 f#5 a5 g5 c5 f#5 a5 g5"",
+  ""[drumloop_170:2 drumloop_170:6 drumloop_170:2 drumloop_170:6 ]"
+  -> "drumloop_170:2 drumloop_170:6 drumloop_170:2 drumloop_170:6"",
+  ""[e f]*4"
+  -> "e f e f e f e f"",
+  ""[e4 f#4 f#4 e4]"
+  -> "e4 f#4 f#4 e4"",
+  ""[g#2][f2][c#2][c2]"
+  -> "g#2 f2 c#2 c2"",
+  ""[g#4 -] [g#4 - ] c# d# - g#3 g#5 - - - - - - - - -"
+  -> "g#4 ~ g#4 ~ c# ~ d# ~ ~ ~ g#3 ~ g#5 ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~"",
+  ""[g#4 ~ ~ ~]"
+  -> "g#4 ~ ~ ~"",
+  ""[g4 d4 b3][f#4 c4 a3][e4 b3 g3][d4 a3 f#3]"
+  -> "g4 d4 b3 f#4 c4 a3 e4 b3 g3 d4 a3 f#3"",
+  ""[g4 f#4 g4 e4 d4 e4 c4 d4]"
+  -> "g4 f#4 g4 e4 d4 e4 c4 d4"",
+  ""[g4,g#4,c5,d5,d#5][f4,a4,b4,c5,e5][c#4,f4,g4,g#4,c5][c4,e4,g4,b4]"
+  -> "[g4,g#4,c5,d5,d#5] [c5,f4,a4,b4,e5] [g4,g#4,c5,f4,c#4] [g4,b4,c4,e4]"",
+  ""[g5 c4] [d5 fb4] [gm4 c5] [a4]"
+  -> "g5 c4 d5 fb4 gm4 c5 a4 ~"",
+  ""[oh hh hh] oh hh sd"
+  -> "oh hh hh oh ~ ~ hh ~ ~ sd ~ ~"",
+  ""[oh hh oh hh hh hh oh hh ]"
+  -> "oh hh oh hh hh hh oh hh"",
+  ""[square, sawtooth]"
+  -> "[square,sawtooth]"",
+  ""[triangle, sine]"
+  -> "[triangle,sine]"",
+  ""[triangle]"
+  -> "triangle"",
+  ""[~ a1]*2 [~ d2]*2"
+  -> "~ a1 ~ a1 ~ d2 ~ d2"",
+  ""[~ cp]"
+  -> "~ cp"",
+  ""[~ cp]*2"
+  -> "~ cp ~ cp"",
+  ""[~ hh] [~ hh] [~ hh] [~ hh]"
+  -> "~ hh ~ hh ~ hh ~ hh"",
+  ""[~ hh]*4"
+  -> "~ hh ~ hh ~ hh ~ hh"",
+  ""[~ noise] ~ [noise] ~ [~ noise] ~"
+  -> "~ noise ~ ~ noise ~ ~ ~ ~ noise ~ ~"",
+  ""[~ sd:16]*2"
+  -> "~ sd:16 ~ sd:16"",
+  ""[~ sd]*2"
+  -> "~ sd ~ sd"",
+  ""[~ white]*4"
+  -> "~ white ~ white ~ white ~ white"",
+  ""a a a a b b a ~ ~ ~ a ~ [c c] [b b]"
+  -> "a ~ a ~ a ~ a ~ b ~ b ~ a ~ ~ ~ ~ ~ ~ ~ a ~ ~ ~ c c b b"",
+  ""a c [e g]"
+  -> "a ~ c ~ e g"",
+  ""a4 - bb5 c3"
+  -> "a4 ~ bb5 c3"",
+  ""a4 [a4 bb4] c5 [d5 e5] f5 [e5 d5] c5 [bb4 a4]"
+  -> "a4 ~ a4 bb4 c5 ~ d5 e5 f5 ~ e5 d5 c5 ~ bb4 a4"",
+  ""a5*16"
+  -> "a5 a5 a5 a5 a5 a5 a5 a5 a5 a5 a5 a5 a5 a5 a5 a5"",
+  ""a6!3 as6   a6 as6 a6!2"
+  -> "a6 a6 a6 as6 a6 as6 a6 a6"",
+  ""balafon balafon:4 - clap - clap -"
+  -> "balafon balafon:4 ~ clap ~ clap ~"",
+  ""bb4 [bb4 d5] bb4 ~ f5 [f5 g5] f5 ~"
+  -> "bb4 ~ bb4 d5 bb4 ~ ~ ~ f5 ~ f5 g5 f5 ~ ~ ~"",
+  ""bd !2"
+  -> "bd bd"",
+  ""bd - [- bd] -"
+  -> "bd ~ ~ ~ ~ bd ~ ~"",
+  ""bd - sd - bd [- bd] sd [- bd]"
+  -> "bd ~ ~ ~ sd ~ ~ ~ bd ~ ~ bd sd ~ ~ bd"",
+  ""bd -!15"
+  -> "bd ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~"",
+  ""bd [bd - bd], sd(2,4,1), hh*6"
+  -> "bd ~ ~ ~ ~ ~ bd ~ ~ ~ bd ~, ~ ~ ~ sd ~ ~ ~ ~ ~ sd ~ ~, hh ~ hh ~ hh ~ hh ~ hh ~ hh ~"",
+  ""bd [bd bd - bd], sd(2,4,1), hh*8"
+  -> "bd ~ ~ ~ bd bd ~ bd, ~ ~ sd ~ ~ ~ sd ~, hh hh hh hh hh hh hh hh"",
+  ""bd [bd bd - bd], sd(4,4,1), hh*8"
+  -> "bd ~ ~ ~ bd bd ~ bd, sd ~ sd ~ sd ~ sd ~, hh hh hh hh hh hh hh hh"",
+  ""bd bd  ~ bd*2"
+  -> "bd ~ bd ~ ~ ~ bd bd"",
+  ""bd bd - bd,hh,sd,cp"
+  -> "bd bd ~ bd, hh ~ ~ ~, sd ~ ~ ~, cp ~ ~ ~"",
+  ""bd bd bd bd, - hh - hh"
+  -> "bd bd bd bd, ~ hh ~ hh"",
+  ""bd bd bd sd sd[cp cp cp]"
+  -> "bd ~ ~ bd ~ ~ bd ~ ~ sd ~ ~ sd ~ ~ cp cp cp"",
+  ""bd bd sd hh,oh"
+  -> "bd bd sd hh, oh ~ ~ ~"",
+  ""bd cp bd cp bd cp bd cp, hh*8"
+  -> "bd cp bd cp bd cp bd cp, hh hh hh hh hh hh hh hh"",
+  ""bd hh bd - [sd,sd] bd hh*2"
+  -> "bd ~ hh ~ bd ~ ~ ~ sd ~ bd ~ hh hh"",
+  ""bd hh sd [hh sd] [hh sd] bd sd oh"
+  -> "bd ~ hh ~ sd ~ hh sd hh sd bd ~ sd ~ oh ~"",
+  ""bd hh*2 sd bd"
+  -> "bd ~ hh hh sd ~ bd ~"",
+  ""bd hh*2 sd hh*2"
+  -> "bd ~ hh hh sd ~ hh hh"",
+  ""bd ht lt*2 - hh sd -rim"
+  -> "bd ~ ht ~ lt lt ~ ~ hh ~ sd ~ -rim ~"",
+  ""bd sd bd sd,hh*16"
+  -> "bd ~ ~ ~ sd ~ ~ ~ bd ~ ~ ~ sd ~ ~ ~, hh hh hh hh hh hh hh hh hh hh hh hh hh hh hh hh"",
+  ""bd sd cp hh oh cp, cr hh bd"
+  -> "bd sd cp hh oh cp, cr ~ hh ~ bd ~"",
+  ""bd sd hh, gm_overdriven_guitar"
+  -> "bd sd hh, gm_overdriven_guitar ~ ~"",
+  ""bd sd oh hh hh [oh hh oh], hh ht bd"
+  -> "bd ~ ~ sd ~ ~ oh ~ ~ hh ~ ~ hh ~ ~ oh hh oh, hh ~ ~ ~ ~ ~ ht ~ ~ ~ ~ ~ bd ~ ~ ~ ~ ~"",
+  ""bd ~ [sd:1, rim] [bd rim] [~ rim] bd [sd:1, rim] ~"
+  -> "bd ~ ~ ~ [sd:1,rim] ~ bd rim ~ rim bd ~ [sd:1,rim] ~ ~ ~"",
+  ""bd ~ [~ bd] ~, ~ [~ sd] ~ sd"
+  -> "bd ~ ~ ~ ~ bd ~ ~, ~ ~ ~ sd ~ ~ sd ~"",
+  ""bd!4"
+  -> "bd bd bd bd"",
+  ""bd(1,16)"
+  -> "bd ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~"",
+  ""bd(11,16)"
+  -> "bd ~ bd bd ~ bd bd ~ bd bd ~ bd bd ~ bd bd"",
+  ""bd(3, 8), hh(4, 8, 1)"
+  -> "bd ~ ~ bd ~ ~ bd ~, ~ hh ~ hh ~ hh ~ hh"",
+  ""bd(3,8)"
+  -> "bd ~ ~ bd ~ ~ bd ~"",
+  ""bd(3,8,0)"
+  -> "bd ~ ~ bd ~ ~ bd ~"",
+  ""bd*16"
+  -> "bd bd bd bd bd bd bd bd bd bd bd bd bd bd bd bd"",
+  ""bd*2"
+  -> "bd bd"",
+  ""bd*2 sd bd*2 sd bd oh bd sd"
+  -> "bd bd sd ~ bd bd sd ~ bd ~ oh ~ bd ~ sd ~"",
+  ""bd*2,~ [cp,sd]"
+  -> "bd bd, ~ [cp,sd]"",
+  ""bd*4"
+  -> "bd bd bd bd"",
+  ""bd*4, [- cp]*2, [- hh]*4"
+  -> "bd ~ bd ~ bd ~ bd ~, ~ ~ cp ~ ~ ~ cp ~, ~ hh ~ hh ~ hh ~ hh"",
+  ""bd*4, cp(7, 16,14)"
+  -> "bd ~ ~ ~ bd ~ ~ ~ bd ~ ~ ~ bd ~ ~ ~, ~ cp ~ cp ~ cp ~ ~ cp ~ cp ~ cp ~ cp ~"",
+  ""bd*4, sd(2,4,1), hh*8"
+  -> "bd ~ bd ~ bd ~ bd ~, ~ ~ sd ~ ~ ~ sd ~, hh hh hh hh hh hh hh hh"",
+  ""bd*5"
+  -> "bd bd bd bd bd"",
+  ""bd*5 ~*5"
+  -> "bd bd bd bd bd ~ ~ ~ ~ ~"",
+  ""bd*8"
+  -> "bd bd bd bd bd bd bd bd"",
+  ""bd- bd oh - bd bd mt bd cp hh bd"
+  -> "bd- bd oh ~ bd bd mt bd cp hh bd"",
+  ""bd:1 -, - [sd:1:.6 -]"
+  -> "bd:1 ~ ~ ~, ~ ~ sd:1:.6 ~"",
+  ""bd:6(3,8) -"
+  -> "bd:6 ~ ~ bd:6 ~ ~ bd:6 ~ ~ ~ ~ ~ ~ ~ ~ ~"",
+  ""c2, eb3 g3 [bb3 c4 c3]"
+  -> "c2 ~ ~ ~ ~ ~ ~ ~ ~, eb3 ~ ~ g3 ~ ~ bb3 c4 c3"",
+  ""c2, eb3 g3 [bb3 c4]"
+  -> "c2 ~ ~ ~ ~ ~, eb3 ~ g3 ~ bb3 c4"",
+  ""c3*8"
+  -> "c3 c3 c3 c3 c3 c3 c3 c3"",
+  ""c4 - c4 - [c4 d4] - c4 -"
+  -> "c4 ~ ~ ~ c4 ~ ~ ~ c4 d4 ~ ~ c4 ~ ~ ~"",
+  ""c4,g4"
+  -> "c4, g4"",
+  ""c5 [c5 bb4] a4 g4 f4 [g4 a4] bb4 c5"
+  -> "c5 ~ c5 bb4 a4 ~ g4 ~ f4 ~ g4 a4 bb4 ~ c5 ~"",
+  ""casio,balafon,compurhythm78_misc"
+  -> "casio, balafon, compurhythm78_misc"",
+  ""cb*4"
+  -> "cb cb cb cb"",
+  ""cp*4"
+  -> "cp cp cp cp"",
+  ""cp*8"
+  -> "cp cp cp cp cp cp cp cp"",
+  ""crackle*4"
+  -> "crackle crackle crackle crackle"",
+  ""crystal*8"
+  -> "crystal crystal crystal crystal crystal crystal crystal crystal"",
+  ""d#1*4"
+  -> "d#1 d#1 d#1 d#1"",
+  ""d4 d4  d e2 d2 d2 e2 c2"
+  -> "d4 d4 d e2 d2 d2 e2 c2"",
+  ""d5 [d5 eb5] f5 ~ bb5 [bb5 a5] g5 ~"
+  -> "d5 ~ d5 eb5 f5 ~ ~ ~ bb5 ~ bb5 a5 g5 ~ ~ ~"",
+  ""e c c# a*2"
+  -> "e ~ c ~ c# ~ a a"",
+  ""e c c# a*2 ~ e c"
+  -> "e ~ c ~ c# ~ a a ~ ~ e ~ c ~"",
+  ""e1 g1 e3 [g1 e3 g1]"
+  -> "e1 ~ ~ g1 ~ ~ e3 ~ ~ g1 e3 g1"",
+  ""e1*10"
+  -> "e1 e1 e1 e1 e1 e1 e1 e1 e1 e1"",
+  ""f4 [f4 a4] c5 f5 e5 [d5 c5] bb4 [a4 g4]"
+  -> "f4 ~ f4 a4 c5 ~ f5 ~ e5 ~ d5 c5 bb4 ~ a4 g4"",
+  ""f5 [f5 a5] c6 a5 f5 [e5 d5] c5 f4"
+  -> "f5 ~ f5 a5 c6 ~ a5 ~ f5 ~ e5 d5 c5 ~ f4 ~"",
+  ""f5 [f5 e5] d5 [c5 bb4] a4 [bb4 c5] d5 f5"
+  -> "f5 ~ f5 e5 d5 ~ c5 bb4 a4 ~ bb4 c5 d5 ~ f5 ~"",
+  ""g4\\n     !4 g#2 f2 g2!2"
+  -> "g4 g4 g4 g4 g#2 f2 g2 g2"",
+  ""gm_choir_aahs,gm_choir_aahs"
+  -> "gm_choir_aahs, gm_choir_aahs"",
+  ""gm_electric_guitar_jazz,supersaw"
+  -> "gm_electric_guitar_jazz, supersaw"",
+  ""gm_electric_guitar_muted,sawtooth,pulse,z_tan"
+  -> "gm_electric_guitar_muted, sawtooth, pulse, z_tan"",
+  ""gm_fretless_bass,square"
+  -> "gm_fretless_bass, square"",
+  ""gm_taiko_drum:1*4"
+  -> "gm_taiko_drum:1 gm_taiko_drum:1 gm_taiko_drum:1 gm_taiko_drum:1"",
+  ""hh !8"
+  -> "hh hh hh hh hh hh hh hh"",
+  ""hh hh [hh hh] hh"
+  -> "hh ~ hh ~ hh hh hh ~"",
+  ""hh hh cp - "
+  -> "hh hh cp ~"",
+  ""hh sd bd [hh oh] db"
+  -> "hh ~ sd ~ bd ~ hh oh db ~"",
+  ""hh ~ [oh hh]"
+  -> "hh ~ ~ ~ oh hh"",
+  ""hh!4"
+  -> "hh hh hh hh"",
+  ""hh!5 hh!5 hh!6"
+  -> "hh hh hh hh hh hh hh hh hh hh hh hh hh hh hh hh"",
+  ""hh(1,16,0)"
+  -> "hh ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~"",
+  ""hh(15,16,1)"
+  -> "~ hh hh hh hh hh hh hh hh hh hh hh hh hh hh hh"",
+  ""hh(7,8,1)"
+  -> "~ hh hh hh hh hh hh hh"",
+  ""hh(9,16)"
+  -> "hh ~ hh hh ~ hh ~ hh ~ hh hh ~ hh ~ hh ~"",
+  ""hh*10"
+  -> "hh hh hh hh hh hh hh hh hh hh"",
+  ""hh*16"
+  -> "hh hh hh hh hh hh hh hh hh hh hh hh hh hh hh hh"",
+  ""hh*2"
+  -> "hh hh"",
+  ""hh*20"
+  -> "hh hh hh hh hh hh hh hh hh hh hh hh hh hh hh hh hh hh hh hh"",
+  ""hh*3"
+  -> "hh hh hh"",
+  ""hh*4"
+  -> "hh hh hh hh"",
+  ""hh*4 - - -"
+  -> "hh hh hh hh ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~"",
+  ""hh*8"
+  -> "hh hh hh hh hh hh hh hh"",
+  ""hh,hh oh sd"
+  -> "hh ~ ~, hh oh sd"",
+  ""hh:1*4"
+  -> "hh:1 hh:1 hh:1 hh:1"",
+  ""hh:1*8"
+  -> "hh:1 hh:1 hh:1 hh:1 hh:1 hh:1 hh:1 hh:1"",
+  ""insect:2 [insect:2]"
+  -> "insect:2 insect:2"",
+  ""lt mt [ht ht lt]"
+  -> "lt ~ ~ mt ~ ~ ht ht lt"",
+  ""misc misc [~ cb]"
+  -> "misc ~ misc ~ ~ cb"",
+  ""misc(3, 8)"
+  -> "misc ~ ~ misc ~ ~ misc ~"",
+  ""numbers*4"
+  -> "numbers numbers numbers numbers"",
+  ""numbers, - piano"
+  -> "numbers ~, ~ piano"",
+  ""oh(1,16,15)"
+  -> "~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ oh"",
+  ""oh*16"
+  -> "oh oh oh oh oh oh oh oh oh oh oh oh oh oh oh oh"",
+  ""oh*4"
+  -> "oh oh oh oh"",
+  ""passerine_hihat:4*16"
+  -> "passerine_hihat:4 passerine_hihat:4 passerine_hihat:4 passerine_hihat:4 passerine_hihat:4 passerine_hihat:4 passerine_hihat:4 passerine_hihat:4 passerine_hihat:4 passerine_hihat:4 passerine_hihat:4 passerine_hihat:4 passerine_hihat:4 passerine_hihat:4 passerine_hihat:4 passerine_hihat:4"",
+  ""perc:0(3,12,3)"
+  -> "~ ~ ~ perc:0 ~ ~ ~ perc:0 ~ ~ ~ perc:0"",
+  ""perc:2(7,12,3)"
+  -> "~ perc:2 ~ perc:2 ~ perc:2 perc:2 ~ perc:2 ~ perc:2 perc:2"",
+  ""piano,sine"
+  -> "piano, sine"",
+  ""piano1,jazz"
+  -> "piano1, jazz"",
+  ""sawtooth,pink"
+  -> "sawtooth, pink"",
+  ""sawtooth,square:0:.2"
+  -> "sawtooth, square:0:.2"",
+  ""sawtooth,supersaw"
+  -> "sawtooth, supersaw"",
+  ""sawtooth,triangle"
+  -> "sawtooth, triangle"",
+  ""sd sd*2"
+  -> "sd ~ sd sd"",
+  ""sd*2 sd*4 sd*8"
+  -> "sd ~ ~ ~ sd ~ ~ ~ sd ~ sd ~ sd ~ sd ~ sd sd sd sd sd sd sd sd"",
+  ""sh:1!4 sh:0!2"
+  -> "sh:1 sh:1 sh:1 sh:1 sh:0 sh:0"",
+  ""sine,sawtooth"
+  -> "sine, sawtooth"",
+  ""sine,square"
+  -> "sine, square"",
+  ""siren:1*4 - siren:2"
+  -> "siren:1 siren:1 siren:1 siren:1 ~ ~ ~ ~ siren:2 ~ ~ ~"",
+  ""square,sawtooth"
+  -> "square, sawtooth"",
+  ""supersaw(11, 16)"
+  -> "supersaw ~ supersaw supersaw ~ supersaw supersaw ~ supersaw supersaw ~ supersaw supersaw ~ supersaw supersaw"",
+  ""supersaw(9, 16)"
+  -> "supersaw ~ supersaw supersaw ~ supersaw ~ supersaw ~ supersaw supersaw ~ supersaw ~ supersaw ~"",
+  ""supersaw*12"
+  -> "supersaw supersaw supersaw supersaw supersaw supersaw supersaw supersaw supersaw supersaw supersaw supersaw"",
+  ""supersaw*4"
+  -> "supersaw supersaw supersaw supersaw"",
+  ""supersaw,gm_accordion"
+  -> "supersaw, gm_accordion"",
+  ""supersaw,white:0:.1"
+  -> "supersaw, white:0:.1"",
+  ""vib*2 "
+  -> "vib vib"",
+  ""white!8"
+  -> "white white white white white white white white"",
+  ""white*10"
+  -> "white white white white white white white white white white"",
+  ""white*16"
+  -> "white white white white white white white white white white white white white white white white"",
+  ""white*8"
+  -> "white white white white white white white white"",
+  ""x(3,8)"
+  -> "x ~ ~ x ~ ~ x ~"",
+  ""~  bd  ~ bd"
+  -> "~ bd ~ bd"",
+  ""~ [~ ~ perc perc:2] [perc:4 perc:4 ~ perc:1] perc:4"
+  -> "~ ~ ~ ~ ~ ~ perc perc:2 perc:4 perc:4 ~ perc:1 perc:4 ~ ~ ~"",
+  ""~ c5 ~ ~ ,~ f5 ~ ~ ,~ c6*2 ~ ~ "
+  -> "~ ~ c5 ~ ~ ~ ~ ~, ~ ~ f5 ~ ~ ~ ~ ~, ~ ~ c6 c6 ~ ~ ~ ~"",
+  ""~ hh ~ [hh hh] ~ hh ~ hh"
+  -> "~ ~ hh ~ ~ ~ hh hh ~ ~ hh ~ ~ ~ hh ~"",
+  ""~ hh*12"
+  -> "~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ hh hh hh hh hh hh hh hh hh hh hh hh"",
+  ""~ sd ~ [sd ~ ~ sd]"
+  -> "~ ~ ~ ~ sd ~ ~ ~ ~ ~ ~ ~ sd ~ ~ sd"",
+  ""~ ~ ~ ~ ~ ~  F2!2"
+  -> "~ ~ ~ ~ ~ ~ F2 F2"",
+]
+`;
+
+exports[`round-trip — an unedited open→write must not change the text > grid: LOCKED — these round-trip today and must not stop > grid-round-trips-locked 1`] = `
+[
+  " C D ",
+  " c4 a e c1",
+  " g c g c g c g c",
+  " gm_distortion_guitar",
+  " gm_electric_bass_finger",
+  " gm_slap_bass_2",
+  "<[bb4 ~ c5 ~] [d5 ~ bb4 ~] [c5 ~ ab4 ~] [bb4 ~ g4 ~]>",
+  "<[c2,c1] [ab0,ab1] [f0,f1] [g0,g1]>",
+  "<[g3,bb3,d4,f4] [bb3,d4,f4] [f3,ab3,c4] [ab3,c4,eb4]>",
+  "<[g5 bb5] ~ [f5 ab5] ~>",
+  "<a2 ~ ~ f2 ~ ~ g2 ~ ~ e2 ~ ~ a2 ~ ~ f2 ~ ~ g2 ~ ~ c3 ~ ~>",
+  "<a4 ~ ~ c5 ~ e5 ~ c5 ~ ~ g4 ~ b4 ~ g4 ~ ~ e5 ~ a5 ~>",
+  "<bd sd>",
+  "<bigb:2 bigb:1>",
+  "<c1 ab1 d1 g1>",
+  "<c4 ~ ~ e4 ~ g4 ~ ~ b4 ~ g4 ~ e4 ~>",
+  "<d2 e2 c#2 a1>",
+  "<eb4 f4 g4 d4>",
+  "<g2 bb2 f2 ab2>",
+  "<g3 bb3 f3 ab3>",
+  "<gm_slap_bass_1 gm_fx_crystal gm_marimba>",
+  "<i_came_here_for_rizz i_stayed_for_something_more>",
+  "<piano sine>",
+  "<triangle sawtooth square sawtooth triangle>",
+  "<triangle square>",
+  "<z_sawtooth z_triangle z_sawtooth z_square z_tan>",
+  "<~ sd ~ sd ~ sd ~ sd ~>",
+  "<~ ~ ~ ~ ~ ~ ~ ~ c5 ~ e5 g5 ~ ~ e5 g5>",
+  "A",
+  "A1 A1 A1 E3",
+  "A1 ~ A1 ~ ~ A1 A1 ~",
+  "AkaiLinn_bd",
+  "AkaiMPC60_cp",
+  "AkaiMPC60_rim",
+  "AlesisSR16_hh",
+  "BossDR110_rd",
+  "C Em",
+  "C2 D2 E2",
+  "C3",
+  "C5 A4 F5 E4",
+  "E2",
+  "EmuDrumulator_cr",
+  "Evermore",
+  "F",
+  "F# E D C# C Bm1 Am1 G",
+  "Fearless",
+  "G2",
+  "G3 Bb4 D4 G4 D4 Bb4 D4 F#3",
+  "KorgDDM110_cp",
+  "LinnDrum_bd",
+  "LinnDrum_hh:0:.3",
+  "LinnDrum_rim",
+  "Metadata",
+  "Nineteen",
+  "Purple",
+  "Red",
+  "Reputation",
+  "RolandTR909_bd",
+  "RolandTR909_oh",
+  "[g,b,d]",
+  "a b c2 d1 e3 f4 g5 f4 a a b b b c c d d e e e e f f f f g g g g a a a",
+  "a b g",
+  "a e b1 c d1 f g",
+  "a#4 d#5",
+  "a2",
+  "a2 gs2 g2 fs2 f2 a2 gs2 as2",
+  "a3",
+  "a3 c3 e3 f3",
+  "a3 c4 f4 e4 d4 c4 bb3 a3",
+  "a3 f3 bb3 c4 d4 c4 bb3 a3",
+  "a3 ~ ~ ~",
+  "a4 a4 a4 a4",
+  "a4 a4 a4 a4  ",
+  "a4 c5 f5 a5 g5 e5 c5 g4",
+  "ace_hh",
+  "ace_ht",
+  "amen",
+  "b3",
+  "balafon",
+  "balingba",
+  "bass",
+  "bassdrum1:3",
+  "bb1 ~ f2 ~ bb1 ~ f2 ~",
+  "bb2 ~ f2 ~ bb2 ~ f2 ~",
+  "bb3 ~ f3 ~ bb3 ~ f3 ~",
+  "bd",
+  "bd bd bd bd",
+  "bd bd bd bd bd bd bd bd",
+  "bd bd bd bd, hh ~ hh ~, ~ ~ sd:3 ~",
+  "bd cd sd lt bd bd bd sd hh cr",
+  "bd hh bd hh",
+  "bd hh bd sd bd rim bd hh ",
+  "bd hh hh rim",
+  "bd hh hh sd hh hh",
+  "bd hh sd bd hh bd hh sd bd hh bd bd hh bd hh sd",
+  "bd hh sd hh",
+  "bd hh sd oh",
+  "bd lt cb cb",
+  "bd oh hh",
+  "bd rim",
+  "bd rim rim hh hh sd oh",
+  "bd sd",
+  "bd sd bd bd hh",
+  "bd sd bd sd",
+  "bd sd hh",
+  "bd sd hh oh lt ht mt rd cr",
+  "bd sn",
+  "bd ~",
+  "bd ~ bd ~",
+  "bd ~ sd ~ bd ~ ~ sd",
+  "bd ~ ~ bd ~ ~ ~ ~",
+  "bd808 ~ ~ ~",
+  "bd:1 sd:1 bd:1 sax:1",
+  "bd:2",
+  "bd:3",
+  "bd_kick",
+  "bdbd hh sd oh",
+  "bfoley",
+  "bh sd bh hh rain",
+  "bigb:5",
+  "blue-velvet",
+  "bossdr55_hh",
+  "brazil",
+  "break",
+  "breaks165",
+  "c a f f e",
+  "c a g",
+  "c d f e",
+  "c eb g bb",
+  "c1",
+  "c1 f1",
+  "c1 ~ ~ ~ c1 ~ g1 ~",
+  "c2",
+  "c2 e3 g4 b5 c6 b5 g4 e3 c2",
+  "c2 f2 c2 g2",
+  "c2 ~ a2 g2 ~",
+  "c2 ~ ~ g1 ~ ~ a1 ~",
+  "c3",
+  "c3 bb2 f3 eb3",
+  "c3 c2 c2 c2 c3 c2 d3 d#3 c2 c3 c3 c2 c3 c2 d3 d#2",
+  "c3 c3 c3 c3",
+  "c3 e3 f3 g3",
+  "c3 g3 a3 f3 d3 e3",
+  "c3 ~ g3 ~ a3 ~",
+  "c4 a4 f4 e4",
+  "c4 f4 a4 c5 a4 f4 a4 c4",
+  "c4 f4 a4 g4 f4 e4 d4 c4",
+  "c4 g4 c5 g5",
+  "c4 ~ eb4 ~ g4 ~ bb4 ~",
+  "c4 ~ g4 a4",
+  "c5 b4 a4 g4 f#4 g4 e4 f#4",
+  "c5 e5 g5 a5 b5 a5 g5 e5",
+  "c5 e5 g5 b5",
+  "c5 f5 a5 f5 c5 ~ f5 ~",
+  "c5 f5 g5 c5 c5 f5 g5 g5",
+  "c5 ~ ~ ~ g5 ~ ~ ~",
+  "c6 f6 a6",
+  "casio",
+  "casio:1",
+  "casio:3",
+  "cb eb gb bb bb bb bb",
+  "chap:1",
+  "charli:1",
+  "charli:2",
+  "church_organ",
+  "cicbird",
+  "clap",
+  "clap:1, clap:7",
+  "claus",
+  "cocaina",
+  "cowbell",
+  "cp",
+  "cp rim sd db",
+  "crackle",
+  "crow",
+  "d e g b a g a b b a g g g a b a",
+  "d2 a2 d2 d2",
+  "d3",
+  "d4 d4 d d2 d2 e2 c2",
+  "d4 d4 d3 e2 d2 d2 e2 c2",
+  "d4 f4 d4 c4 bb3 d4 c4 bb3",
+  "dancing",
+  "dantranh_tremolo",
+  "distkick",
+  "dkick",
+  "duck",
+  "e",
+  "e f f a c",
+  "e1 ~ ~ ~ ~ b0 ~ ~",
+  "e2 e2",
+  "e2 e2 d3 e3 d3 c3",
+  "e3",
+  "e3 d2 g4 a3",
+  "e4 f4 e4 g4",
+  "east",
+  "eb2",
+  "electric_piano",
+  "f#3 b3 e4",
+  "f2 a2 c3 f3 c3 a2 g2 c2",
+  "f2 c3 a2 c3 f2 c3 g2 c3",
+  "f2 c3 d3 bb2 a2 f2 c3 f2",
+  "f2 c3 f2 c3 f2 c3 f2 c3",
+  "f2 c3 g3 ab3 bb3 eb4 a2 gb3 a3 db4 f4 eb4 bb2 f3 ab3 c4",
+  "f2 ~ c3 ~ f2 ~ c3 ~",
+  "f3 a3 c4 a3 f3 a3 c4 f3",
+  "f3 ~ a3 ~ e3 ~ d3 ~",
+  "f3 ~ a3 ~ g3 ~ d3",
+  "f4 c4",
+  "finance",
+  "fmpiano",
+  "folkharp",
+  "fs1 fs1 ~ fs1 d1 ~ a1 ~ e1",
+  "fs5 fs5 e5 fs5 a5 g#5 fs5 e5 d5 d5 cs5 b4 a4 b4 cs5 e5",
+  "fx, square",
+  "fx_revcrash",
+  "g1",
+  "g2 d2 g3 d2",
+  "g3 f#3 e3 ~",
+  "g3 g4 g5 g6",
+  "g4 d4 e4 d4 b3 a3 f#4 g4",
+  "gardbird",
+  "glasstap:2",
+  "glitch:7",
+  "gm_accordion",
+  "gm_accordion:1",
+  "gm_accordion:2",
+  "gm_acoustic_bass",
+  "gm_acoustic_bass:1",
+  "gm_acoustic_bass:5",
+  "gm_acoustic_guitar_nylon",
+  "gm_acoustic_guitar_steel",
+  "gm_agogo",
+  "gm_alto_sax",
+  "gm_banjo",
+  "gm_bassoon:0",
+  "gm_brass_section",
+  "gm_celesta:3",
+  "gm_celesta:4",
+  "gm_cello",
+  "gm_choir_aahs",
+  "gm_church_organ",
+  "gm_church_organ:2",
+  "gm_clavinet",
+  "gm_contrabass",
+  "gm_distortion_guitar",
+  "gm_distortion_guitar:2",
+  "gm_drawbar_organ",
+  "gm_drawbar_organ:4",
+  "gm_dulcimer",
+  "gm_electric_bass_finger",
+  "gm_electric_bass_finger:2",
+  "gm_electric_bass_finger:3",
+  "gm_electric_bass_pick",
+  "gm_electric_bass_pick:2",
+  "gm_electric_guitar_clean",
+  "gm_electric_guitar_clean, gm_kalimba",
+  "gm_electric_guitar_clean:4",
+  "gm_electric_guitar_jazz",
+  "gm_electric_guitar_muted",
+  "gm_eletric_guitar_clean",
+  "gm_epiano1",
+  "gm_epiano1 piano:x:.5",
+  "gm_epiano1:1",
+  "gm_epiano1:4",
+  "gm_epiano2",
+  "gm_fiddle",
+  "gm_fingered_bass",
+  "gm_flute",
+  "gm_french_horn",
+  "gm_fretless_bass",
+  "gm_fx_atmosphere",
+  "gm_fx_brightness",
+  "gm_fx_crystal",
+  "gm_fx_crystal:5",
+  "gm_fx_goblins",
+  "gm_fx_soundtrack",
+  "gm_guitar_fret_noise",
+  "gm_harpsichord, sine",
+  "gm_harpsichord:3",
+  "gm_helicopter",
+  "gm_kalimba",
+  "gm_lead_1_square",
+  "gm_lead_2_sawtooth",
+  "gm_lead_6_voice",
+  "gm_lead_7_fifths",
+  "gm_lead_8_bass_lead",
+  "gm_marimba",
+  "gm_music_box",
+  "gm_oboe",
+  "gm_oboe:4",
+  "gm_ocarina",
+  "gm_orchestra_hit",
+  "gm_overdriven_guitar",
+  "gm_pad_bowed",
+  "gm_pad_bowed:1",
+  "gm_pad_choir",
+  "gm_pad_halo",
+  "gm_pad_metallic",
+  "gm_pad_poly",
+  "gm_pad_sweep",
+  "gm_pad_warm",
+  "gm_pan_flute",
+  "gm_piano",
+  "gm_piano gm_electric_guitar_jazz",
+  "gm_piano:1",
+  "gm_pizzicato_strings",
+  "gm_reed_organ",
+  "gm_rock_organ:1",
+  "gm_rock_organ:2",
+  "gm_shamisen",
+  "gm_shanai",
+  "gm_sitar",
+  "gm_slap_bass_1:1",
+  "gm_slap_bass_2",
+  "gm_string_ensemble_2",
+  "gm_synth_bass_1",
+  "gm_synth_bass_1:6",
+  "gm_synth_bass_2",
+  "gm_synth_bass_2:0",
+  "gm_synth_bass_2:1",
+  "gm_synth_brass_1",
+  "gm_synth_brass_1:3",
+  "gm_synth_brass_2",
+  "gm_synth_choir",
+  "gm_synth_strings_1",
+  "gm_synth_strings_1 piano",
+  "gm_synth_strings_1, gm_pad_new_age",
+  "gm_synth_strings_1:1",
+  "gm_synth_strings_1:2",
+  "gm_synth_strings_2:1",
+  "gm_synth_strings_2:2",
+  "gm_tenor_sax",
+  "gm_timpani",
+  "gm_tinkle_bell",
+  "gm_trombone",
+  "gm_trumpet",
+  "gm_tuba",
+  "gm_tubular_bells",
+  "gm_vibraphone",
+  "gm_viola",
+  "gm_violin",
+  "gm_violin:6",
+  "gm_voice_oohs",
+  "gm_whistle",
+  "gm_xylophone ",
+  "gong:1 agogo:2 marktrees:1 bassdrum1:3",
+  "great:8",
+  "gretsch",
+  "guiro",
+  "handchimes",
+  "harp",
+  "hats:12",
+  "haunted",
+  "hh",
+  "hh ",
+  "hh hh hh hh",
+  "hh:1 ~ sd:1 ~",
+  "hihat",
+  "ht lt",
+  "ihatebirds",
+  "industrial",
+  "insect",
+  "jazz",
+  "kalimba",
+  "kawa",
+  "kawai",
+  "laugh:7",
+  "long",
+  "loopAmen02",
+  "loopAmen03",
+  "loopamen02",
+  "lt cp",
+  "lt ht mt cp",
+  "lt mt ht ht",
+  "lt mt lt cr",
+  "message3",
+  "metal",
+  "movement",
+  "noise",
+  "noise:4",
+  "numbers",
+  "ny",
+  "o1",
+  "oberheimdmx_rim",
+  "ocarina_small",
+  "ocarina_vib",
+  "oceandrum",
+  "odia",
+  "oh",
+  "oh hh rd",
+  "oh oh oh oh",
+  "ohohno",
+  "oneshots",
+  "pad",
+  "passerine_acc:2",
+  "passerine_acc:4",
+  "passerine_acc:5",
+  "passerine_kick:5, passerine_basse:5 ",
+  "perc",
+  "piano",
+  "piano, gm_synth_bass_2",
+  "piano, handchimes",
+  "piano, square",
+  "pigeon",
+  "pink",
+  "pno",
+  "psaltery_pluck",
+  "pulse",
+  "pulse:.3",
+  "rave",
+  "recorder_alto_sus, piano",
+  "rhodes",
+  "ride",
+  "riffin",
+  "rim it it rim ",
+  "rim rim rim rim",
+  "rs ~ ~ ~ ~ rs ~ rs",
+  "sawbass",
+  "sawtooth",
+  "sawtooth ",
+  "sawtooth, triangle",
+  "sawtooth:0:.8",
+  "sax:2 sax:3 sax:1 saxello:1",
+  "sax_stacc",
+  "saxello_stacc",
+  "scream",
+  "sd",
+  "sd bd bd",
+  "senegal",
+  "shaker_large",
+  "shortahh",
+  "sine",
+  "sine ",
+  "sine pink",
+  "sine sine sine sine sawtooth",
+  "sine, triangle",
+  "siren",
+  "something_in_return",
+  "spacedrum",
+  "square",
+  "square ",
+  "square, sine",
+  "square, triangle, sawtooth",
+  "sri",
+  "steinway",
+  "supersaw",
+  "supersaw:4 ~ supersaw:7 supersaw:11",
+  "swpad",
+  "swpad:0",
+  "swpad:1",
+  "synth",
+  "tabla2",
+  "tech:5",
+  "temporality end",
+  "thailand",
+  "theslayestcapybaraaonearth",
+  "think",
+  "todo",
+  "tom",
+  "tr909_bd",
+  "tr909_oh",
+  "tr909_sd",
+  "tri",
+  "trial",
+  "trial:0:.4",
+  "triangle",
+  "triangle, sawtooth",
+  "tubularbells",
+  "vibraphone",
+  "vibraphone_bowed",
+  "violin",
+  "viscospacedrum_misc:3",
+  "vox",
+  "vox1 ~ vox2 ~ vox3 ~ vox1",
+  "warm_pad",
+  "white",
+  "wind",
+  "wind:1",
+  "wind:2",
+  "woodblock",
+  "x",
+  "x x x",
+  "xylophone_hard_ff",
+  "xylophone_medium_ff",
+  "z_noise",
+  "z_sawtooth",
+  "z_sine",
+  "z_square",
+  "z_tan",
+  "z_triangle",
+  "zilpzalp",
+  "~",
+  "~ G4 ~ D4 ~ C4",
+  "~ a4 ~ a4 ~ g4 ~ g4",
+  "~ bd ~ ~, ~ ~ ~ rim",
+  "~ cp",
+  "~ cp ~ cp",
+  "~ cp ~ ~ cp",
+  "~ f4 ~ f4 ~ f4 ~ f4",
+  "~ hh",
+  "~ hh ~ hh",
+  "~ hh ~ hh ~ hh ~ hh",
+  "~ sd",
+  "~ sd ~ sd",
+  "~ siren",
+  "~ ~ sd ~",
+  "~ ~ sd ~ ~ ~ sd ~",
+  "~ ~ ~ A1",
+  "~ ~ ~ cp:1",
+  "~ ~ ~ ~ ~ ~ F2",
+  "~ ~ ~ ~ ~ ~ ~ A3",
+  "~ ~ ~ ~ ~ ~ ~ C2",
+]
+`;
+
+exports[`round-trip — an unedited open→write must not change the text > grid: serializer refuses a model it just parsed > grid-serializer-null 1`] = `[]`;
+
+exports[`round-trip — an unedited open→write must not change the text > roll: KNOWN RESIDUAL — these are rewritten today and MUST flip (#903 A2) > roll-rewritten-residual 1`] = `
+[
+  ""  [ a4 ~ ~ a4] [ a4 ~ a4 ~]  [ a4 ~ ~ a4 ]  [ a4 ~ a4 a4 ]*2 "
+  -> "a4@2 ~ ~ ~ ~ a4@2 a4@2 ~ ~ a4@2 ~ ~ a4@2 ~ ~ ~ ~ a4@2 a4 ~ a4 a4 a4 ~ a4 a4"",
+  "" <c2*2 g2*5 [a g]>"
+  -> "<[c2@5 c2@5] [g2@2 g2@2 g2@2 g2@2 g2@2] [a@5 g@5]>"",
+  "" C D "
+  -> "c d"",
+  "" c - c [a a] a a c@2"
+  -> "c@2 ~ ~ c@2 a a a@2 a@2 c@4"",
+  "" d - d e f - d - d e f - a - a b c4 - a - c4 b "
+  -> "d ~ d e f ~ d ~ d e f ~ a ~ a b c4 ~ a ~ c4 b"",
+  ""- - d4 - - d4 - - d4 - - d4 - - d4 - - d4 - d4 - - d4@3 - d4 - - d4 - - e4 - - f4 - - f#4 - - g4 - a4 - - d5@3 - d5 - - d5 - - d5 - - d5 - - d5 - - d5 - d5  - - d5@3  - d5 - - d5 - - c5 - - b4 - - a4 - - g4 - f#4 - - d4@2 "
+  -> "~ ~ d4 ~ ~ d4 ~ ~ d4 ~ ~ d4 ~ ~ d4 ~ ~ d4 ~ d4 ~ ~ d4@3 ~ d4 ~ ~ d4 ~ ~ e4 ~ ~ f4 ~ ~ f#4 ~ ~ g4 ~ a4 ~ ~ d5@3 ~ d5 ~ ~ d5 ~ ~ d5 ~ ~ d5 ~ ~ d5 ~ ~ d5 ~ d5 ~ ~ d5@3 ~ d5 ~ ~ d5 ~ ~ c5 ~ ~ b4 ~ ~ a4 ~ ~ g4 ~ f#4 ~ ~ d4@2"",
+  ""- - f*2 - -"
+  -> "~ ~ ~ ~ f f ~ ~ ~ ~"",
+  ""- e2 [e3, e4] [e3, e4] [e3, e4]@2 -"
+  -> "~ e2 [e3,e4] [e3,e4] [e3,e4]@2 ~"",
+  ""0 0 0 0 0 0 -"
+  -> "0 0 0 0 0 0 ~"",
+  ""0 1 2 [3 4] 5 6 7 6 5 4 3 2 1"
+  -> "0@2 1@2 2@2 3 4 5@2 6@2 7@2 6@2 5@2 4@2 3@2 2@2 1@2"",
+  ""0 1 [4 3] 2 0 2 [~ 3] 4"
+  -> "0@2 1@2 4 3 2@2 0@2 2@2 ~ 3 4@2"",
+  ""0 12*2"
+  -> "0@2 12 12"",
+  ""0 4 [0 2] -4 -2 -2 [~ 6] 4"
+  -> "0@2 4@2 0 2 -4@2 -2@2 -2@2 ~ 6 4@2"",
+  ""0 8 [0 8] -2 4 2 [~ 3] 4"
+  -> "0@2 8@2 0 8 -2@2 4@2 2@2 ~ 3 4@2"",
+  ""0(-10,16)"
+  -> "~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~"",
+  ""0*4"
+  -> "0 0 0 0"",
+  ""0,-12"
+  -> "[0,-12]"",
+  ""0,2"
+  -> "[0,2]"",
+  ""0,2,4"
+  -> "[0,2,4]"",
+  ""0,3,5"
+  -> "[0,3,5]"",
+  ""0,4,7"
+  -> "[0,4,7]"",
+  ""1 5 6 [7 8 9]*2"
+  -> "1@6 5@6 6@6 7 8 9 7 8 9"",
+  ""1,3,5"
+  -> "[1,3,5]"",
+  ""1,5"
+  -> "[1,5]"",
+  ""10 8 4 2 [10 8] 6 2 0"
+  -> "10@2 8@2 4@2 2@2 10 8 6@2 2@2 0@2"",
+  ""2*4"
+  -> "2 2 2 2"",
+  ""3 - 2 - 6 7 5"
+  -> "3 ~ 2 ~ 6 7 5"",
+  ""3 1 - 1"
+  -> "3 1 ~ 1"",
+  ""4,6"
+  -> "[4,6]"",
+  ""4,6,1"
+  -> "[4,6,1]"",
+  ""48 67 63 [62, 58]"
+  -> "48 67 63 [62,58]"",
+  ""< [g6, e6] [f6, d6] [e6, c6] [a5, b5] >"
+  -> "<[g6,e6] [f6,d6] [e6,c6] [a5,b5]>"",
+  ""<- [0,3,7]>"
+  -> "<~ [0,3,7]>"",
+  ""<- c5>"
+  -> "<~ c5>"",
+  ""<0 -@7>"
+  -> "<0 ~ ~ ~ ~ ~ ~ ~>"",
+  ""<0 [0 1] 0 [0 1 0]>"
+  -> "<0 [0@3 1@3] 0 [0@2 1@2 0@2]>"",
+  ""<0*2>"
+  -> "0 0"",
+  ""<0>"
+  -> "0"",
+  ""<12!8 7!8>"
+  -> "<12 12 12 12 12 12 12 12 7 7 7 7 7 7 7 7>"",
+  ""<A1@4 D2@4 C#2@1>"
+  -> "<a1@4 d2@4 c#2>"",
+  ""<A1@8 D2@8 C#2@2>"
+  -> "<a1@8 d2@8 c#2@2>"",
+  ""<G#2!3 C2>"
+  -> "<g#2 g#2 g#2 c2>"",
+  ""<[-3@1 -2@1 -1@1 0@1]*2>"
+  -> "-3 -2 -1 0 -3 -2 -1 0"",
+  ""<[0 4 7] [~ ~ ~] [0 4 7] [~ ~ ~]>"
+  -> "<[0 4 7] ~ [0 4 7] ~>"",
+  ""<[0 5]*4 [5 10]*4>"
+  -> "<[0 5 0 5 0 5 0 5] [5 10 5 10 5 10 5 10]>"",
+  ""<[A2, C#3, E3] A3 G#3 G3 [D3, F#3] B3 C#3 E3 D#3>"
+  -> "<[a2,c#3,e3] a3 g#3 g3 [d3,f#3] b3 c#3 e3 d#3>"",
+  ""<[A2, C#3, E3]@4 [D3, F#3, A3]@5>"
+  -> "<[a2,c#3,e3]@4 [d3,f#3,a3]@5>"",
+  ""<[b2 b3]*4 [a2 a3]*4 >"
+  -> "<[b2 b3 b2 b3 b2 b3 b2 b3] [a2 a3 a2 a3 a2 a3 a2 a3]>"",
+  ""<[c2 c3]*4 [bb1 bb2]*2 [f2 f3]*4 [eb2 eb3]*2>"
+  -> "<[c2 c3 c2 c3 c2 c3 c2 c3] [bb1@2 bb2@2 bb1@2 bb2@2] [f2 f3 f2 f3 f2 f3 f2 f3] [eb2@2 eb3@2 eb2@2 eb3@2]>"",
+  ""<[c2 c3]*4 [bb1 bb2]*4 [f2 f3]*4 [eb2 eb3]*2>"
+  -> "<[c2 c3 c2 c3 c2 c3 c2 c3] [bb1 bb2 bb1 bb2 bb1 bb2 bb1 bb2] [f2 f3 f2 f3 f2 f3 f2 f3] [eb2@2 eb3@2 eb2@2 eb3@2]>"",
+  ""<[c2 c3]*4 [bb1 bb2]*4 [f2 f3]*4 [eb2 eb3]*4>"
+  -> "<[c2 c3 c2 c3 c2 c3 c2 c3] [bb1 bb2 bb1 bb2 bb1 bb2 bb1 bb2] [f2 f3 f2 f3 f2 f3 f2 f3] [eb2 eb3 eb2 eb3 eb2 eb3 eb2 eb3]>"",
+  ""<[c5, e5] [d5, f5] [e5, g5] [f5, a5]>"
+  -> "<[c5,e5] [d5,f5] [e5,g5] [f5,a5]>"",
+  ""<c4 ->"
+  -> "<c4 ~>"",
+  ""<eb*3 c*3>"
+  -> "<[eb eb eb] [c c c]>"",
+  ""<eb2*3 a2*3 c2*3 a2*3 >"
+  -> "<[eb2 eb2 eb2] [a2 a2 a2] [c2 c2 c2] [a2 a2 a2]>"",
+  ""A"
+  -> "a"",
+  ""A1 A1 A1 E3"
+  -> "a1 a1 a1 e3"",
+  ""A1 A1 [A1 ~ ~ A1] [~ ~ A1 ~]"
+  -> "a1@4 a1@4 a1 ~ ~ a1 ~ ~ a1 ~"",
+  ""A1 ~ A1 ~ ~ A1 A1 ~"
+  -> "a1 ~ a1 ~ ~ a1 a1 ~"",
+  ""A1!4"
+  -> "a1 a1 a1 a1"",
+  ""A1!8"
+  -> "a1 a1 a1 a1 a1 a1 a1 a1"",
+  ""A3 C4 -"
+  -> "a3 c4 ~"",
+  ""C2 D2 E2"
+  -> "c2 d2 e2"",
+  ""C3"
+  -> "c3"",
+  ""C5 A4 F5 E4"
+  -> "c5 a4 f5 e4"",
+  ""E2"
+  -> "e2"",
+  ""E2@3 E2@3 E2@3 E2@3 E2@2 E2@2"
+  -> "e2@3 e2@3 e2@3 e2@3 e2@2 e2@2"",
+  ""E3 E3 [E3 f3] E3 "
+  -> "e3@2 e3@2 e3 f3 e3@2"",
+  ""F"
+  -> "f"",
+  ""F [D F A] [C E A]"
+  -> "f@3 d f a c e a"",
+  ""G1 [G1 D2] C1 C1 G1 G1 A1 [D1 F#1]"
+  -> "g1@2 g1 d2 c1@2 c1@2 g1@2 g1@2 a1@2 d1 f#1"",
+  ""G2"
+  -> "g2"",
+  ""G3 Bb4 D4 G4 D4 Bb4 D4 F#3"
+  -> "g3 bb4 d4 g4 d4 bb4 d4 f#3"",
+  ""[ 0 3 2 5 4 8 -2 ]"
+  -> "0 3 2 5 4 8 -2"",
+  ""[ ~  ~ [a4,c5,e5] ~ ] [ ~  ~ [a4,c5,e5] ~ ] [ ~  ~ [a4,c5,e5] ~ ]  [ ~ ~ ~ [g4,c5,e5]]"
+  -> "~ ~ [a4,c5,e5] ~ ~ ~ [a4,c5,e5] ~ ~ ~ [a4,c5,e5] ~ ~ ~ ~ [g4,c5,e5]"",
+  ""[ ~ ~ [a4,c5,e5] ~]  [ ~ ~ [a4,c5,e5] ~]  [ ~ ~ [a4,c5,e5] ~] [ ~ ~ ~ [g4,c5,e5]]"
+  -> "~ ~ [a4,c5,e5] ~ ~ ~ [a4,c5,e5] ~ ~ ~ [a4,c5,e5] ~ ~ ~ ~ [g4,c5,e5]"",
+  ""[- - - - - - - 17 16 15 - - - - - 14 14 5 10 11 - - - 10 - 10 10 9 11 8 9 9 7 6 9 4 1 1 5 1 1 6 9 3 4 2 3 - ]"
+  -> "~ ~ ~ ~ ~ ~ ~ 17 16 15 ~ ~ ~ ~ ~ 14 14 5 10 11 ~ ~ ~ 10 ~ 10 10 9 11 8 9 9 7 6 9 4 1 1 5 1 1 6 9 3 4 2 3 ~"",
+  ""[- - - - - - - 17 16 15 - - - - - 14@2 5 10 11 - - - 10 - 10@2 9 11 8 9@2 7 6 9 4 1@2 5 1@2 6 9 3 4 2 3 - ]"
+  -> "~ ~ ~ ~ ~ ~ ~ 17 16 15 ~ ~ ~ ~ ~ 14@2 5 10 11 ~ ~ ~ 10 ~ 10@2 9 11 8 9@2 7 6 9 4 1@2 5 1@2 6 9 3 4 2 3 ~"",
+  ""[0 - - 4] [- - 8 -] [0 - - 4] [- - 8 -]"
+  -> "0 ~ ~ 4 ~ ~ 8 ~ 0 ~ ~ 4 ~ ~ 8 ~"",
+  ""[0 1 2 3]"
+  -> "0 1 2 3"",
+  ""[0 12]*4"
+  -> "0 12 0 12 0 12 0 12"",
+  ""[0 4 9 14]*4 "
+  -> "0 4 9 14 0 4 9 14 0 4 9 14 0 4 9 14"",
+  ""[0, 1, 2, 3, 4]"
+  -> "[0,1,2,3,4]"",
+  ""[0, 12]"
+  -> "[0,12]"",
+  ""[0,7,0] [2 -] [[0,3] 4]"
+  -> "[0,7,0]@2 2 ~ [0,3] 4"",
+  ""[1 2 3 4 5 6]*2"
+  -> "1 2 3 4 5 6 1 2 3 4 5 6"",
+  ""[1 2 4 7]"
+  -> "1 2 4 7"",
+  ""[1 2 4 7] [1 3 8]"
+  -> "1@3 2@3 4@3 7@3 1@4 3@4 8@4"",
+  ""[13 - - 15@4 16 17 16 14@2 16 14@2 15 13 12 6 7 10@3 8 9@3 10 7 11@2 12@2 11 10 8 0 0 1 6 4 5 2@3 3 2 - ]"
+  -> "13 ~ ~ 15@4 16 17 16 14@2 16 14@2 15 13 12 6 7 10@3 8 9@3 10 7 11@2 12@2 11 10 8 0 0 1 6 4 5 2@3 3 2 ~"",
+  ""[1@2 2] [3@2 4] 2 [0 1@2]@2 - - -"
+  -> "1@2 2 3@2 4 2@3 0@2 1@4 ~ ~ ~ ~ ~ ~ ~ ~ ~"",
+  ""[3 4 2 4]*8"
+  -> "3 4 2 4 3 4 2 4 3 4 2 4 3 4 2 4 3 4 2 4 3 4 2 4 3 4 2 4 3 4 2 4"",
+  ""[A0 E0] [C1 E0] [D1 E1] ~"
+  -> "a0 e0 c1 e0 d1 e1 ~ ~"",
+  ""[A1 E1] [C2 E1] [D2 E2] [Cb2 C2]"
+  -> "a1 e1 c2 e1 d2 e2 cb2 c2"",
+  ""[B3] [E3] [B3] [A3], ~ E2 ~ E2"
+  -> "b3 [e3,e2] b3 [a3,e2]"",
+  ""[C Eb] [G Bb] [D2 F A]"
+  -> "c@3 eb@3 g@3 bb@3 d2@2 f@2 a@2"",
+  ""[C2 ~ ~ G1]"
+  -> "c2 ~ ~ g1"",
+  ""[G4, C4] [G4, Eb4] [F4, A3, Eb4]"
+  -> "[g4,c4] [g4,eb4] [f4,a3,eb4]"",
+  ""[a1][a1][e1][fs1] [d1][fs1][d1][e1]"
+  -> "a1 a1 e1 fs1 d1 fs1 d1 e1"",
+  ""[a2, e3, cs3][a2, e3, c3][e2, g3, b3][fs2, cs3, as3]  [d2, f3, a3][fs2, cs3, as3][d2, f3, a3][e2, gs3, b3, d3]"
+  -> "[a2,e3,cs3] [a2,e3,c3] [e2,g3,b3] [fs2,cs3,as3] [d2,f3,a3] [fs2,cs3,as3] [d2,f3,a3] [e2,gs3,b3,d3]"",
+  ""[a4, f#4, d4, b3, g3][b4, g#4, e4, c#4, a3][c5, a4, f4, d4, bb3][b4, g#4, e4, c#4, a3, e3]"
+  -> "[a4,f#4,d4,b3,g3] [b4,g#4,e4,c#4,a3] [c5,a4,f4,d4,bb3] [b4,g#4,e4,c#4,a3,e3]"",
+  ""[a4,c#4,e4,g#4,c#5],c#6"
+  -> "[a4,c#4,e4,g#4,c#5,c#6]"",
+  ""[a4@3] [b4] [b4] [a4]"
+  -> "a4@3 b4@3 b4@3 a4@3"",
+  ""[c#4 d4 d4 c#4]"
+  -> "c#4 d4 d4 c#4"",
+  ""[c2, ds3, as3, d4]@3 [ds2, g3, as3, e4] [d3, f3, c4, e3]@3[cs2, g3, b3, f4]"
+  -> "[c2,ds3,as3,d4]@3 [ds2,g3,as3,e4] [d3,f3,c4,e3]@3 [cs2,g3,b3,f4]"",
+  ""[c2@6 c2 d2@0.75]*2"
+  -> "c2@12 c2@2 d2@1.5 c2@12 c2@2 d2@1.5"",
+  ""[c3@3 e3] [~ g2@2 b2]"
+  -> "c3@3 e3 ~ g2@2 b2"",
+  ""[c4,e4,g4,b4][g#4,c4,d#4,g4][g4,b4,d4,f4][c4,e4,g4,c4]"
+  -> "[c4,e4,g4,b4] [g#4,c4,d#4,g4] [g4,b4,d4,f4] [c4,e4,g4,c4]"",
+  ""[c4,e4,g4,c5]*2"
+  -> "[c4,e4,g4,c5] [c4,e4,g4,c5]"",
+  ""[c5 d5 e5 g5]"
+  -> "c5 d5 e5 g5"",
+  ""[c5 d5 f5 g#5 a5 g#5 f5]*2"
+  -> "c5 d5 f5 g#5 a5 g#5 f5 c5 d5 f5 g#5 a5 g#5 f5"",
+  ""[c5 f#5 a5 g5]*2"
+  -> "c5 f#5 a5 g5 c5 f#5 a5 g5"",
+  ""[d3@ a1 a2][a1 e1@2 d1][- cs2 a1 ds1 ][a2 c1@3]"
+  -> "d3@2 a1 a2 a1 e1@2 d1 ~ cs2 a1 ds1 a2 c1@3"",
+  ""[e f]*4"
+  -> "e f e f e f e f"",
+  ""[e2, g3, b3, d4]@3 [g2, b3, d4, e4] [a2, c3, e3, g3]@3 [b1, d3, f#3, a3]"
+  -> "[e2,g3,b3,d4]@3 [g2,b3,d4,e4] [a2,c3,e3,g3]@3 [b1,d3,f#3,a3]"",
+  ""[e4 f#4 f#4 e4]"
+  -> "e4 f#4 f#4 e4"",
+  ""[g#2][f2][c#2][c2]"
+  -> "g#2 f2 c#2 c2"",
+  ""[g#4 -] [g#4 - ] c# d# - g#3 g#5 - - - - - - - - -"
+  -> "g#4 ~ g#4 ~ c#@2 d#@2 ~ ~ g#3@2 g#5@2 ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~ ~"",
+  ""[g#4 ~ ~ ~]"
+  -> "g#4 ~ ~ ~"",
+  ""[g2 d2 e2][d2 b1@2 a1][- a2 f#2 g2 ][d2 b1@3]"
+  -> "g2@4 d2@4 e2@4 d2@3 b1@6 a1@3 ~ ~ ~ a2@3 f#2@3 g2@3 d2@3 b1@9"",
+  ""[g4 d4 b3][f#4 c4 a3][e4 b3 g3][d4 a3 f#3]"
+  -> "g4 d4 b3 f#4 c4 a3 e4 b3 g3 d4 a3 f#3"",
+  ""[g4 f#4 g4 e4 d4 e4 c4 d4]"
+  -> "g4 f#4 g4 e4 d4 e4 c4 d4"",
+  ""[g4,g#4,c5,d5,d#5][f4,a4,b4,c5,e5][c#4,f4,g4,g#4,c5][c4,e4,g4,b4]"
+  -> "[g4,g#4,c5,d5,d#5] [f4,a4,b4,c5,e5] [c#4,f4,g4,g#4,c5] [c4,e4,g4,b4]"",
+  ""[~ a1]*2 [~ d2]*2"
+  -> "~ a1 ~ a1 ~ d2 ~ d2"",
+  ""a a a a b b a ~ ~ ~ a ~ [c c] [b b]"
+  -> "a@2 a@2 a@2 a@2 b@2 b@2 a@2 ~ ~ ~ ~ ~ ~ a@2 ~ ~ c c b b"",
+  ""a c [e g]"
+  -> "a@2 c@2 e g"",
+  ""a!4 b!2 a@4 a@2 c*2 b*2"
+  -> "a@2 a@2 a@2 a@2 b@2 b@2 a@8 a@4 c c b b"",
+  ""a3 [c4@3 e4] g3 b4"
+  -> "a3@4 c4@3 e4 g3@4 b4@4"",
+  ""a3 [f3@3 d4] b4 g3"
+  -> "a3@4 f3@3 d4 b4@4 g3@4"",
+  ""a4 - bb5 c3"
+  -> "a4 ~ bb5 c3"",
+  ""a4 [a4 bb4] c5 [d5 e5] f5 [e5 d5] c5 [bb4 a4]"
+  -> "a4@2 a4 bb4 c5@2 d5 e5 f5@2 e5 d5 c5@2 bb4 a4"",
+  ""a5*16"
+  -> "a5 a5 a5 a5 a5 a5 a5 a5 a5 a5 a5 a5 a5 a5 a5 a5"",
+  ""a6!3 as6   a6 as6 a6!2"
+  -> "a6 a6 a6 as6 a6 as6 a6 a6"",
+  ""bb4 [bb4 d5] bb4 ~ f5 [f5 g5] f5 ~"
+  -> "bb4@2 bb4 d5 bb4@2 ~ ~ f5@2 f5 g5 f5@2 ~ ~"",
+  ""c3*8"
+  -> "c3 c3 c3 c3 c3 c3 c3 c3"",
+  ""c4 - c4 - [c4 d4] - c4 -"
+  -> "c4@2 ~ ~ c4@2 ~ ~ c4 d4 ~ ~ c4@2 ~ ~"",
+  ""c4 [e4@3 g4] b4 d4"
+  -> "c4@4 e4@3 g4 b4@4 d4@4"",
+  ""c4,g4"
+  -> "[c4,g4]"",
+  ""c5 [c5 bb4] a4 g4 f4 [g4 a4] bb4 c5"
+  -> "c5@2 c5 bb4 a4@2 g4@2 f4@2 g4 a4 bb4@2 c5@2"",
+  ""cb*4"
+  -> "cb cb cb cb"",
+  ""d#1*4"
+  -> "d#1 d#1 d#1 d#1"",
+  ""d4 d4  d e2 d2 d2 e2 c2"
+  -> "d4 d4 d e2 d2 d2 e2 c2"",
+  ""d5 [d5 eb5] f5 ~ bb5 [bb5 a5] g5 ~"
+  -> "d5@2 d5 eb5 f5@2 ~ ~ bb5@2 bb5 a5 g5@2 ~ ~"",
+  ""e c c# a*2"
+  -> "e@2 c@2 c#@2 a a"",
+  ""e c c# a*2 ~ e c"
+  -> "e@2 c@2 c#@2 a a ~ ~ e@2 c@2"",
+  ""e1 g1 e3 [g1 e3 g1]"
+  -> "e1@3 g1@3 e3@3 g1 e3 g1"",
+  ""e1*10"
+  -> "e1 e1 e1 e1 e1 e1 e1 e1 e1 e1"",
+  ""e4 [c#5@3 d5] [d4, g4, b4] [d4, g4, b4] [d4, g4, b4]@2 [d5, f#5]"
+  -> "e4@4 c#5@3 d5 [d4,g4,b4]@4 [d4,g4,b4]@4 [d4,g4,b4]@8 [d5,f#5]@4"",
+  ""f4 [f4 a4] c5 f5 e5 [d5 c5] bb4 [a4 g4]"
+  -> "f4@2 f4 a4 c5@2 f5@2 e5@2 d5 c5 bb4@2 a4 g4"",
+  ""f5 [f5 a5] c6 a5 f5 [e5 d5] c5 f4"
+  -> "f5@2 f5 a5 c6@2 a5@2 f5@2 e5 d5 c5@2 f4@2"",
+  ""f5 [f5 e5] d5 [c5 bb4] a4 [bb4 c5] d5 f5"
+  -> "f5@2 f5 e5 d5@2 c5 bb4 a4@2 bb4 c5 d5@2 f5@2"",
+  ""g4\\n     !4 g#2 f2 g2!2"
+  -> "g4 g4 g4 g4 g#2 f2 g2 g2"",
+  ""~ 1 ~  3 ~ ~ 3 1"
+  -> "~ 1 ~ 3 ~ ~ 3 1"",
+  ""~ 3 [8 0] 4 ~ 8 [~ 5] -3"
+  -> "~ ~ 3@2 8 0 4@2 ~ ~ 8@2 ~ 5 -3@2"",
+  ""~ G4 ~ D4 ~ C4"
+  -> "~ g4 ~ d4 ~ c4"",
+  ""~ ~ ~ A1"
+  -> "~ ~ ~ a1"",
+  ""~ ~ ~ ~ ~ ~  F2!2"
+  -> "~ ~ ~ ~ ~ ~ f2 f2"",
+  ""~ ~ ~ ~ ~ ~ F2"
+  -> "~ ~ ~ ~ ~ ~ f2"",
+  ""~ ~ ~ ~ ~ ~ ~ A3"
+  -> "~ ~ ~ ~ ~ ~ ~ a3"",
+  ""~ ~ ~ ~ ~ ~ ~ C2"
+  -> "~ ~ ~ ~ ~ ~ ~ c2"",
+  ""~@2 c6 d#5@2 c6 ~@6"
+  -> "~ ~ c6 d#5@2 c6 ~ ~ ~ ~ ~ ~"",
+]
+`;
+
+exports[`round-trip — an unedited open→write must not change the text > roll: LOCKED — these round-trip today and must not stop > roll-round-trips-locked 1`] = `
+[
+  " c4 a e c1",
+  " g c g c g c g c",
+  "-7",
+  "0",
+  "0 0 0 0",
+  "0 0 0 1",
+  "0 1 -2 -1",
+  "0 1 2",
+  "0 1 2 3",
+  "0 1 2 3 0 1 2 3",
+  "0 1 2 3 4 5",
+  "0 1 4 2 0 6 3 2",
+  "0 2 1 4 3 2 6 7",
+  "0 2 3 4 7@5",
+  "0 2 4 5 6 5 4 2",
+  "0 2 4 7",
+  "0 8 4 7",
+  "0 ~ 1 ~ 2 ~ 3 ~",
+  "1",
+  "1 2 3",
+  "1 3 4 6",
+  "1 3 5",
+  "1 3 5 4",
+  "10",
+  "11",
+  "12",
+  "13",
+  "14",
+  "15",
+  "16",
+  "16 44 55 66 77 16 ",
+  "17",
+  "18",
+  "19",
+  "2",
+  "2 9 5 5",
+  "20",
+  "21",
+  "22",
+  "23",
+  "24",
+  "25",
+  "26",
+  "27",
+  "28",
+  "29",
+  "3",
+  "3 5 8 10",
+  "30",
+  "31",
+  "32",
+  "33",
+  "33 44 56",
+  "34",
+  "35",
+  "36",
+  "37",
+  "38",
+  "39",
+  "4",
+  "40",
+  "41",
+  "42",
+  "43",
+  "44",
+  "45",
+  "46",
+  "47",
+  "48",
+  "49",
+  "5",
+  "50",
+  "51",
+  "52",
+  "53",
+  "54",
+  "55",
+  "56",
+  "57",
+  "58",
+  "59",
+  "6",
+  "60",
+  "60 62 64 67 69 67 64 62",
+  "60 89 53 71",
+  "61",
+  "62",
+  "63",
+  "64 67 55 90 89",
+  "69 67 65 64 65 64 64 65 67 65 64 64 62 62 60 62",
+  "69 71 73 76 76 74 76 74 76 74",
+  "7",
+  "72 69 72 69 72 69 69 70 72 67 67 65 67 65 67 67",
+  "77 76 74 72 76 74 76 74 76 74 77 79 72 76 74 76 74 76 74",
+  "79 93 7 32 ",
+  "8",
+  "9",
+  "<-16@7 [-15 -17 -14]>",
+  "<-18 -18 -18 -18 -15 -17 -18 -18 -15 -17 -20 -22>",
+  "<0 1 2 1 4 5 [4 3 4 5 6 7] 0>",
+  "<0 1 2 3 4 5 6 7 8 0 0>",
+  "<0 1 2 3 4>",
+  "<0 1 5 3 3 7 3>",
+  "<0 2 5 3>",
+  "<0 3 5 7 3 5 0 2>",
+  "<0 [0 1 2]>",
+  "<1 0>",
+  "<11 [12 11 10 9] 11 [10 9 10 8] 7 [6 7 8 6] 7 7>",
+  "<24@4 26@2>",
+  "<3 4>",
+  "<33 ~ 33 ~ 33 ~ 31 ~>",
+  "<4 3 5 1>",
+  "<5 4 3>",
+  "<5 7>",
+  "<[0 0 0 0] [4 4 4 4] [7 7 7 7] [4 4 4 4]>",
+  "<[2@3 -2@3 -2@2] [-2@3 -2@3 -3@2] [2@3 -3@3 -3@2] [-3@3 -3@3 -5@2]>",
+  "<[bb4 ~ c5 ~] [d5 ~ bb4 ~] [c5 ~ ab4 ~] [bb4 ~ g4 ~]>",
+  "<[c2,c1] [ab0,ab1] [f0,f1] [g0,g1]>",
+  "<[c2,e2] [a1,d2] [g1,c2] [f1,a1]>",
+  "<[c3,eb3,g3] [g2,bb2,d3] [ab2,c3,eb3] [f2,ab2,c3]>",
+  "<[c3,g3,e4] [bb2,f3,d4] [a2,f3,c4] [bb2,g3,eb4]>",
+  "<[c4,e4,g4] [a3,d4,f4] [g3,c4,e4] [f3,a3,c4]>",
+  "<[d4,f4,bb4] [f4,bb4,d5] [c4,f4,ab4] [eb4,ab4,c5]>",
+  "<[g3,bb3,d4,f4] [bb3,d4,f4] [f3,ab3,c4] [ab3,c4,eb4]>",
+  "<[g5 bb5] ~ [f5 ab5] ~>",
+  "<a2 ~ ~ f2 ~ ~ g2 ~ ~ e2 ~ ~ a2 ~ ~ f2 ~ ~ g2 ~ ~ c3 ~ ~>",
+  "<a4 ~ ~ c5 ~ e5 ~ c5 ~ ~ g4 ~ b4 ~ g4 ~ ~ e5 ~ a5 ~>",
+  "<c1 ab1 d1 g1>",
+  "<c4 ~ ~ e4 ~ g4 ~ ~ b4 ~ g4 ~ e4 ~>",
+  "<d2 e2 c#2 a1>",
+  "<eb1 f1 gb1 [ab1@3 bb1]>",
+  "<eb4 f4 g4 d4>",
+  "<g# f c d# [f2@7 g2] g#2 c a#2>",
+  "<g2 bb2 f2 ab2>",
+  "<g3 bb3 f3 ab3>",
+  "<~ ~ ~ ~ ~ ~ ~ ~ c5 ~ e5 g5 ~ ~ e5 g5>",
+  "[-7,-2]",
+  "[g,b,d]",
+  "a b c2 d1 e3 f4 g5 f4 a a b b b c c d d e e e e f f f f g g g g a a a",
+  "a b g",
+  "a e b1 c d1 f g",
+  "a#4 d#5",
+  "a2",
+  "a2 gs2 g2 fs2 f2 a2 gs2 as2",
+  "a3",
+  "a3 c3 e3 f3",
+  "a3 c4 f4 e4 d4 c4 bb3 a3",
+  "a3 f3 bb3 c4 d4 c4 bb3 a3",
+  "a3 ~ ~ ~",
+  "a4 a4 a4 a4",
+  "a4 a4 a4 a4  ",
+  "a4 c5 f5 a5 g5 e5 c5 g4",
+  "b3",
+  "bb1 ~ f2 ~ bb1 ~ f2 ~",
+  "bb2 ~ f2 ~ bb2 ~ f2 ~",
+  "bb3 ~ f3 ~ bb3 ~ f3 ~",
+  "c a f f e",
+  "c a g",
+  "c d f e",
+  "c eb g bb",
+  "c#4@3 f#4@1.5 e4@1.5 b3",
+  "c1",
+  "c1 f1",
+  "c1 ~ ~ ~ c1 ~ g1 ~",
+  "c2",
+  "c2 e3 g4 b5 c6 b5 g4 e3 c2",
+  "c2 f2 c2 g2",
+  "c2 ~ a2 g2 ~",
+  "c2 ~ ~ g1 ~ ~ a1 ~",
+  "c2@2 e2 c2 f2 c2 g2 e2",
+  "c3",
+  "c3 bb2 f3 eb3",
+  "c3 c2 c2 c2 c3 c2 d3 d#3 c2 c3 c3 c2 c3 c2 d3 d#2",
+  "c3 c3 c3 c3",
+  "c3 e3 f3 g3",
+  "c3 g3 a3 f3 d3 e3",
+  "c3 ~ g3 ~ a3 ~",
+  "c4 a4 f4 e4",
+  "c4 f4 a4 c5 a4 f4 a4 c4",
+  "c4 f4 a4 g4 f4 e4 d4 c4",
+  "c4 g4 c5 g5",
+  "c4 ~ eb4 ~ g4 ~ bb4 ~",
+  "c4 ~ g4 a4",
+  "c5 b4 a4 g4 f#4 g4 e4 f#4",
+  "c5 e5 g5 a5 b5 a5 g5 e5",
+  "c5 e5 g5 b5",
+  "c5 f5 a5 f5 c5 ~ f5 ~",
+  "c5 f5 g5 c5 c5 f5 g5 g5",
+  "c5 ~ ~ ~ g5 ~ ~ ~",
+  "c5@8 b4@8",
+  "c6 f6 a6",
+  "cb eb gb bb bb bb bb",
+  "d e g b a g a b b a g g g a b a",
+  "d2 a2 d2 d2",
+  "d3",
+  "d4 d4 d d2 d2 e2 c2",
+  "d4 d4 d3 e2 d2 d2 e2 c2",
+  "d4 f4 d4 c4 bb3 d4 c4 bb3",
+  "e",
+  "e f f a c",
+  "e1 ~ ~ ~ ~ b0 ~ ~",
+  "e2 e2",
+  "e2 e2 d3 e3 d3 c3",
+  "e3",
+  "e3 d2 g4 a3",
+  "e4 f4 e4 g4",
+  "eb2",
+  "f#3 b3 e4",
+  "f2 a2 c3 f3 c3 a2 g2 c2",
+  "f2 c3 a2 c3 f2 c3 g2 c3",
+  "f2 c3 d3 bb2 a2 f2 c3 f2",
+  "f2 c3 f2 c3 f2 c3 f2 c3",
+  "f2 c3 g3 ab3 bb3 eb4 a2 gb3 a3 db4 f4 eb4 bb2 f3 ab3 c4",
+  "f2 ~ c3 ~ f2 ~ c3 ~",
+  "f3 a3 c4 a3 f3 a3 c4 f3",
+  "f3 ~ a3 ~ e3 ~ d3 ~",
+  "f3 ~ a3 ~ g3 ~ d3",
+  "f4 c4",
+  "fs1 fs1 ~ fs1 d1 ~ a1 ~ e1",
+  "fs5 fs5 e5 fs5 a5 g#5 fs5 e5 d5 d5 cs5 b4 a4 b4 cs5 e5",
+  "g1",
+  "g2 d2 g3 d2",
+  "g3 f#3 e3 ~",
+  "g3 g4 g5 g6",
+  "g4 d4 e4 d4 b3 a3 f#4 g4",
+  "~",
+  "~ 6 ~ 6 ~ 6 ~ 6",
+  "~ a4 ~ a4 ~ g4 ~ g4",
+  "~ f4 ~ f4 ~ f4 ~ f4",
+  "~ ~ 0 ~ 0 ~ ~ 0",
+]
+`;
+
+exports[`round-trip — an unedited open→write must not change the text > roll: serializer refuses a model it just parsed > roll-serializer-null 1`] = `
+[
+  "<[g3,b3,e4] [a3,c3,e4] [b3,d3,f#4] [b3,e4,g4]@0.75 [b3,d3,f#4]@0.25>",
+  "<~ [~@3.5 d2@2 c#2@2.5]>",
+]
+`;

--- a/packages/app/tests/parity-corpus/round-trip.test.ts
+++ b/packages/app/tests/parity-corpus/round-trip.test.ts
@@ -1,0 +1,177 @@
+/**
+ * round-trip.test.ts — opening a view and writing it back must not change the text.
+ *
+ * THE LAW: for any mini string a view can open, `serialize(parse(mini))` must
+ * equal `mini` when nothing was edited. Opening a grid is a READ. A read that
+ * rewrites the document is data loss, and it is loss the user never asked for
+ * and cannot see coming.
+ *
+ * THE LAW DOES NOT HOLD TODAY. That is why this file exists and why most of it
+ * is a pinned residual rather than a green assertion. Measured over the 1500
+ * real-world strings in `mini-corpus.json`:
+ *
+ *     GRID   opens 781   round-trips 512 (65.6%)   REWRITES 269
+ *     ROLL   opens 392   round-trips 230 (58.7%)   REWRITES 160
+ *
+ * Concretely, today: open `bd hh*2 sd cp` in the grid, nudge one cell, and the
+ * user's line becomes `bd ~ hh hh sd ~ cp ~`. Their `*2` is gone. Reading the
+ * grid rewrites of the corpus and classifying them by hand rather than trusting
+ * the total: 2 are whitespace, 16 swap the user's `-` rests for `~`, and 251
+ * are STRUCTURAL — sugar expanded, groups flattened, the grid padded to a
+ * uniform resolution. 93% of the rewrites destroy notation.
+ *
+ * This is not news to the catalogue — `atom*n` is documented as parse-only
+ * sugar that "serializes back as the EXPANDED sequence". It was a deliberate
+ * choice. What was never recorded is the BLAST RADIUS: a third of everything
+ * the grid can open. A design note that reads reasonably as "sugar expands"
+ * reads differently as "32% of real content is rewritten on touch".
+ *
+ * WHAT THIS FILE IS FOR — three jobs, and the middle one is the point:
+ *
+ *   1. LOCK what already works. The 512 grid / 230 roll strings that round-trip
+ *      today are asserted exactly. If a change breaks one, this goes red now,
+ *      not in someone's project.
+ *   2. PIN the residual, VISIBLY. The failures are snapshotted with what each
+ *      mini becomes — so the loss is documented instead of hidden, and it is
+ *      reviewable. A number in a summary can be netted away; a list cannot.
+ *   3. BE MEANT TO FLIP. This snapshot is a WORKLIST, not a baseline. #903 A2
+ *      (span-surgery write) exists to shrink it, and its PR is measured by the
+ *      lines LEAVING this file. Entries disappearing is the goal.
+ *
+ * DRIFT POLICY — read carefully, it differs by direction:
+ *   - an entry LEAVING the residual  = A2 working. Expected, good, review it.
+ *   - an entry ARRIVING              = a REGRESSION. Something that round-tripped
+ *                                      stopped. Do not accept it with `-u`.
+ *   - the locked set going red       = stop. That is live data loss.
+ * `vitest -u` cannot tell these apart. You can. Read the diff.
+ *
+ * SCOPE: the UNEDITED open→write path only. An edited grid must of course emit
+ * new text; identity is the right bar only when nothing changed. That is also
+ * exactly the path a user hits by clicking a cell and clicking away.
+ */
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// Deep source path, not the `@stave/editor` barrel — the barrel pulls
+// @strudel/draw -> gifenc (CJS) and crashes the ESM resolver under vite-node
+// (same convention as parity.test.ts:38).
+import {
+  parseStepGrid,
+  parsePianoRoll,
+} from '../../../editor/src/visualEdit/notation/parse'
+import {
+  serializeStepGrid,
+  serializePianoRoll,
+} from '../../../editor/src/visualEdit/notation/serialize'
+
+const corpusDir = path.dirname(fileURLToPath(import.meta.url))
+const corpus: { minis: { mini: string }[] } = JSON.parse(
+  fs.readFileSync(path.join(corpusDir, 'mini-corpus.json'), 'utf8'),
+)
+
+type Outcome =
+  | { kind: 'closed' }
+  | { kind: 'identity' }
+  | { kind: 'rewritten'; out: string }
+  | { kind: 'null' }
+
+/** open → write, with nothing edited in between */
+function roundTrip(
+  mini: string,
+  parse: (m: string) => { ok: boolean; model?: unknown },
+  serialize: (model: never) => string | null,
+): Outcome {
+  const r = parse(mini)
+  if (!r.ok) return { kind: 'closed' }
+  let out: string | null
+  try {
+    out = serialize(r.model as never)
+  } catch {
+    // A serializer THROW on an unedited model is not a residual to pin — it is
+    // a crash on the read path. Surfaced separately below.
+    return { kind: 'null' }
+  }
+  if (out === null) return { kind: 'null' }
+  return out.trim() === mini.trim() ? { kind: 'identity' } : { kind: 'rewritten', out }
+}
+
+const VIEWS = [
+  { name: 'grid', parse: parseStepGrid, serialize: serializeStepGrid },
+  { name: 'roll', parse: parsePianoRoll, serialize: serializePianoRoll },
+] as const
+
+/** the residual, computed once — the same data feeds the lock and the pin */
+const outcomes = VIEWS.map((v) => ({
+  view: v.name,
+  rows: corpus.minis.map(({ mini }) => ({
+    mini,
+    r: roundTrip(mini, v.parse as never, v.serialize as never),
+  })),
+}))
+
+describe('round-trip — an unedited open→write must not change the text', () => {
+  /**
+   * JOB 1 — lock what works: the set of real-world strings a user can safely
+   * open TODAY, pinned by name. If one leaves this list, a change made a safe
+   * string unsafe, and the diff says exactly which.
+   *
+   * This is a SNAPSHOT and not a computed check on purpose. The first draft of
+   * this test recomputed the round-trip and asserted the result differed from
+   * the result — `expect(X).toEqual(X)` with extra steps, on deterministic
+   * code. It passed, it looked like a lock, and it could not have failed for
+   * any reason. A lock needs a reference OUTSIDE the run it is checking; the
+   * snapshot file is that reference.
+   */
+  it.each(VIEWS.map((v) => v.name))('%s: LOCKED — these round-trip today and must not stop', (name) => {
+    const rows = outcomes.find((o) => o.view === name)!.rows
+    const safe = rows.filter((x) => x.r.kind === 'identity').map((x) => x.mini)
+    expect(safe).toMatchSnapshot(`${name}-round-trips-locked`)
+  })
+
+  /**
+   * JOB 2 + 3 — pin the loss, visibly, as a worklist meant to shrink.
+   * The snapshot records what each mini BECOMES, because "269 fail" is a number
+   * that can be argued with and `bd hh*2 sd cp -> bd ~ hh hh sd ~ cp ~` is not.
+   */
+  it.each(VIEWS.map((v) => v.name))(
+    '%s: KNOWN RESIDUAL — these are rewritten today and MUST flip (#903 A2)',
+    (name) => {
+      const rows = outcomes.find((o) => o.view === name)!.rows
+      const residual = rows
+        .filter((x): x is typeof x & { r: { kind: 'rewritten'; out: string } } => x.r.kind === 'rewritten')
+        .map((x) => `${JSON.stringify(x.mini)}\n  -> ${JSON.stringify(x.r.out)}`)
+      expect(residual).toMatchSnapshot(`${name}-rewritten-residual`)
+    },
+  )
+
+  /**
+   * The headline, asserted as a CEILING that A2 lowers. A ceiling rather than
+   * an equality so an added fixture cannot trip it — but it cannot silently
+   * grow either. When A2 lands, this number comes down and the snapshot shrinks
+   * with it; the two must move together, which is what makes either credible.
+   */
+  it('the rewrite count does not grow', () => {
+    const counts = Object.fromEntries(
+      outcomes.map((o) => [o.view, o.rows.filter((x) => x.r.kind === 'rewritten').length]),
+    )
+    // MEASURED 2026-07-17 by running it, over 1500 real strings:
+    //   grid 269 of 781 opened (65.6% round-trip) — of these, 251 STRUCTURAL
+    //   roll 160 of 392 opened (58.7% round-trip)
+    expect(counts.grid).toBeLessThanOrEqual(269)
+    expect(counts.roll).toBeLessThanOrEqual(160)
+  })
+
+  /**
+   * A serializer returning `null`/throwing on an UNEDITED model it just parsed
+   * is a different animal from a rewrite: the view opened, and then could not
+   * write back what it read. Pinned separately so it is never mistaken for a
+   * notation residual A2 will fix.
+   */
+  it.each(VIEWS.map((v) => v.name))('%s: serializer refuses a model it just parsed', (name) => {
+    const rows = outcomes.find((o) => o.view === name)!.rows
+    const nulls = rows.filter((x) => x.r.kind === 'null').map((x) => x.mini)
+    expect(nulls).toMatchSnapshot(`${name}-serializer-null`)
+  })
+})


### PR DESCRIPTION
Part of #903. **Does not close it.** This is the measurement A2 will be judged by, landed first and separately so the gap is visible **before** the writer changes.

**This PR fixes nothing.** That's deliberate.

## The law

For any mini a view can open, `serialize(parse(mini))` must equal `mini` when nothing was edited. **Opening a grid is a READ.** A read that rewrites the document is data loss the user never asked for and cannot see coming.

## It does not hold today

Measured over the 1500 real strings in `mini-corpus.json` (#911):

| | opens | round-trips | **rewrites** |
|---|---|---|---|
| **grid** | 781 | 512 (65.6%) | **269** |
| **roll** | 392 | 230 (58.7%) | **160** |

Concretely, right now: open `bd hh*2 sd cp` in the grid, nudge one cell, and the user's line becomes `bd ~ hh hh sd ~ cp ~`. Their `*2` is gone.

I classified all 269 grid rewrites **by reading them**, not by trusting the total:

| count | class |
|---:|---|
| 2 | whitespace only |
| 16 | `-` rest rewritten as `~` — semantics identical (`mini.mjs:157`), but not their text |
| **251** | **STRUCTURAL — sugar expanded, groups flattened, grid padded** |

**93% of the rewrites destroy notation.**

## This is known behaviour — the *scale* is what's new

`atom*n` is documented in the catalogue as parse-only sugar that "serializes back as the EXPANDED sequence". It was a deliberate design choice, and I'm not filing it as a bug. What was never recorded is the **blast radius**: a third of everything the grid can open.

*"Sugar expands"* and *"32% of real content is rewritten on touch"* are the same sentence at different scales — and only one of them sounds like a problem. That gap is the whole reason this is a file and not a paragraph.

## Three jobs — the middle one is the point

1. **LOCK** — the 512 grid / 230 roll strings that round-trip today, pinned by name. If one leaves, a change made a safe string unsafe.
2. **PIN** — the residual, *with what each mini becomes*. "269 fail" is a number you can argue with; `bd hh*2 sd cp -> bd ~ hh hh sd ~ cp ~` is not.
3. **FLIP** — this is a **worklist, not a baseline**. A2 is measured by the lines *leaving* this snapshot.

### Drift policy — it differs by direction, which is why `-u` can't be trusted here

| movement | meaning |
|---|---|
| entry **leaves** the residual | A2 working — expected, review it |
| entry **arrives** | a **regression** — something that round-tripped stopped |
| the **locked set** goes red | **stop.** That is live data loss |

`vitest -u` cannot tell these apart. You can.

## Test plan

**The lock is shown RED.** Corrupting `serializeStepGrid` so a currently-safe string stops round-tripping turns it red, naming the string.

That arm earned its keep: **the first draft of the lock could not fail.** It recomputed the round-trip and asserted the result differed from the result — `expect(X).toEqual(X)` with extra steps, on deterministic code. It passed. It read like a lock. It was worthless. A lock needs a reference *outside* the run it checks; the snapshot file is that reference. (Written, with no irony available, in a PR about tests that cannot fail.)

- app **747** (+7, reconciled) · editor **2997** unchanged · test-only, no dist rebuild.

## The law already found something — an A1 consequence

Two roll minis parse but their serializer returns `null`:

```
<[g3,b3,e4] [a3,c3,e4] [b3,d3,f#4] [b3,e4,g4]@0.75 [b3,d3,f#4]@0.25>
<~ [~@3.5 d2@2 c#2@2.5]>
```

Fractional weights — which **A1 made parseable** — inside a multi-bar chord alternation the serializer has never supported (#628). The write path handles it correctly (`if (mini == null) return // inexpressible — leave the document untouched`), so **there is no data loss**. But the roll now **opens** them, and a drag **silently does nothing**. A1 traded a clean refusal for a false affordance in 2/1500 cases.

Small — but it's the same silent-no-op class as #180, so it's pinned in **its own snapshot**, not mixed into the residual: **A2 does not fix this**, and it shouldn't look like it will. Worth its own issue if you want it chased.

## Scope

The **unedited** open→write path only. An edited grid must emit new text; identity is the right bar only when nothing changed — which is exactly what a user hits by clicking a cell and clicking away.
