### PR TITLE
✅ test(gate): cover src/ir and browser specs — close the seam that let a stale spec contradict shipped code

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,10 @@
     "parity:bakery": "node packages/app/scripts/parity-bakery.mjs",
     "edit:coverage": "pnpm --filter @stave/app exec vitest run --config vitest.edit-coverage.config.ts",
     "edit:coverage:bakery": "node packages/app/scripts/edit-coverage-bakery.mjs",
-    "gate:editing": "pnpm gate:editing:editor; e=$?; pnpm gate:editing:app; a=$?; exit $((e|a))",
-    "gate:editing:editor": "pnpm --filter @stave/editor exec vitest run src/visualEdit",
-    "gate:editing:app": "pnpm --filter @stave/app exec vitest run tests/parity-corpus"
+    "gate:editing": "pnpm gate:editing:editor; e=$?; pnpm gate:editing:app; a=$?; pnpm gate:editing:browser; b=$?; exit $((e|a|b))",
+    "gate:editing:editor": "pnpm --filter @stave/editor exec vitest run",
+    "gate:editing:app": "pnpm --filter @stave/app exec vitest run tests/parity-corpus",
+    "gate:editing:browser": "pnpm --filter @stave/app exec playwright test tests/sequencer.spec.ts tests/velocity.spec.ts tests/piano-roll.spec.ts tests/visual-edit-tabs.spec.ts --project=chromium --workers=1"
   },
   "devDependencies": {
     "turbo": "^2.0.0",

--- a/packages/app/playwright.config.ts
+++ b/packages/app/playwright.config.ts
@@ -71,7 +71,16 @@ export default defineConfig({
       // is SKIPPED ENTIRELY — its 29 tests do not run and are not even reported as
       // skipped. The gate then prints a plausible-looking "375 passed" that is
       // simply a smaller suite. So ALWAYS reconcile the total: a complete run is
-      // 505 + 29 = 534. If the count is short, tests were dropped, not passed.
+      // 531 + 29 = 560 (2026-07-20). If the count is short, tests were dropped,
+      // not passed — and re-check this number when specs are added, because a
+      // stale total makes a dropped-test run look like a normal one.
+      //
+      // Also budget for contention: a full parallel run reproducibly reports
+      // ~15 failures that pass on a serial re-run of the same files (measured
+      // 2026-07-20: 15 failed parallel → 1 failed serial). Most carry the same
+      // signature — `[data-bottom-panel="root"]` never appearing, i.e. the app
+      // never loaded, several workers deep. Re-run failures serially before
+      // treating any of them as a product defect.
       dependencies: ['chromium'],
     },
   ],

--- a/packages/app/tests/sequencer.spec.ts
+++ b/packages/app/tests/sequencer.spec.ts
@@ -188,11 +188,34 @@ test.describe('Sequencer (#382)', () => {
     ).toBeVisible({ timeout: 5000 })
   })
 
