### PR TITLE
🐛 fix(timeline): a signal-indexed sample track draws its own lane (#927)

### DIFF
--- a/packages/app/src/components/musicalTimeline/timelineMarks.ts
+++ b/packages/app/src/components/musicalTimeline/timelineMarks.ts
@@ -30,6 +30,36 @@ function clamp01(n: number): number {
 }
 
 /**
+ * Every DECLARED top-level track's containment anchor `(laneKey → $:-line start)`,
+ * read straight from the IR Track wrappers — NOT from `collectCycles` events.
+ *
+ * #927 (P1b): a track whose note value is a signal (`n(run(8)).s(…)`,
+ * `n(irand(8))…`) emits NO static-IR events, so the event-driven anchor build
+ * below never registers its lane. Its eval haps, however, DO carry a `loc` (the
+ * `.s("piano")` mini-string), so `irLaneFor` resolves them to the largest anchor
+ * ≤ that offset — the PREVIOUS track's lane — and the signal track silently folds
+ * into its neighbour (one lane where there should be two). Seeding the anchor map
+ * from the declared Track wrappers (which exist and carry `trackId` + a `$:`-line
+ * `loc` even with zero events) gives every declared track its own anchor, so a
+ * located hap lands on its OWN lane and the eval-lane append (timelineScene) then
+ * renders it. Loc-less haps (`note(sine…)`) are unaffected — they still fall
+ * through to `evalTrackIdToLaneKey`. Only the TOP-LEVEL wrappers matter: a stack's
+ * inner voices share their track's `trackId` (one lane), so no recursion.
+ */
+function declaredTrackAnchors(ir: PatternIR): Array<[string, number]> {
+  const tracks = ir.tag === 'Stack' ? ir.tracks : [ir]
+  const out: Array<[string, number]> = []
+  for (const t of tracks) {
+    if (t.tag !== 'Track') continue
+    const start = t.loc?.[0]?.start
+    if (typeof t.trackId === 'string' && typeof start === 'number' && Number.isFinite(start)) {
+      out.push([t.trackId, start])
+    }
+  }
+  return out
+}
+
+/**
  * Collect read-only mini-note marks for the display span by querying the IR
  * directly (`collectCycles`), grouped by the SAME `laneKeyOf` identity the
  * analysis lanes use, capped per lane. `null` IR / non-positive span → empty.
@@ -166,6 +196,17 @@ export function collectNoteMarks(
         gain: clamp01(ev.gain ?? 1),
         voice: ev.s ?? null,
       })
+    }
+  }
+  // #927 — seed containment anchors for DECLARED tracks the event walk missed
+  // (a signal-valued track emits zero static-IR events, so it never appeared
+  // above). Additive + `!has`-guarded: event-producing tracks keep their
+  // event-derived `dollarPos`; only zero-event tracks gain an anchor, so a
+  // located hap in their span lands on their OWN lane instead of folding into
+  // the previous one. Only meaningful for the eval path (haps carry `loc`).
+  if (useEval && ir.tag === 'Stack') {
+    for (const [key, start] of declaredTrackAnchors(ir)) {
+      if (!labelOffsetByLane.has(key)) labelOffsetByLane.set(key, start)
     }
   }
   // When eval events are present, derive the marks from them instead of the IR

--- a/packages/app/tests/full-song-eval-lanes.spec.ts
+++ b/packages/app/tests/full-song-eval-lanes.spec.ts
@@ -93,3 +93,44 @@ test('a sampled-signal track (no static-IR events) gets its own eval-backed lane
 
   expect(errors).toEqual([])
 })
+
+// #927 — the LOCATED-hap fold (distinct from the #865 case above, which is a
+// LOC-LESS signal that already fell through to the eval lane). A signal-INDEXED
+// SAMPLE track (`n(run(8)).s('piano')`) emits zero static-IR events, so its lane
+// never entered the containment-anchor map — but its haps DO carry a `loc` (the
+// `.s('piano')` mini-string), so they folded into the PREVIOUS track's lane
+// instead of getting their own (one lane where there should be two). The fix
+// seeds the anchor map from the declared Track wrappers.
+const P1B_CASES: Array<[string, string, string[]]> = [
+  // run(): 8 discrete located haps, no IR events. The primary regression.
+  ['run() index melody', '$: s("bd sd")\n$: n(run(8)).s("piano")', ['d1', 'd2']],
+  // a segmented signal fed through `n(...).s(...)` — discrete + located.
+  ['segmented signal index', '$: s("bd sd")\n$: n(irand(8).segment(8)).s("piano")', ['d1', 'd2']],
+  // NAMED tracks — the anchor is keyed by the track name, not a positional d{N}.
+  ['named signal track', 'drums: s("bd sd")\nlead: n(run(8)).s("piano")', ['drums', 'lead']],
+  // The zero-event track sits BETWEEN two event tracks — its anchor must not let
+  // its haps fold up into d1 NOR steal d3's; all three lanes must survive.
+  ['middle zero-event track', '$: s("bd sd")\n$: n(run(8)).s("piano")\n$: s("hh*4")', ['d1', 'd2', 'd3']],
+]
+
+for (const [label, code, keys] of P1B_CASES) {
+  test(`#927 signal-indexed sample track gets its own lane: ${label}`, async ({ page }) => {
+    const errors: string[] = []
+    page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+    page.on('console', (m) => {
+      if (m.type() === 'error') errors.push(`console.error: ${m.text()}`)
+    })
+
+    await boot(page)
+    await evalCode(page, code)
+    await page.locator('[data-full-song="root"]').waitFor({ timeout: 10_000 })
+
+    // One lane per track — the sample track is NOT folded into a neighbour.
+    await expect(page.locator('[data-full-song-lane]')).toHaveCount(keys.length, { timeout: 10_000 })
+    for (const k of keys) {
+      await expect(page.locator(`[data-full-song-lane="${k}"]`)).toHaveCount(1)
+    }
+
+    expect(errors).toEqual([])
+  })
+}


### PR DESCRIPTION
## Problem

A track whose note value is a **signal** — `n(run(8)).s("piano")`, `n(irand(8).segment(8)).s(...)`, any `n(<signal>).s(<sample>)` — emits **zero static-IR note events**, so the Song timeline's containment-anchor map (built by walking the collected IR events) never learned its lane. Its evaluated haps **do** carry a source location (the `.s("piano")` mini-string), so when they were attributed to a lane by "largest anchor start ≤ hap offset", they matched the **previous** track's anchor and folded into it. Result: two tracks, **one lane** — the sample melody silently vanished into the drums.

`note(<signal>)` tracks escaped only by being location-less (they fell through to the eval-lane path); `n("0 1 2").s()` escaped only by having real IR events. The `run`/`irand` index melodies fell in the gap.

## Fix

Seed the containment-anchor map from the **declared top-level Track wrappers**, which the parser emits with a `trackId` and a `$:`-line location even when a track produces no events. Every declared track now has its own anchor, so a located hap lands on its **own** lane and the existing eval-lane append renders it.

The seed is additive and `!has`-guarded: event-producing tracks keep their event-derived offsets untouched, and location-less signal haps are unaffected — so the earlier sampled-signal case (the loc-less path) does not regress. Only the eval path is touched (haps carry locations); pre-eval display is unchanged. App-only change (`timelineMarks.ts`) — no editor `dist` rebuild.

### Residual (by design, not a fold)

A genuinely **continuous** signal note value (`n(irand(8))` with no `.segment`) has no discrete onsets to draw, so it shows no lane. It does **not** pollute a neighbour. This is the signals-stay-as-code residual; tracked in #927-follow-up.

## Test plan

New cases in `full-song-eval-lanes.spec.ts`, driven against the **real evaluated app** (the only faithful instrument — the hap path runs in-browser):
- `n(run(8)).s("piano")` — the primary regression (was 1 lane → now 2)
- `n(irand(8).segment(8)).s(...)` — segmented signal index
- named tracks (`drums:` / `lead:`) — anchor keyed by name
- 3 tracks with the zero-event track in the **middle** — all three lanes survive

Verified green: the new spec (5/5, real app) · full app suite (763/763, incl. `collectNoteMarks` + `parity-corpus`) · editor gate (690/690) · the two changed files are tsc-clean.

Advances #927 (eval-backed lanes), part of #925.