### PR TITLE
✅ test(ir): pin the control-classification behaviours no metric can see

### DIFF
--- a/packages/editor/src/ir/__tests__/controlClassificationGuards.test.ts
+++ b/packages/editor/src/ir/__tests__/controlClassificationGuards.test.ts
@@ -16,14 +16,42 @@
  *      arrow; a change there alters the emitted STRING while leaving every tag
  *      count identical. Counting nodes cannot see a change in how a node is
  *      spelled.
- *   3. SEMANTICS DO NOT MOVE EITHER. The degraded arrow form is hap-equivalent
- *      to the idiomatic one (pinned below with the eval oracle), so even a
- *      behavioural test would stay green. Only the emitted string shows it.
+ *   3. SEMANTICS DO NOT MOVE EITHER. The two arrow forms are hap-equivalent
+ *      (pinned below with the eval oracle), so even a behavioural test would
+ *      stay green. Only the emitted string shows a change.
  *
  * So the assertions here are deliberately on the EMITTED STRING and the
  * COLLECTED EVENT PARAMS, not on tags. Each pin says whether the collapse is
  * expected to PRESERVE it or deliberately FLIP it — a pin whose intent is
  * unstated is just a tripwire, and the next person deletes it.
+ *
+ * ---------------------------------------------------------------------------
+ * SCOPE — what these pins are, and what they are NOT
+ * ---------------------------------------------------------------------------
+ * Read before treating a failure here as a user-facing bug. It is not one.
+ * Both surfaces this file pins are INTERNAL:
+ *
+ *   - `toStrudel` has ZERO production callers. The two modules that could call
+ *     it document that they deliberately do not (`visualEdit/writeback.ts:11`,
+ *     `visualEdit/arrange/serialize.ts:7`): write-back does span surgery on
+ *     TEXT precisely to avoid this whole-statement regenerator, and
+ *     `dist/index.d.ts:156` states the reason outright — "NEVER calls
+ *     `toStrudel` (no fidelity tax)". So neither arrow spelling ever reaches a
+ *     user's document. `toStrudel` IS the oracle for several test suites, and
+ *     that is the reason to pin it.
+ *   - The split param keys (`params.lpf` vs `params.cutoff`) are read in
+ *     production by NOTHING except the IR Inspector's `Object.keys()` debug
+ *     views (`IRInspectorPanel.tsx:469`, `IRInspectorChrome.ts:29`). Pitch
+ *     resolution reads only `note`/`n`/`freq` (`musicalTimeline/pitch.ts`).
+ *     Audio gets its `room`/`cutoff`/`delay` from Strudel's own eval, never
+ *     from our IR.
+ *
+ * The collapse these pins guard is therefore INTERNAL COHERENCE and drift
+ * removal — retiring the last hand-maintained mirror of Strudel's control
+ * vocabulary — not a fix for anything a user can currently observe. That is a
+ * good reason to do it, and a bad reason to rush it ahead of defects that ARE
+ * user-visible. Stating the scope here so the next reader prices it correctly
+ * rather than inferring urgency from the density of assertions.
  *
  * Everything asserted here was verified against unmodified `f6c5049f` before
  * being written down. Nothing here is transcribed from a design document.
