### PR TITLE
✅ chore(test): one `pnpm gate:editing` that runs both editing suites (#926)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,27 @@ Open an issue describing the feature, its motivation, and how it fits into Stave
 3. Make your changes
 4. Run the test suite: `cd packages/editor && npx vitest run`
 5. Run type checking: `cd packages/editor && npx tsc --noEmit`
-6. Sign off all commits (see DCO section above)
-7. Open a PR against `main` with a clear description
+6. If you touched pattern parsing, the notation model, or the visual-edit write-back path, also
+   run the editing fidelity gate from the repo root: `pnpm gate:editing` (see below)
+7. Sign off all commits (see DCO section above)
+8. Open a PR against `main` with a clear description
+
+#### The editing fidelity gate
+
+The editing suites span two packages: the notation model's own tests in `packages/editor`, and the
+corpus-wide reach, round-trip, locality and stress sweeps in `packages/app` — which deep-import the
+editor's notation *source*. Because the app's pinned snapshots sit downstream of the editor's
+model, a parsing or reach change can leave `packages/editor` fully green while flipping app
+snapshots. Per-package green is not suite green, so run both together:
+
+```bash
+pnpm gate:editing          # both packages, one verdict (~6s)
+pnpm gate:editing:editor   # notation model only, for a fast inner loop
+pnpm gate:editing:app      # corpus reach/round-trip only
+```
+
+`pnpm gate:editing` runs both halves unconditionally — it deliberately does not stop at the first
+failure, so one package's breakage can never hide the other's. It exits non-zero if either fails.
 
 ### Commit Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,15 +53,16 @@ Open an issue describing the feature, its motivation, and how it fits into Stave
 
 #### The editing fidelity gate
 
-The editing suites span two packages: the notation model's own tests in `packages/editor`, and the
-corpus-wide reach, round-trip, locality and stress sweeps in `packages/app` — which deep-import the
-editor's notation *source*. Because the app's pinned snapshots sit downstream of the editor's
-model, a parsing or reach change can leave `packages/editor` fully green while flipping app
-snapshots. Per-package green is not suite green, so run both together:
+The editing suites span two packages: the whole visual-editing subsystem in
+`packages/editor/src/visualEdit` (notation model, write-back, chunk detection, panels), and the
+corpus-wide reach, round-trip, locality and stress sweeps in `packages/app/tests/parity-corpus` —
+which deep-import the editor's notation *source*. Because the app's pinned snapshots sit
+downstream of the editor's model, a parsing or reach change can leave `packages/editor` fully green
+while flipping app snapshots. Per-package green is not suite green, so run both together:
 
 ```bash
-pnpm gate:editing          # both packages, one verdict (~6s)
-pnpm gate:editing:editor   # notation model only, for a fast inner loop
+pnpm gate:editing          # both packages, one verdict (~8s)
+pnpm gate:editing:editor   # visual-editing subsystem only, for a fast inner loop
 pnpm gate:editing:app      # corpus reach/round-trip only
 ```
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "parity:refresh": "node packages/app/scripts/parity-refresh.mjs",
     "parity:bakery": "node packages/app/scripts/parity-bakery.mjs",
     "edit:coverage": "pnpm --filter @stave/app exec vitest run --config vitest.edit-coverage.config.ts",
-    "edit:coverage:bakery": "node packages/app/scripts/edit-coverage-bakery.mjs"
+    "edit:coverage:bakery": "node packages/app/scripts/edit-coverage-bakery.mjs",
+    "gate:editing": "pnpm gate:editing:editor; e=$?; pnpm gate:editing:app; a=$?; exit $((e|a))",
+    "gate:editing:editor": "pnpm --filter @stave/editor exec vitest run src/visualEdit/notation",
+    "gate:editing:app": "pnpm --filter @stave/app exec vitest run tests/parity-corpus"
   },
   "devDependencies": {
     "turbo": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "edit:coverage": "pnpm --filter @stave/app exec vitest run --config vitest.edit-coverage.config.ts",
     "edit:coverage:bakery": "node packages/app/scripts/edit-coverage-bakery.mjs",
     "gate:editing": "pnpm gate:editing:editor; e=$?; pnpm gate:editing:app; a=$?; exit $((e|a))",
-    "gate:editing:editor": "pnpm --filter @stave/editor exec vitest run src/visualEdit/notation",
+    "gate:editing:editor": "pnpm --filter @stave/editor exec vitest run src/visualEdit",
     "gate:editing:app": "pnpm --filter @stave/app exec vitest run tests/parity-corpus"
   },
   "devDependencies": {


### PR DESCRIPTION
## Problem

The editing fidelity suites live in **two packages**:

- `packages/editor/src/visualEdit/notation/__tests__/` — the notation model's own tests
- `packages/app/tests/parity-corpus/` — the corpus-wide reach, round-trip, locality and stress sweeps

The app suite deep-imports the editor's notation **source** (`../../../editor/src/visualEdit/notation/parse`), so its pinned snapshots sit downstream of the editor's model. A parsing or reach change can therefore leave `packages/editor` fully green while flipping app snapshots — per-package green is not suite green. Until now the two halves were only ever run ad-hoc.

## Fix

A single `pnpm gate:editing` from the repo root, plus `:editor` / `:app` halves for a fast inner loop:

```bash
pnpm gate:editing          # both packages, one verdict (~6s)
pnpm gate:editing:editor   # notation model only
pnpm gate:editing:app      # corpus reach/round-trip only
```

Documented in `CONTRIBUTING.md` as the step for any parse / notation / write-back change.

Two choices worth naming:

- **Membership is directory-derived, not a file list.** The gate is scoped to the two directories, so a new editing test joins it by existing rather than by being remembered. A transcribed list would silently omit new tests — the same drift the control-registry work removed from classification.
- **It does not short-circuit.** Both halves run unconditionally and the exit code is their OR. A fail-fast `&&` was tried first and rejected on observation (below).

No test files and no vitest configs were changed. The gate reuses each package's existing config with a path filter, so there is no second config to drift from the real suites. The app tests import editor *source*, not `dist`, so no build step is needed and the gate cannot pass against a stale `dist`.

## Test plan

Baseline on `studio_v0.2.0` @ `8631ee9b` — editor **7 files / 256 tests**, app **11 files / 161 tests**, ~6s combined, green.

Beyond "the tests pass", the gate's own claim — *this catches a cross-package regression* — was verified by injecting one. Narrowing the multi-cycle static probe in `notation/parse.ts` from 8 cycles to 2 (a real reach change that silently drops cycles on write-back):

| Scenario | Editor half | App half | `pnpm gate:editing` exit |
|---|---|---|---|
| Injected reach regression | 1 test fails | 2 pinned snapshots fail | **1**, both reported in one run |
| App-only failure, editor green | passes | 1 test fails | **1** (not swallowed) |
| Clean tree | passes | passes | **0** |

That first row is what killed the `&&` form: fail-fast stopped at the editor's single failing test and **hid the two broken app snapshots** — precisely the failure this gate exists to prevent. Both injections were fully reverted; the tree is clean.

## Note on enforcement

This repo has no CI workflows and no git hooks, so the gate is **disciplinary, not mechanical** — it is run before every editing PR by convention, and nothing forces it. Adding CI would be new repo-wide infrastructure well outside this issue's scope; flagging it rather than implying a gate exists that doesn't.

Closes #926. Part of #925.