-  test('non-grid pattern falls back to standby', async ({ page }) => {
+  // The standby element is `data-bottom-panel-tab={`${panel}-standby`}` (a
+  // template literal in VisualEditStandby), and the panel is now `pattern`, not
+  // `sequencer`. The old id never matched, so this assertion was 0-vs-1 for ANY
+  // input — it had stopped testing the fallback and was only testing itself.
+  //
+  // The example moved too. `s("bd*<2 3>")` used to be non-griddable; behaviour
+  // projection now bar-expands it into a correct 12-cell grid (2 bars × LCM(2,3):
+  // hits at 0,3 then 6,8,10). What still reaches standby is a pattern with no
+  // discrete onsets at all — a continuous signal has nothing to put in a cell.
+  test('a pattern with no discrete onsets falls back to standby', async ({ page }) => {
+    await boot(page)
+    await setStrudelCode(page, '$: note(sine.range(40,80))')
+    const drawer = await openSequencer(page)
+    await expect(drawer.locator('[data-bottom-panel-tab="pattern-standby"]')).toHaveCount(1)
+    await expect(drawer.locator('[data-seq-cell]')).toHaveCount(0)
+  })
+
+  // The other half of the pair: the pattern the case above used to cover is now
+  // editable, and that is the behaviour worth pinning. Without this, a
+  // regression that re-broke bar expansion would only show up as the standby
+  // test going green again — which reads like a pass.
+  test('a bar-varying multiplier bar-expands into a grid (#930)', async ({ page }) => {
     await boot(page)
     await setStrudelCode(page, '$: s("bd*<2 3>")')
     const drawer = await openSequencer(page)
-    await expect(drawer.locator('[data-bottom-panel-tab="sequencer-standby"]')).toHaveCount(1)
+    await expect(drawer.locator('[data-bottom-panel-tab="pattern-standby"]')).toHaveCount(0)
+    // 2 bars × LCM(2,3) = 12 columns; bar 1 fires twice, bar 2 three times.
+    await expect(drawer.locator('[data-seq-cell]')).toHaveCount(12)
   })
 
   // #904 — an underscore inside a sound NAME is not mini-notation syntax.


### PR DESCRIPTION
Closes #951 (base is `studio_v0.2.0`, so this will not auto-close — closing by hand on merge).

## Problem

The editing gate could not see two whole classes of regression:

- **`src/ir` was never gated.** `gate:editing:editor` ran `vitest run src/visualEdit` only, leaving the krill adapter and IR classifier outside the gate — exactly where the recent structural work landed.
- **No browser spec ran in the gate at all**, so UI-level state went unchecked.

A live failure was sitting behind both. `sequencer.spec.ts` asserted `s("bd*<2 3>")` falls back to standby — untrue since bar expansion — and looked for `sequencer-standby`, an id that never matches, because the element is `${panel}-standby` and the panel is now `pattern`. **The assertion was 0-vs-1 for any input:** it had stopped testing the fallback and was only testing itself. Nothing caught it, because nothing gating ever ran the spec.

## Fix

- `gate:editing:editor` runs the **full** editor suite — 3074 tests in ~8s. The narrower filter saved no meaningful time and cost the `src/ir` coverage.
- New **`gate:editing:browser`** arm — sequencer, velocity, piano-roll, visual-edit, serial (~1 min). Joins the existing non-short-circuiting chain, so one red arm never masks another.
- Standby test corrected to the real id and to a pattern that genuinely has no discrete onsets (a continuous signal). A bar-varying multiplier is now pinned as **editable** — without that second test, re-breaking bar expansion would surface as the standby test quietly going green, which reads like a pass.
- `playwright.config`: run-total reconciliation refreshed 534 → 560, plus the measured parallel-contention rate so a full-run failure list gets re-checked serially before anything is called a defect.

## Test plan

Restored tree — all three arms green, by the gate's own exit code:

```
gate:editing:editor    3074 passed
gate:editing:app        161 passed
gate:editing:browser     53 passed
GATE EXIT = 0
```

**A gate that cannot go red is not a gate**, so that was verified directly rather than assumed. Injecting a fault into bar expansion (`projectStepGrid` refusing any `<…>`), rebuilding the editor dist and re-running:

```
GATE EXIT = 1
✘ sequencer.spec.ts › a bar-varying multiplier bar-expands into a grid (#930)
```

Reverted → exit 0 again. Exit codes read from the gate itself, not from piped output.

## Notes for review

- The injected fault was **also** caught by the existing vitest arm (`writer-reach`). The browser arm's unique value is UI-level state — standby vs grid rendering — which the unit suites cannot see, and which is precisely what went unnoticed here.
- Parallel full runs reproducibly report ~15 failures that pass on a serial re-run of the same files (measured: 15 parallel → 1 serial). Most share one signature: `[data-bottom-panel="root"]` never appearing, i.e. the app never loaded several workers deep. That is why the browser arm runs serial.
- `s("bd*<2 3>")` was verified by driving the real app and counting cells, not inferred: 12 cells = 2 bars × LCM(2,3), bar 1 firing at 0 and 3, bar 2 at 6, 8 and 10.