@@ -92,21 +120,23 @@ async function haps(code: string, cycles = 4): Promise<string[]> {
 // ---------------------------------------------------------------------------
 // 1. extractTransform — the FX-only privileged path (toStrudel.ts:347)
 // ---------------------------------------------------------------------------
-describe('extractTransform: FX is the exception, not the rule', () => {
+describe('extractTransform: the FX arrow form is the minority path', () => {
   // COLLAPSE WILL FLIP THIS. `x => x.room(0.8)` is reachable ONLY because a
   // numeric-arg control still tags FX. Once room/delay/lpf become Param, this
   // branch has no real users left and the emission becomes the `() =>` form
   // below. That flip is EXPECTED and correct-to-make; it must be DECLARED.
-  it('an FX body emits the idiomatic single-argument arrow', () => {
+  it('an FX body emits the single-argument arrow form', () => {
     expect(emit('s("bd hh").every(4, x => x.room(0.8))'))
       .toBe('s("bd hh").every(4, x => x.room(0.8))')
   })
 
   // COLLAPSE PRESERVES THESE. They already take the generic fallback today —
-  // which is the point: the degraded form is the MAJORITY behaviour, covering
+  // which is the point: the `() =>` form is the MAJORITY behaviour, covering
   // all 18 transform-arrow bodies in the corpus (add 12, speed 5, rev 1, ply 1).
   // The fallback emits a ZERO-ARGUMENT arrow that inlines a duplicate copy of
-  // the receiver. It discards its input entirely.
+  // the receiver, discarding its input entirely — which is verbose but, per the
+  // hap pins below, plays identically. Calling it "the norm" is not a value
+  // judgement either way; it is simply which path most bodies take.
   it.each([
     // Every corpus transform-arrow shape, with the tag it carries. The tag is
     // ASSERTED, not just documented — otherwise this table would keep passing
@@ -115,16 +145,16 @@ describe('extractTransform: FX is the exception, not the rule', () => {
     ['s("bd hh").every(4, x => x.add(12))',  's("bd hh").every(4, () => s("bd hh").add(12))',  'Code'],
     ['s("bd hh").every(4, x => x.rev())',    's("bd hh").every(4, () => s("bd hh").rev())',    'Code'],
     ['s("bd hh").every(4, x => x.ply(2))',   's("bd hh").every(4, () => s("bd hh").ply(2))',   'Ply'],
-  ])('a non-FX body (%s) degrades to a 0-arg arrow duplicating the receiver', (src, expected, tag) => {
+  ])('a non-FX body (%s) emits a 0-arg arrow duplicating the receiver', (src, expected, tag) => {
     expect(emit(src)).toBe(expected)
     expect(nodesWithTag(src, tag)).not.toHaveLength(0)
   })
 
   // The #935 path: a PATTERN arg on a curated control already tags Param, so a
-  // control that emits the idiomatic form with a number emits the degraded form
+  // control that emits the `x =>` form with a number emits the `() =>` form
   // with a pattern. Same control, same position — two spellings, decided purely
-  // by arg shape. This is the defect the collapse resolves by making BOTH take
-  // the same path.
+  // by arg shape. This is the incoherence the collapse resolves by making BOTH
+  // take the same path.
   it('one control emits two different arrow forms depending on arg shape', () => {
     expect(emit('s("bd hh").every(4, x => x.room(0.8))'))
       .toBe('s("bd hh").every(4, x => x.room(0.8))')
@@ -141,14 +171,15 @@ describe('extractTransform: FX is the exception, not the rule', () => {
 })
 
 // ---------------------------------------------------------------------------
-// 2. The degraded arrow is hap-equivalent — why no behavioural test catches it
+// 2. Both arrow forms are hap-equivalent — why no behavioural test catches it
 // ---------------------------------------------------------------------------
-describe('the degraded arrow plays identically (so only the string shows it)', () => {
-  // This pin is the REASON the string assertions above must exist. The 0-arg
-  // arrow ignores its argument and rebuilds the receiver — and the receiver is
-  // exactly what it rebuilds, so the music is unchanged. Stating this stops the
-  // defect being over-claimed as "broken code": it is a FIDELITY defect, not a
-  // correctness one.
+describe('both arrow forms play identically (so only the string shows a change)', () => {
+  // This pin is the REASON the string assertions above must exist, and the
+  // reason not to over-claim them. The 0-arg arrow ignores its argument and
+  // rebuilds the receiver — and the receiver is exactly what it rebuilds, so
+  // the music is unchanged. The two forms are verbosely different and
+  // semantically identical. Since `toStrudel` has no production callers
+  // (see SCOPE above), neither spelling reaches a user's file either.
   //
   // COLLAPSE MUST PRESERVE THIS. If a later change makes these diverge, the
   // duplication has turned into wrong music and this test is the alarm.
@@ -158,7 +189,7 @@ describe('the degraded arrow plays identically (so only the string shows it)', (
     's("bd hh").fast(2).every(4, x => x.room("0.3 0.5"))',
   ])('%s round-trips to hap-identical code', async (src) => {
     const out = emit(src)
-    expect(out).not.toBe(src)          // it really did degrade
+    expect(out).not.toBe(src)          // the spelling really did change
     expect(await haps(out)).toEqual(await haps(src))
   })
 })
@@ -214,11 +245,17 @@ describe('controls the corpus cannot see', () => {
 // 4. One control, two param keys — the defect at the consumer-facing level
 // ---------------------------------------------------------------------------
 describe('the same control files under different keys by arg shape', () => {
-  // The sharpest statement of what the collapse fixes. Tag counts show a node
-  // moving between tags; THIS shows a downstream reader of `params.lpf` finding
-  // nothing when the user wrote a pattern. The canonical key (`cutoff`) is the
-  // one #928 established, so the pattern arm is already correct and the NUMERIC
-  // arm is the one out of step.
+  // Tag counts show a node moving between tags; THIS shows a reader of
+  // `params.lpf` finding nothing when the user wrote a pattern. The canonical
+  // key (`cutoff`) is the one #928 established, so the pattern arm is already
+  // correct and the NUMERIC arm is the one out of step.
+  //
+  // Scope, so this is not read as bigger than it is: the only production
+  // readers of these keys are the IR Inspector's `Object.keys()` debug views.
+  // Audio never reads them — Strudel's own eval supplies the real values. So
+  // this is an internal-coherence defect, and the honest reason to fix it is
+  // that ONE control answering to TWO keys will mislead the next person who
+  // reasons about the IR, not that anything currently sounds or looks wrong.
   //
   // COLLAPSE WILL FLIP THE NUMERIC ROW: after it, both spellings should file
   // under the canonical key. That is the whole point — declare it here.

--- a/packages/editor/src/ir/__tests__/controlClassificationGuards.test.ts
+++ b/packages/editor/src/ir/__tests__/controlClassificationGuards.test.ts
@@ -1,0 +1,283 @@
+/**
+ * controlClassificationGuards.test.ts — the control-classification behaviours
+ * that NO metric can see.
+ *
+ * The FX→Param collapse moves ~54 corpus nodes off the `FX` tag. Tag counts and
+ * parity snapshots will move loudly and review well. This file exists for the
+ * behaviours that sit in the blind spots BEHIND those counts — where a
+ * regression produces no count movement, no snapshot churn, no thrown error,
+ * and no failing gate.
+ *
+ * Three independent reasons a blind spot exists here:
+ *
+ *   1. ZERO CORPUS OCCURRENCES. `reverb` and `hpf` appear nowhere in the 57
+ *      corpus files, so no count can ever observe them regressing.
+ *   2. THE METRIC IS THE WRONG SHAPE. `extractTransform` emits a transform
+ *      arrow; a change there alters the emitted STRING while leaving every tag
+ *      count identical. Counting nodes cannot see a change in how a node is
+ *      spelled.
+ *   3. SEMANTICS DO NOT MOVE EITHER. The degraded arrow form is hap-equivalent
+ *      to the idiomatic one (pinned below with the eval oracle), so even a
+ *      behavioural test would stay green. Only the emitted string shows it.
+ *
+ * So the assertions here are deliberately on the EMITTED STRING and the
+ * COLLECTED EVENT PARAMS, not on tags. Each pin says whether the collapse is
+ * expected to PRESERVE it or deliberately FLIP it — a pin whose intent is
+ * unstated is just a tripwire, and the next person deletes it.
+ *
+ * Everything asserted here was verified against unmodified `f6c5049f` before
+ * being written down. Nothing here is transcribed from a design document.
+ *
+ * See #955 (this suite) · #944 (the collapse) · #929 (adapter consolidation).
+ */
+import { describe, it, expect, beforeAll } from 'vitest'
+import { evalScope, evaluate } from '@strudel/core/evaluate.mjs'
+import * as strudelCore from '@strudel/core'
+import { mini, miniAllStrings } from '@strudel/mini/mini.mjs'
+import { isControlName } from '@strudel/core/controls.mjs'
+import type { PatternIR } from '../PatternIR'
+import { parseStrudel } from '../parseStrudel'
+import { toStrudel } from '../toStrudel'
+import { collectCycles } from './helpers/collectCycles'
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+// One-time Strudel scope boot — same shape as parity.test.ts. Needed only by
+// the hap-equivalence pin; the string pins are pure.
+beforeAll(async () => {
+  await evalScope(Promise.resolve(strudelCore), Promise.resolve({ mini }))
+  miniAllStrings()
+})
+
+/** Every node in the tree, depth-first. Walks the sub-IR carriers by name so a
+ *  Stack's `tracks` and a Seq's `children` are both reached. */
+function walk(node: unknown, out: PatternIR[] = []): PatternIR[] {
+  if (!node || typeof node !== 'object') return out
+  const n = node as any
+  if (typeof n.tag === 'string') out.push(n)
+  for (const key of ['body', 'tracks', 'children', 'items', 'default_', 'transform', 'lookup', 'selector']) {
+    const v = n[key]
+    if (Array.isArray(v)) v.forEach((c) => walk(c, out))
+    else if (v) walk(v, out)
+  }
+  return out
+}
+
+const nodesWithTag = (src: string, tag: string): any[] =>
+  walk(parseStrudel(src)).filter((n) => n.tag === tag)
+
+const emit = (src: string): string => toStrudel(parseStrudel(src) as never)
+
+/** Collected params for the first event of cycle 0. The consumer-facing view:
+ *  what a downstream reader actually finds on the event. */
+const firstEventParams = (src: string): Record<string, unknown> => {
+  const evs = collectCycles(parseStrudel(src) as never, 0, 1) as any[]
+  expect(evs.length).toBeGreaterThan(0)
+  return evs[0].params
+}
+
+/** Haps as comparable strings, 4 cycles — the second oracle. Asks Strudel what
+ *  it actually triggers rather than trusting our own re-parse. */
+async function haps(code: string, cycles = 4): Promise<string[]> {
+  const evaluated = await evaluate(code)
+  const out: string[] = []
+  for (let c = 0; c < cycles; c++) {
+    for (const h of (evaluated.pattern as any).queryArc(c, c + 1)) {
+      out.push(`${h.whole?.begin?.valueOf?.() ?? '?'}:${JSON.stringify(h.value)}`)
+    }
+  }
+  return out.sort()
+}
+
+// ---------------------------------------------------------------------------
+// 1. extractTransform — the FX-only privileged path (toStrudel.ts:347)
+// ---------------------------------------------------------------------------
+describe('extractTransform: FX is the exception, not the rule', () => {
+  // COLLAPSE WILL FLIP THIS. `x => x.room(0.8)` is reachable ONLY because a
+  // numeric-arg control still tags FX. Once room/delay/lpf become Param, this
+  // branch has no real users left and the emission becomes the `() =>` form
+  // below. That flip is EXPECTED and correct-to-make; it must be DECLARED.
+  it('an FX body emits the idiomatic single-argument arrow', () => {
+    expect(emit('s("bd hh").every(4, x => x.room(0.8))'))
+      .toBe('s("bd hh").every(4, x => x.room(0.8))')
+  })
+
+  // COLLAPSE PRESERVES THESE. They already take the generic fallback today —
+  // which is the point: the degraded form is the MAJORITY behaviour, covering
+  // all 18 transform-arrow bodies in the corpus (add 12, speed 5, rev 1, ply 1).
+  // The fallback emits a ZERO-ARGUMENT arrow that inlines a duplicate copy of
+  // the receiver. It discards its input entirely.
+  it.each([
+    // arg shape → tag, all four already degraded on f6c5049f
+    ['s("bd hh").every(4, x => x.speed(2))',  's("bd hh").every(4, () => s("bd hh").speed(2))',  'Param'],
+    ['s("bd hh").every(4, x => x.add(12))',   's("bd hh").every(4, () => s("bd hh").add(12))',   'Code'],
+    ['s("bd hh").every(4, x => x.rev())',     's("bd hh").every(4, () => s("bd hh").rev())',     'Code'],
+    ['s("bd hh").every(4, x => x.ply(2))',    's("bd hh").every(4, () => s("bd hh").ply(2))',    'Ply'],
+  ])('a non-FX body (%s) degrades to a 0-arg arrow duplicating the receiver', (src, expected) => {
+    expect(emit(src)).toBe(expected)
+  })
+
+  // The #935 path: a PATTERN arg on a curated control already tags Param, so a
+  // control that emits the idiomatic form with a number emits the degraded form
+  // with a pattern. Same control, same position — two spellings, decided purely
+  // by arg shape. This is the defect the collapse resolves by making BOTH take
+  // the same path.
+  it('one control emits two different arrow forms depending on arg shape', () => {
+    expect(emit('s("bd hh").every(4, x => x.room(0.8))'))
+      .toBe('s("bd hh").every(4, x => x.room(0.8))')
+    expect(emit('s("bd hh").every(4, x => x.room("0.3 0.5"))'))
+      .toBe('s("bd hh").every(4, () => s("bd hh").room("0.3 0.5"))')
+  })
+
+  // The duplication is not cosmetic — it scales with the receiver. An upstream
+  // chain is copied wholesale into the arrow body.
+  it('the duplicated receiver carries the whole upstream chain', () => {
+    expect(emit('s("bd hh").fast(2).every(4, x => x.room("0.3 0.5"))'))
+      .toBe('s("bd hh").fast(2).every(4, () => s("bd hh").fast(2).room("0.3 0.5"))')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. The degraded arrow is hap-equivalent — why no behavioural test catches it
+// ---------------------------------------------------------------------------
+describe('the degraded arrow plays identically (so only the string shows it)', () => {
+  // This pin is the REASON the string assertions above must exist. The 0-arg
+  // arrow ignores its argument and rebuilds the receiver — and the receiver is
+  // exactly what it rebuilds, so the music is unchanged. Stating this stops the
+  // defect being over-claimed as "broken code": it is a FIDELITY defect, not a
+  // correctness one.
+  //
+  // COLLAPSE MUST PRESERVE THIS. If a later change makes these diverge, the
+  // duplication has turned into wrong music and this test is the alarm.
+  it.each([
+    's("bd hh").every(4, x => x.room("0.3 0.5"))',
+    's("bd hh").every(4, x => x.lpf("400 800"))',
+    's("bd hh").fast(2).every(4, x => x.room("0.3 0.5"))',
+  ])('%s round-trips to hap-identical code', async (src) => {
+    const out = emit(src)
+    expect(out).not.toBe(src)          // it really did degrade
+    expect(await haps(out)).toEqual(await haps(src))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3. reverb / hpf — zero corpus occurrences, therefore metric-invisible
+// ---------------------------------------------------------------------------
+describe('controls the corpus cannot see', () => {
+  // The registry itself is the authority for WHY reverb must stay curated.
+  // Asserting `isControlName` rather than a transcribed list means this pin
+  // re-derives from Strudel on every run and cannot go stale.
+  it('reverb is not a core control, hence cannot migrate to the registry path', () => {
+    expect(isControlName('reverb')).toBe(false)
+    expect(isControlName('room')).toBe(true)
+  })
+
+  // COLLAPSE MUST PRESERVE. A wholesale delete of the curated arms regresses
+  // this from classified to opaque, and no count would ever show it.
+  it('reverb with a numeric arg classifies today', () => {
+    expect(nodesWithTag('s("bd").reverb(0.5)', 'FX')).toHaveLength(1)
+    expect(firstEventParams('s("bd").reverb(0.5)')).toMatchObject({ reverb: 0.5 })
+  })
+
+  // Faithful to TODAY, and deliberately so: reverb is not in the registry, so
+  // the #935 pattern-arg rescue does not apply and it opaques. Pinned as the
+  // asymmetry it is — NOT as an endorsement.
+  it('reverb with a pattern arg opaques, unlike every registry control', () => {
+    expect(nodesWithTag('s("bd").reverb("0.3 0.5")', 'Code')).not.toHaveLength(0)
+    expect(nodesWithTag('s("bd").reverb("0.3 0.5")', 'FX')).toHaveLength(0)
+  })
+
+  it('hpf classifies in both arg shapes though the corpus contains none', () => {
+    expect(nodesWithTag('s("bd").hpf(400)', 'FX')).toHaveLength(1)
+    expect(nodesWithTag('s("bd").hpf("200 400")', 'Param')).toHaveLength(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 4. One control, two param keys — the defect at the consumer-facing level
+// ---------------------------------------------------------------------------
+describe('the same control files under different keys by arg shape', () => {
+  // The sharpest statement of what the collapse fixes. Tag counts show a node
+  // moving between tags; THIS shows a downstream reader of `params.lpf` finding
+  // nothing when the user wrote a pattern. The canonical key (`cutoff`) is the
+  // one #928 established, so the pattern arm is already correct and the NUMERIC
+  // arm is the one out of step.
+  //
+  // COLLAPSE WILL FLIP THE NUMERIC ROW: after it, both spellings should file
+  // under the canonical key. That is the whole point — declare it here.
+  it('lpf: numeric files under lpf, pattern files under the canonical cutoff', () => {
+    expect(firstEventParams('s("bd").lpf(800)')).toMatchObject({ lpf: 800 })
+    expect(firstEventParams('s("bd").lpf("400 800")')).toMatchObject({ cutoff: '400' })
+  })
+
+  it('hpf: numeric files under hpf, pattern files under the canonical hcutoff', () => {
+    expect(firstEventParams('s("bd").hpf(400)')).toMatchObject({ hpf: 400 })
+    expect(nodesWithTag('s("bd").hpf("200 400")', 'Param')[0].key).toBe('hcutoff')
+  })
+
+  // `userMethod` is what keeps the round-trip byte-identical while the key is
+  // canonicalised. If this drifts, the user's source gets rewritten under them.
+  it('the user token survives canonicalisation, so source round-trips', () => {
+    expect(nodesWithTag('s("bd").lpf("400 800")', 'Param')[0].userMethod).toBe('lpf')
+    expect(emit('s("bd").lpf("400 800")')).toBe('s("bd").lpf("400 800")')
+    expect(emit('s("bd").hpf("200 400")')).toBe('s("bd").hpf("200 400")')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 5. Stacked same-control calls — first-wins at the merge
+// ---------------------------------------------------------------------------
+describe('repeated control calls merge first-wins', () => {
+  // Two nested FX nodes both survive in the tree; the merge in `collect` is
+  // what picks a winner, and the INNER (first-written) one takes it.
+  //
+  // The collapse changes the merge path (FX carries a params Record, Param
+  // carries key/value), so this is exactly the kind of behaviour that can flip
+  // silently. Pinned BEFORE, so a flip has to be argued for.
+  it('.room(0.3).room(0.5) collects the first value', () => {
+    expect(nodesWithTag('s("bd").room(0.3).room(0.5)', 'FX')).toHaveLength(2)
+    expect(firstEventParams('s("bd").room(0.3).room(0.5)')).toMatchObject({ room: 0.3 })
+  })
+
+  it('holds for a control that canonicalises, too', () => {
+    expect(firstEventParams('s("bd").lpf(400).lpf(900)')).toMatchObject({ lpf: 400 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 6. Synthetic jux pans — an internal marker wearing the FX tag
+// ---------------------------------------------------------------------------
+describe('jux pan nodes are not a control classification', () => {
+  // These are the 6 nodes that SURVIVE the collapse with tag FX, and they are
+  // not user-written controls at all — `jux` synthesises them to pan its two
+  // arms. `userMethod === undefined` is the discriminator, and
+  // `irProjection.ts:236` strips on exactly that predicate.
+  //
+  // COLLAPSE PRESERVES. Rehoming them off the FX tag is a SEPARATE change
+  // (the tag deletion), and this pin is what makes that change safe to attempt.
+  it('jux synthesises one pan FX node per arm, neither with a userMethod', () => {
+    const pans = nodesWithTag('s("bd hh").jux(x => x.rev())', 'FX')
+    expect(pans).toHaveLength(2)                        // one per stacked arm
+    expect(pans.map((p) => p.params.pan).sort()).toEqual([-1, 1])
+    for (const p of pans) {
+      expect(p.name).toBe('pan')
+      expect(p.userMethod).toBeUndefined()              // the strip predicate
+    }
+  })
+
+  // The contrast that gives the discriminator its meaning — and it is sharper
+  // than `userMethod` alone. `pan` is NOT one of the curated arms, so a
+  // user-written `.pan(0.5)` already takes the registry path and tags Param.
+  // User pan and synthetic pan are therefore already on DIFFERENT TAGS today.
+  //
+  // This is what makes the eventual tag deletion tractable: once the collapse
+  // empties FX of real controls, `FX` denotes ONLY jux's internal marker — it
+  // stops being a classification and becomes a private flag, which is the
+  // honest thing to rename it to.
+  it('a user-written pan is not FX at all — it takes the registry path', () => {
+    expect(nodesWithTag('s("bd").pan(0.5)', 'FX')).toHaveLength(0)
+    const [userPan] = nodesWithTag('s("bd").pan(0.5)', 'Param')
+    expect(userPan.key).toBe('pan')
+    expect(userPan.userMethod).toBe('pan')
+  })
+})

--- a/packages/editor/src/ir/__tests__/controlClassificationGuards.test.ts
+++ b/packages/editor/src/ir/__tests__/controlClassificationGuards.test.ts
@@ -108,13 +108,16 @@ describe('extractTransform: FX is the exception, not the rule', () => {
   // The fallback emits a ZERO-ARGUMENT arrow that inlines a duplicate copy of
   // the receiver. It discards its input entirely.
   it.each([
-    // arg shape → tag, all four already degraded on f6c5049f
-    ['s("bd hh").every(4, x => x.speed(2))',  's("bd hh").every(4, () => s("bd hh").speed(2))',  'Param'],
-    ['s("bd hh").every(4, x => x.add(12))',   's("bd hh").every(4, () => s("bd hh").add(12))',   'Code'],
-    ['s("bd hh").every(4, x => x.rev())',     's("bd hh").every(4, () => s("bd hh").rev())',     'Code'],
-    ['s("bd hh").every(4, x => x.ply(2))',    's("bd hh").every(4, () => s("bd hh").ply(2))',    'Ply'],
-  ])('a non-FX body (%s) degrades to a 0-arg arrow duplicating the receiver', (src, expected) => {
+    // Every corpus transform-arrow shape, with the tag it carries. The tag is
+    // ASSERTED, not just documented — otherwise this table would keep passing
+    // if a body silently changed tag while its emission happened to match.
+    ['s("bd hh").every(4, x => x.speed(2))', 's("bd hh").every(4, () => s("bd hh").speed(2))', 'Param'],
+    ['s("bd hh").every(4, x => x.add(12))',  's("bd hh").every(4, () => s("bd hh").add(12))',  'Code'],
+    ['s("bd hh").every(4, x => x.rev())',    's("bd hh").every(4, () => s("bd hh").rev())',    'Code'],
+    ['s("bd hh").every(4, x => x.ply(2))',   's("bd hh").every(4, () => s("bd hh").ply(2))',   'Ply'],
+  ])('a non-FX body (%s) degrades to a 0-arg arrow duplicating the receiver', (src, expected, tag) => {
     expect(emit(src)).toBe(expected)
+    expect(nodesWithTag(src, tag)).not.toHaveLength(0)
   })
 
   // The #935 path: a PATTERN arg on a curated control already tags Param, so a
@@ -191,6 +194,20 @@ describe('controls the corpus cannot see', () => {
     expect(nodesWithTag('s("bd").hpf(400)', 'FX')).toHaveLength(1)
     expect(nodesWithTag('s("bd").hpf("200 400")', 'Param')).toHaveLength(1)
   })
+
+  // `scale` is the OTHER non-registry control (#944 names it beside `reverb`),
+  // and the two do NOT behave alike — which is the reason to pin both rather
+  // than treat "non-core" as one case. `reverb` is a curated FX arm, so its
+  // pattern form opaques; `scale` is a curated Param arm, so it classifies.
+  // A collapse that reasons about "the non-core controls" as a single group
+  // gets one of them wrong, and neither is in the corpus to catch it.
+  it('scale is also non-core, but curated as Param rather than FX', () => {
+    expect(isControlName('scale')).toBe(false)
+    expect(nodesWithTag('s("bd").scale("C:major")', 'FX')).toHaveLength(0)
+    const [node] = nodesWithTag('s("bd").scale("C:major")', 'Param')
+    expect(node.key).toBe('scale')
+    expect(firstEventParams('s("bd").scale("C:major")')).toMatchObject({ scale: 'C:major' })
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -213,6 +230,33 @@ describe('the same control files under different keys by arg shape', () => {
   it('hpf: numeric files under hpf, pattern files under the canonical hcutoff', () => {
     expect(firstEventParams('s("bd").hpf(400)')).toMatchObject({ hpf: 400 })
     expect(nodesWithTag('s("bd").hpf("200 400")', 'Param')[0].key).toBe('hcutoff')
+  })
+
+  // `delay` is the flagship case and a DIFFERENT shape from lpf/hpf: it splits
+  // the TAG without splitting the KEY, because `getControlName('delay')` is
+  // already `delay`. In the corpus it appears as 16 FX plus 3 Param — one
+  // control, two tags, decided purely by how the user wrote the argument.
+  //
+  // This is why the collapse is worth doing and also why "did the key move?"
+  // is not a sufficient check: for delay the key never moves, so only the tag
+  // shows the defect, while for lpf only the key shows it. Pin both shapes.
+  it('delay splits the tag but not the key', () => {
+    expect(nodesWithTag('s("bd").delay(0.5)', 'FX')).toHaveLength(1)
+    expect(nodesWithTag('s("bd").delay("0.3 0.5")', 'Param')).toHaveLength(1)
+    expect(firstEventParams('s("bd").delay(0.5)')).toMatchObject({ delay: 0.5 })
+    expect(firstEventParams('s("bd").delay("0.3 0.5")')).toMatchObject({ delay: '0.3' })
+  })
+
+  // The remaining curated arms, pinned as a set so the collapse cannot quietly
+  // drop one. All four are real registry controls that key to themselves, so a
+  // correct collapse leaves every assertion here untouched.
+  it.each([
+    ['crush', 4], ['begin', 0.2], ['resonance', 10], ['cut', 1],
+  ])('%s classifies numerically and keys to itself', (method, value) => {
+    const src = `s("bd").${method}(${value})`
+    expect(nodesWithTag(src, 'FX')).toHaveLength(1)
+    expect(isControlName(method)).toBe(true)
+    expect(firstEventParams(src)).toMatchObject({ [method]: value })
   })
 
   // `userMethod` is what keeps the round-trip byte-identical while the key is

--- a/packages/editor/src/ir/__tests__/controlClassificationGuards.test.ts
+++ b/packages/editor/src/ir/__tests__/controlClassificationGuards.test.ts
@@ -347,15 +347,17 @@ describe('jux pan nodes are not a control classification', () => {
   })
 
   // The contrast that gives the discriminator its meaning — and it is sharper
-  // than `userMethod` alone. `pan` is NOT one of the curated arms, so a
-  // user-written `.pan(0.5)` already takes the registry path and tags Param.
-  // User pan and synthetic pan are therefore already on DIFFERENT TAGS today.
+  // than `userMethod` alone. The curated method switch has TWO groups, and
+  // `pan` sits in the Param one (`parseStrudel.ts:2575`, beside s/n/note/scale/
+  // speed), not the FX one (`:2376`, room/delay/lpf…). So a user-written
+  // `.pan(0.5)` tags Param while jux's synthetic pan tags FX: the two are
+  // already on DIFFERENT TAGS today, by construction rather than by accident.
   //
   // This is what makes the eventual tag deletion tractable: once the collapse
   // empties FX of real controls, `FX` denotes ONLY jux's internal marker — it
   // stops being a classification and becomes a private flag, which is the
   // honest thing to rename it to.
-  it('a user-written pan is not FX at all — it takes the registry path', () => {
+  it('a user-written pan is not FX — it is a curated Param arm', () => {
     expect(nodesWithTag('s("bd").pan(0.5)', 'FX')).toHaveLength(0)
     const [userPan] = nodesWithTag('s("bd").pan(0.5)', 'Param')
     expect(userPan.key).toBe('pan')


### PR DESCRIPTION
Closes #955. Part of #929, guard rail for #944.

> **Scope, stated up front.** Everything pinned here is an **internal** surface — none of it is currently observable by a user. The suite is still worth having (`toStrudel` is the oracle for several test suites, so the collapse will move snapshots someone must triage), but it should not be priced as a user-facing fix. Evidence in "What this is not" below.

## Problem

The coming FX→Param collapse moves ~54 corpus nodes off the `FX` tag. Tag counts and parity snapshots will move loudly and review well — but several behaviours sit in blind spots *behind* those counts, where a change produces no count movement, no snapshot churn, no error and no failing gate.

Three independent reasons a blind spot exists:

1. **Zero corpus occurrences.** `reverb` and `hpf` appear in none of the 57 corpus files. `reverb` is not a core control (`isControlName('reverb') === false`), so `.reverb("0.3 0.5")` opaques while `.reverb(0.5)` classifies — the asymmetry a wholesale delete would erase. `scale` is the *other* non-registry control and behaves **differently**: it is a curated `Param` arm, so it classifies where `reverb` opaques. Reasoning about "the non-core controls" as one group gets one wrong, and neither is in the corpus to catch it.
2. **The metric is the wrong shape.** `extractTransform` (`toStrudel.ts:347`) matches `tag === 'FX'` to rebuild a transform arrow. A change there alters the emitted **string** while leaving every tag count identical.
3. **Semantics do not move either.** The two arrow forms are hap-equivalent, so even a behavioural test stays green.

## What this is not

Worth being precise, because an earlier draft of this PR overclaimed and the correction is instructive:

- **`toStrudel` has zero production callers.** The two modules that could call it document that they deliberately do not — `visualEdit/writeback.ts:11` and `visualEdit/arrange/serialize.ts:7` both explain that write-back does span surgery on **text** precisely to avoid this whole-statement regenerator, and `dist/index.d.ts:156` states it outright: *"NEVER calls `toStrudel` (no fidelity tax)"*. Neither arrow spelling reaches a user's document.
- **The split param keys are read by nothing but debug views.** `IRInspectorPanel.tsx:469` and `IRInspectorChrome.ts:29` call `Object.keys()`. Pitch resolution reads only `note`/`n`/`freq` (`musicalTimeline/pitch.ts`); audio gets `room`/`cutoff`/`delay` from Strudel's own eval, never from our IR.
- **The `() =>` form is the norm, not a fallback from a better path.** Of the corpus's 18 transform-arrow bodies, `add` (12) and `rev` (1) tag `Code`, `speed` (5) tags `Param`, `ply` (1) tags `Ply` — **all 18 already emit it**. The `x =>` FX form is the minority case.

So the collapse this guards is **internal coherence and drift removal**: it retires the last hand-maintained mirror of Strudel's control vocabulary. That matters on this repo's own record — chain roots (#953), mini grammar (#943), euclid helpers (#943) and this very control list (#935) each drifted and were silently wrong. It is a real reason to do the work, and not a reason to put it ahead of user-visible defects like #950.

## Fix

A guard suite pinning each behaviour **as it behaves today**, asserting on the **emitted string** and **collected event params** rather than tags. Every pin declares whether the collapse should *preserve* or *flip* it — an undeclared pin is a tripwire, and the next person deletes it.

| # | behaviour | collapse |
|---|---|---|
| 1 | `FX` body → `x => x.room(0.8)`; `Param`/`Code`/`Ply` → 0-arg arrow duplicating the receiver | **flips** |
| 2 | both arrow forms are hap-identical (eval oracle, 4 cycles) | preserves |
| 3 | `reverb` classifies numerically, opaques on a pattern arg; `scale` classifies; `hpf` classifies in both | preserves |
| 4 | `delay` splits the **tag** not the key; `lpf`/`hpf` split the **key** | **flips the numeric row** |
| 5 | `.room(0.3).room(0.5)` → `room: 0.3` (first-wins) | preserves |
| 6 | `jux` synthesises two `FX` pans (±1), no `userMethod`; a user `.pan()` is `Param` | preserves |

## Beliefs corrected by observation

Every assertion was probed against unmodified `f6c5049f` before being written. Three did not survive, and all three came from taking a prior framing on trust:

- **"Broken code" was wrong.** The hap oracle shows both arrow forms play identically — the 0-arg arrow ignores its argument and rebuilds the receiver, which is what the receiver was anyway.
- **"Degraded" was also wrong**, and backwards: the `() =>` form is what 4 of 5 tags and all 18 corpus arrows already emit. Retired the word.
- **A user-written `.pan(0.5)` is not `FX` at all** — it tags `Param`, so user and jux-synthetic pans are *already* on different tags, which is what makes the eventual tag deletion tractable. (My first explanation of *why* was also wrong — see the correction comment below.)

## Test plan

- `pnpm gate:editing:editor` — **3107 pass** (3080 + 27 added).
- `pnpm gate:editing:app` — **161 pass, unchanged**; no snapshot movement, confirming behaviour-neutrality.
- **Verified RED twice**, per the rule that a guard which cannot fail is worthless. First with the `Param` branch the collapse will add (6 pins red, in the intended places). Then with a sharper, more realistic fault — removing `delay` from the curated arms, a one-control mini-collapse — which turns the `delay` pin red **and only that pin** (26 unaffected). The pins are targeted, not blanket. Both faults reverted; **zero production changes** in this PR.
- `gate:editing:browser` not run: one unit test file, no production code, so the browser arm cannot be affected.

## Known gaps, on the record

- **App-side FX consumers have no pins.** `irProjection.ts` (5 sites) and `IRInspectorChrome.ts` (2) read the `FX` tag; the jux-pan strip predicate at `irProjection.ts:236` is pinned here only at IR level. That belongs with the tag deletion, since that is the change which moves those sites.
- **`room`'s key is unpinned** (only its first-wins merge is) — it keys to itself and is the largest predicted movement (+27), so the count prediction covers it. These pins are for what counts *cannot* see.
