### PR TITLE
🔬 chore(ir): publish the predicate audit for parseStrudel.ts

### DIFF
--- a/packages/editor/src/ir/PREDICATE-AUDIT.md
+++ b/packages/editor/src/ir/PREDICATE-AUDIT.md
@@ -1,0 +1,336 @@
+# Predicate audit — `ir/parseStrudel.ts`
+
+Every anchored regular expression in `parseStrudel.ts`, the question it answers, and the
+system that owns the right answer.
+
+This file is a **census, not a plan**. It exists so that "find the next parser bug" becomes
+"close a finite list". Nothing here changes behaviour, and no entry is an instruction to
+refactor — the sequencing lives in the issue.
+
+`predicateAudit.test.ts` re-derives the census from the source on every run and fails if the
+two disagree, so a new predicate cannot be added without appearing here first.
+
+---
+
+## Why this file exists
+
+`parseStrudel.ts` decides things about JavaScript source text and about Strudel's vocabulary.
+It answers those questions itself, in hand-written regular expressions. Every other module in
+the parse path asks somebody who already knows:
+
+| module | asks | anchored regexes | lines |
+|---|---|---|---|
+| `ir/parseMini.ts` | krill | **0** | 397 |
+| `ir/collect.ts` | — | **0** | 1419 |
+| `ir/parseStrudelStages.ts` | — | **0** | 377 |
+| `visualEdit/chunkDetect.ts` | acorn | **0** | 496 |
+| `visualEdit/arrange/parse.ts` | acorn | **0** | 223 |
+| **`ir/parseStrudel.ts`** | **nobody** | **42** | **3335** |
+
+Every module that delegates has zero. The one that does not has forty-two. `parseMini.ts` is
+the controlled before/after: 512 lines with a hand-rolled tokenizer, 397 lines and no anchored
+regexes after it was rebuilt on krill.
+
+(The five zeroes are a negative result, so they carry a control arm: the same query finds
+anchored regexes in fifteen other `.ts` files in this package, and `parseMini.ts` retains two
+*unanchored* single-character scans — `/[0-9.]/` and `/\s/` at `parseMini.ts:302,377` — which
+locate a boundary rather than decide what a token means.)
+
+### The failure mode is silence
+
+A regular expression cannot express an infinite grammar, so every transcription here is
+incomplete by construction. None of them throw. Three things happen instead, in increasing
+order of harm:
+
+1. **The node opaques.** It becomes `Code`, keeps its bytes, and loses its structure. Honest,
+   and visible in the parity counts.
+2. **The node changes meaning.** `.s("drum/kit")` stops being a literal sample name and is
+   re-read as mini-notation.
+3. **The node silently disappears.** `.every(2, fast(2*2))` produces an `Every` wrapping the
+   *untransformed* pattern. There is no `Code` marker, no count movement, and no error — the
+   IR simply asserts a transform that the source does not contain, and the view draws it.
+
+Class 3 is the reason counting these is worth more than fixing them one at a time.
+
+### How to read the "known-incomplete" column
+
+Every case marked **observed** was run through `parseStrudel` against a control arm that
+differs only in the property under test, and the two IR tag-paths compared. Cases marked
+**reasoned** follow from the regex but were not run. Nothing here is asserted from reading
+the regex alone without saying so.
+
+---
+
+## Category A — JavaScript syntax · owner: **acorn**
+
+26 of the 42. `acorn` is already a dependency and is already used to parse this same source
+text, three times, in `visualEdit/`. The package parses one document two different ways.
+
+### A1 · "is this token a bare identifier?" — 4 sites
+
+`substituteBoundIdentInArg:257` · `parseExpression:1313` · `parseRoot:1519` · `parseRoot:1959`
+
+Owner: acorn (`Identifier`). **Transcribed.**
+
+Known-incomplete: **observed** — a non-ASCII identifier is not recognised. `const café =
+note("c3")` / `stack(café)` opaques the whole program; the ASCII control arm `cafe` yields a
+structured `Play`. JS identifiers admit the full `ID_Start`/`ID_Continue` Unicode sets;
+`[A-Za-z_$][\w$]*` admits a 63-character subset.
+
+```regex
+4x  /^[A-Za-z_$][\w$]*$/
+```
+
+### A2 · "is this a call expression, and what is the callee?" — 2 sites
+
+`parseRoot:1579` · `parseRoot:1927`
+
+Owner: acorn (`CallExpression.callee`). **Transcribed.**
+
+Known-incomplete: **reasoned** — a computed or member callee (`lib.note(…)`, `fns["note"](…)`)
+does not match, and a comment between callee and parenthesis (`note /*x*/ (…)`) does not match.
+
+```regex
+2x  /^([A-Za-z_$][\w$]*)\s*\(/
+```
+
+### A3 · "is this a variable declaration, and what are its name and initialiser?" — 1 site
+
+`BINDING_RE:691`
+
+Owner: acorn (`VariableDeclaration`). **Transcribed.**
+
+Known-incomplete: **reasoned** — one declarator only (`const a = 1, b = 2` captures `a` and
+the rest of the line as its initialiser), no destructuring, no `=` inside a preceding comment.
+
+```regex
+1x  /^(?:let|const|var)\s+([A-Za-z_$][\w$]*)\s*=\s*([\s\S]+)$/
+```
+
+### A4 · "is this an arrow function, and what is its body?" — 1 site
+
+`parseTransform:2791`
+
+Owner: acorn (`ArrowFunctionExpression`). **Transcribed.**
+
+Known-incomplete: **observed, and this one fails silently (class 3 above)** — the parameter
+must be a *single lowercase letter*. `.every(2, pp => pp.fast(2))` and `.every(2, (x) =>
+x.fast(2))` both lose the `Fast` node entirely, against a control arm `x => x.fast(2)` that
+keeps it. No opaque marker is emitted; the transform is simply absent from the IR.
+
+```regex
+1x  /^[a-z]\s*=>\s*[a-z]\s*\.(.+)$/
+```
+
+### A5 · "is this a string literal, and what is inside it?" — 15 sites
+
+`classifyLiteralRhs:206,207` · `parseRoot:1714,1715,1815,1829,1837,1864` · `applyMethod:2175,2506,2596` ·
+`parseParamArg:2838 (×2), 2844 (×2)`
+
+Owner: acorn (`Literal` / `TemplateLiteral`). **Transcribed**, fifteen times, in six spellings
+of the same question.
+
+Known-incomplete: **observed** —
+- An escaped quote terminates the string early. `.s("b\"d")` opaques; the control `.s("bd")`
+  yields `Param:s`.
+- Single quotes are accepted in some arms and not others, so support depends on which arm the
+  text reaches. `.mask('1 0')` and `.struct('1 0')` opaque, while the double-quoted controls
+  give `When` and `Struct`.
+- The two charset-restricted arms at `2596` and `2838` decide meaning, not just shape:
+  `.p("café")` opaques (control `.p("lead")` gives a `Track`), and `.s("drum/kit")` falls
+  through to the mini-notation arm and is re-parsed as a pattern rather than a sample name
+  (control `.s("bd")` stays a literal) — class 2.
+
+Also **reasoned**: no escape sequence is ever decoded, so `"\n"` reaches the IR as two
+characters; and `${…}` inside a backtick arm is treated as literal text.
+
+```regex
+4x  /^"([^"]*)"$/
+2x  /^"[^"]*"$/
+2x  /^'([^']*)'$/
+1x  /^'[^']*'$/
+1x  /^`([^`]*)`$/
+1x  /^`[^`]*`$/
+1x  /^\(\s*("[^"]*"|'[^']*'|`[^`]*`)\s*\)$/
+1x  /^(?:"([a-zA-Z0-9_\-][a-zA-Z0-9_:.\- ]*?)"|'([a-zA-Z0-9_\-][a-zA-Z0-9_:.\- ]*?)')$/
+1x  /^"([a-zA-Z0-9#_:-]*?)"$/
+1x  /^'([a-zA-Z0-9#_:-]*?)'$/
+```
+
+### A6 · "is this statement a guarded call?" — 1 site
+
+`stripParserPrelude:375` (`GUARDED_BOOT_RE`)
+
+Owner: acorn (`ExpressionStatement` → `LogicalExpression` → `UnaryExpression`). **Transcribed.**
+Recognises exactly one idiom, `typeof X !== 'undefined' && X(…)`, and the comment above it
+already records that it is hand-maintained with no programmatic cross-reference.
+
+Known-incomplete: **reasoned** — any other guard spelling (`if (typeof X !== 'undefined')`,
+`X?.()`, `globalThis.X && X()`) is not recognised.
+
+```regex
+1x  /^[ \t]*typeof\s+\w+\s*!==?\s*['"]undefined['"]\s*&&\s*\w+\s*\(/
+```
+
+### A7 · "where does a line comment end?" — 1 site
+
+`splitTopLevelStatements:537`
+
+Owner: acorn (comment ranges via `onComment`). **Transcribed.**
+
+Known-incomplete: **reasoned** — `//` inside a string or regex literal is treated as the start
+of a comment, so `note("http://x")` loses the rest of the line during statement splitting.
+(This runs on a copy used only to decide whether a segment is comment-only, which is what has
+kept it from doing visible damage.)
+
+```regex
+1x  /\/\/.*$/
+```
+
+### A8 · "is this a labelled statement, and what is the label?" — 1 site
+
+`extractTracks:1169`
+
+Owner: acorn (`LabeledStatement`) for the syntax; the `$:` / named-track *convention* is
+Strudel's. **Transcribed.** This site already carries a hand-written guard rejecting matches
+inside brackets, strings and templates — which is the shape of the problem: a regex that needs
+a second regex to undo its false positives is doing a parser's job.
+
+Known-incomplete: **reasoned** — a label whose identifier is non-ASCII (as A1), and any `:`
+adjacency the guard's bracket/string tracking does not model.
+
+```regex
+1x  /^[ \t]*(\/\/[ \t]*)?([A-Za-z_$][\w$]*)\s*:/gm
+```
+
+---
+
+## Category B — Strudel vocabulary · owner: **`controls.mjs` / `signal.mjs` / krill**
+
+16 of the 42. These ask "is this name one of Strudel's?" — the same question #928 routed
+through `controls.mjs` for controls and #953 re-derived from `signal.mjs` for chain roots.
+The remaining sixteen have not had that treatment.
+
+### B1 · "is this call a pattern source, and what is its mini string?" — 10 sites
+
+`parseRoot:1607,1614,1625` (`note`/`n`) · `1639,1645,1653` (`s`/`sound`) · `1666,1672,1679` (`mini`) ·
+`1701` (the loose fallback)
+
+Owner: `@strudel/core` `controls.mjs` for the names, krill for the string. **Transcribed** — and
+transcribed as a 3×3 grid, because each of three name-groups is spelled once per quote style.
+The count is a product of two independent transcriptions, which is why it is the largest
+cluster in the file.
+
+Known-incomplete: **reasoned** — the name list is a hand-picked five (`note`, `n`, `s`,
+`sound`, `mini`) out of ~270 controls, so every other control reaching this position takes the
+fallback path; and the argument must be a single bare string literal, so `note("c3" + x)` or
+`note(seq)` does not match.
+
+```regex
+1x  /^(?:note|n)\s*\(\s*"([^"]*)"\s*\)/
+1x  /^(?:note|n)\s*\(\s*`([^`]*)`\s*\)/
+1x  /^(?:note|n)\s*\(\s*'([^']*)'\s*\)/
+1x  /^(?:s|sound)\s*\(\s*"([^"]*)"\s*\)/
+1x  /^(?:s|sound)\s*\(\s*`([^`]*)`\s*\)/
+1x  /^(?:s|sound)\s*\(\s*'([^']*)'\s*\)/
+1x  /^mini\s*\(\s*"([^"]*)"\s*\)/
+1x  /^mini\s*\(\s*`([^`]*)`\s*\)/
+1x  /^mini\s*\(\s*'([^']*)'\s*\)/
+1x  /^(note|n|s|sound|mini)\s*\(/
+```
+
+### B2 · "is this call a time-sequencing combinator?" — 1 site
+
+`parseTimeSequenceRoot:1411`
+
+Owner: `@strudel/core` (the exported combinator set). **Transcribed** as a list of four.
+
+Known-incomplete: **reasoned** — `timeCat`, `stepcat`, `seq`, `polymeter` and the rest of the
+family are absent, and take the opaque path.
+
+```regex
+1x  /^(arrange|cat|slowcat|fastcat)\s*\(/
+```
+
+### B3 · "is this call `stack`?" — 1 site
+
+`parseRoot:1764`
+
+Owner: `@strudel/core`. **Transcribed.**
+
+Known-incomplete: **observed** — the match is anchored at position 0 of the trimmed text, so a
+leading block comment defeats it: `/*x*/stack(note("c3"))` opaques the whole program where the
+control `stack(note("c3"))` yields a structured `Play`. Also **reasoned**: `overlay` and the
+`,`-separated stack spelling are not this arm.
+
+```regex
+1x  /^stack\s*\(/
+```
+
+### B4 · "is this transform `fast(n)` / `slow(n)`?" — 2 sites
+
+`parseTransform:2776,2783`
+
+Owner: `@strudel/core` for the names, and `Number` for the argument. **Transcribed**, including
+a fresh transcription of the number token as `[0-9.]+` — the same question `isNumericLiteral`
+was created to own in #958, answered here a fourth time and differently.
+
+Known-incomplete: **observed, silent (class 3)** — `fast(2*2)` and `slow(-2)` both drop the
+transform node entirely against controls `fast(2)` / `slow(2)`, with no opaque marker.
+`[0-9.]+` admits `1.2.3` and rejects `-2` and `1e3`. **Reasoned**: only `fast` and `slow` are
+recognised here at all.
+
+```regex
+1x  /^fast\s*\(\s*([0-9.]+)\s*\)$/
+1x  /^slow\s*\(\s*([0-9.]+)\s*\)$/
+```
+
+### B5 · "is this statement a setup/side-effect head?" — 2 sites
+
+`stripParserPrelude:342` (`PRELUDE_CALL_RE`) · module scope `:676` (`SIDE_EFFECT_CALL_RE`)
+
+Owner: `@strudel/core` `repl.mjs` (the setter/boot surface). **Transcribed** — twice, as two
+lists that are *nearly* the same: `SIDE_EFFECT_CALL_RE` adds `all` and `PRELUDE_CALL_RE` does
+not. Two copies of one vocabulary that have already drifted from each other by one entry.
+
+Known-incomplete: **observed** — a setup head absent from the list opaques the whole program:
+`setGain(0.5)` + `note("c3")` goes to `Code`, against a control `setcps(0.5)` that parses.
+
+```regex
+1x  /^[ \t]*(?:samples|useRNG|setcps|setCps|setcpm|setCpm|setVoicingRange|initAudio|aliasBank)\s*\(/
+1x  /^[ \t]*(?:all|samples|setcps|setCps|setcpm|setCpm|useRNG|setVoicingRange|initAudio|aliasBank)\s*\(/
+```
+
+---
+
+## Category C — transcriptions that are not regexes
+
+Out of the gate's scope (it only sees anchored regular expressions), recorded here so the
+audit is not read as complete when it is only complete for one syntactic form. These are the
+five curated sets already enumerated in the issue:
+
+| set | site | owner | status |
+|---|---|---|---|
+| curated FX arms | `applyMethod` switch, ~`:2376` | `controls.mjs` | partly routed via `asControlParam` (#935) |
+| curated Param arms | `applyMethod` switch, ~`:2566` | `controls.mjs` | partly routed (#928 fallback) |
+| `SIDE_EFFECT_CALL_RE` list | `:676` | `repl.mjs` | transcribed (also B5) |
+| `CHAIN_ROOT_RECOGNISER` | module scope | `signal.mjs` | re-derived by a drift gate (#953) |
+| `RESERVED_LABEL_IDENTS` | module scope | — | ours; no external owner |
+
+`classifyLiteralRhs`'s numeric arm is **closed**: all three copies of `/^-?\d+(\.\d+)?$/` were
+replaced by `isNumericLiteral`, which asks `Number` (#958). Confirmed still closed by
+observation — `const n = .5` and `const n = 4` now produce the same IR shape.
+
+---
+
+## Totals
+
+| category | owner | sites |
+|---|---|---|
+| A — JavaScript syntax | acorn | 26 |
+| B — Strudel vocabulary | `controls.mjs` / `signal.mjs` / krill | 16 |
+| **total anchored regexes** | | **42** |
+| distinct sources | | 33 |
+
+Of the 42, **zero** currently delegate. Eleven of the incompleteness claims above are observed
+against a control arm; the rest are reasoned from the expression and marked as such.

--- a/packages/editor/src/ir/PREDICATE-AUDIT.md
+++ b/packages/editor/src/ir/PREDICATE-AUDIT.md
@@ -1,7 +1,8 @@
 # Predicate audit — `ir/parseStrudel.ts`
 
-Every anchored regular expression in `parseStrudel.ts`, the question it answers, and the
-system that owns the right answer.
+Every regular expression in `parseStrudel.ts`, the question it answers, and the system that
+owns the right answer. 42 are anchored predicates (categories A and B); 7 are unanchored
+(category D), two of which are predicates as well.
 
 This file is a **census, not a plan**. It exists so that "find the next parser bug" becomes
 "close a finite list". Nothing here changes behaviour, and no entry is an instruction to
@@ -32,9 +33,13 @@ the controlled before/after: 512 lines with a hand-rolled tokenizer, 397 lines a
 regexes after it was rebuilt on krill.
 
 (The five zeroes are a negative result, so they carry a control arm: the same query finds
-anchored regexes in fifteen other `.ts` files in this package, and `parseMini.ts` retains two
-*unanchored* single-character scans — `/[0-9.]/` and `/\s/` at `parseMini.ts:302,377` — which
-locate a boundary rather than decide what a token means.)
+anchored regexes in 42 other `.ts` files under `packages/editor/src`, and `parseMini.ts`
+retains two *unanchored* single-character scans — `/[0-9.]/` and `/\s/` at
+`parseMini.ts:302,377` — which locate a boundary rather than decide what a token means.)
+
+**Line numbers throughout this file are indicative and drift.** They are navigation aids as of
+the commit that added this document; the gate deliberately keys on regex *source*, never on
+position, so a moved predicate does not read as a new one.
 
 ### The failure mode is silence
 
@@ -303,19 +308,59 @@ Known-incomplete: **observed** — a setup head absent from the list opaques the
 
 ---
 
-## Category C — transcriptions that are not regexes
+## Category D — unanchored regexes
 
-Out of the gate's scope (it only sees anchored regular expressions), recorded here so the
+An anchored regex decides what a whole token *means*; an unanchored one usually just locates a
+boundary. That distinction is real, but it is a judgement, and leaving it to the gate would
+mean the gate quietly deciding what counts as a predicate. So the census covers **every** regex
+literal in the file and this category holds the seven that are not anchored — five of them
+genuinely scans, two of them predicates that the anchored-only reading would have missed.
+
+**D1 · "which characters are JavaScript's arithmetic operators?" — 1 site** (`ARITH_SPLIT:194`)
+
+Owner: acorn (`BinaryExpression`); the operands already delegate to `Number` via
+`isNumericLiteral`. **Transcribed.** This one is a predicate despite being unanchored — it
+decides the operator set for the enumerated-arithmetic arm.
+
+Known-incomplete: **reasoned** — the four operators `/ * + -` only, so `%`, `**`, `<<` and
+parenthesised sub-expressions are not this grammar. The surrounding comment states that as a
+deliberate closed grammar rather than an oversight, which is the right way to record it.
+
+**D2 · "where does a block comment end?" — 1 site** (`splitTopLevelStatements:535`)
+
+Owner: acorn (comment ranges). **Transcribed.** Pairs with A7; same known-incomplete shape —
+`/*` inside a string literal is treated as a comment opener.
+
+**D3 · character scans — 5 sites** (`:615`, `:859`, `:1261`, `:3072`, `:3121`)
+
+`/\s/`, `/\S/`, `/[a-zA-Z0-9_$]/`. These locate a boundary rather than decide what a token
+means, which is the same role the two survivors in `parseMini.ts` play after its rebuild. No
+owner, nothing to delegate — listed only so that "seven unanchored" is accounted for rather
+than waved past.
+
+```regex
+1x  /(?<=[\d.])[ \t]*[/*+\-][ \t]*/
+1x  /\/\*[\s\S]*?\*\//g
+2x  /\s/
+1x  /\S/
+2x  /[a-zA-Z0-9_$]/
+```
+
+---
+
+## Category E — transcriptions that are not regexes at all
+
+Outside the gate's reach entirely — it can only see regex literals. Recorded here so this
 audit is not read as complete when it is only complete for one syntactic form. These are the
-five curated sets already enumerated in the issue:
+curated sets enumerated in the issue, with their sites verified rather than quoted:
 
 | set | site | owner | status |
 |---|---|---|---|
-| curated FX arms | `applyMethod` switch, ~`:2376` | `controls.mjs` | partly routed via `asControlParam` (#935) |
-| curated Param arms | `applyMethod` switch, ~`:2566` | `controls.mjs` | partly routed (#928 fallback) |
+| curated FX arms | `applyMethod` switch, from `:2417` | `controls.mjs` | partly routed via `asControlParam:2733` (#935) |
+| curated Param arms | `applyMethod` switch, from `:2614` | `controls.mjs` | partly routed via the registry fallback (#928) |
+| `CHAIN_ROOT_RECOGNISER` | `:1039` | `signal.mjs` | transcribed, but re-derived by a drift gate (#953) |
 | `SIDE_EFFECT_CALL_RE` list | `:676` | `repl.mjs` | transcribed (also B5) |
-| `CHAIN_ROOT_RECOGNISER` | module scope | `signal.mjs` | re-derived by a drift gate (#953) |
-| `RESERVED_LABEL_IDENTS` | module scope | — | ours; no external owner |
+| `RESERVED_LABEL_IDENTS` | `:1016` | — | ours; no external owner, so nothing to delegate |
 
 `classifyLiteralRhs`'s numeric arm is **closed**: all three copies of `/^-?\d+(\.\d+)?$/` were
 replaced by `isNumericLiteral`, which asks `Number` (#958). Confirmed still closed by
@@ -330,7 +375,10 @@ observation — `const n = .5` and `const n = 4` now produce the same IR shape.
 | A — JavaScript syntax | acorn | 26 |
 | B — Strudel vocabulary | `controls.mjs` / `signal.mjs` / krill | 16 |
 | **total anchored regexes** | | **42** |
-| distinct sources | | 33 |
+| D — unanchored (2 predicates + 5 scans) | acorn / — | 7 |
+| **total regex literals** | | **49** |
+| distinct sources | | 38 |
 
-Of the 42, **zero** currently delegate. Eleven of the incompleteness claims above are observed
-against a control arm; the rest are reasoned from the expression and marked as such.
+Of the 42 anchored predicates, **zero** currently delegate. Eleven of the incompleteness claims
+above are observed against a control arm; the rest are reasoned from the expression and marked
+as such.

--- a/packages/editor/src/ir/__tests__/predicateAudit.test.ts
+++ b/packages/editor/src/ir/__tests__/predicateAudit.test.ts
@@ -1,0 +1,159 @@
+/**
+ * predicateAudit.test.ts — the census in `ir/PREDICATE-AUDIT.md` still matches
+ * the source (#959).
+ *
+ * `parseStrudel.ts` decides things about JavaScript syntax and about Strudel's
+ * vocabulary by hand, in anchored regular expressions. Every other module in
+ * the parse path asks an authority instead and has zero. The audit document
+ * lists all 42, what each one decides, and who owns the right answer — so that
+ * "find the next parser bug" is a finite list rather than a search.
+ *
+ * A document like that decays the moment someone adds a regex, and a decayed
+ * census reads exactly like a current one. Hence this gate: it re-derives the
+ * census from the source on every run and fails if the document disagrees.
+ * Adding a predicate is still allowed; adding one *silently* is not.
+ *
+ * WHY IT ASKS TYPESCRIPT. Finding regex literals in a TypeScript file means
+ * knowing which slashes are division, which are inside strings, and which are
+ * inside comments — the same class of question the audit is about. Answering
+ * it with a scanner here would reproduce the defect inside the tool that
+ * measures it, so the scan delegates to `ts.createSourceFile`. That also makes
+ * the exclusion of commented-out regexes structural rather than heuristic:
+ * four of them are quoted in prose in `parseStrudel.ts` and the tokenizer
+ * never offers them.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import ts from 'typescript'
+
+const IR_DIR = join(__dirname, '..')
+const SOURCE = join(IR_DIR, 'parseStrudel.ts')
+const AUDIT = join(IR_DIR, 'PREDICATE-AUDIT.md')
+
+/** A regex is "anchored" when it decides the shape of a WHOLE token — `^` at
+ *  the start or `$` at the end. Unanchored expressions (a `/\s/` scan, a
+ *  `.replace` over free text) locate a boundary rather than decide what
+ *  something means, which is the distinction the audit turns on. */
+function isAnchored(source: string): boolean {
+  const body = source.replace(/^\//, '').replace(/\/[gimsuy]*$/, '')
+  return body.startsWith('^') || body.endsWith('$')
+}
+
+/** Every anchored regex literal in the source, in file order, duplicates kept. */
+function censusFromSource(): string[] {
+  const text = readFileSync(SOURCE, 'utf8')
+  const sf = ts.createSourceFile(SOURCE, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+  const found: string[] = []
+  const walk = (node: ts.Node): void => {
+    if (node.kind === ts.SyntaxKind.RegularExpressionLiteral) {
+      const src = (node as ts.RegularExpressionLiteral).getText(sf)
+      if (isAnchored(src)) found.push(src)
+    }
+    ts.forEachChild(node, walk)
+  }
+  walk(sf)
+  return found
+}
+
+/** Every `<count>x  <regex>` line inside a ```regex fence in the audit. */
+function censusFromAudit(): string[] {
+  const text = readFileSync(AUDIT, 'utf8')
+  const fences = text.matchAll(/```regex\n([\s\S]*?)```/g)
+  const declared: string[] = []
+  for (const fence of fences) {
+    for (const line of fence[1].split('\n')) {
+      const trimmed = line.trim()
+      if (!trimmed) continue
+      const m = trimmed.match(/^(\d+)x\s+(\/.*)$/)
+      expect(m, `unparseable line in a \`\`\`regex fence: ${JSON.stringify(trimmed)}`).toBeTruthy()
+      const [, count, source] = m as RegExpMatchArray
+      for (let i = 0; i < Number(count); i += 1) declared.push(source)
+    }
+  }
+  return declared
+}
+
+function tally(sources: string[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const s of sources) counts.set(s, (counts.get(s) ?? 0) + 1)
+  return counts
+}
+
+describe('predicate audit (#959)', () => {
+  const actual = censusFromSource()
+  const declared = censusFromAudit()
+
+  it('every anchored regex in parseStrudel.ts has an audit entry', () => {
+    const have = tally(declared)
+    const missing: string[] = []
+    for (const [source, count] of tally(actual)) {
+      const claimed = have.get(source) ?? 0
+      if (claimed < count) missing.push(`${source} — ${count} in source, ${claimed} in audit`)
+    }
+    expect(
+      missing,
+      'A predicate was added to parseStrudel.ts without an audit entry. Add it to ' +
+        'PREDICATE-AUDIT.md under the category that owns the question it answers — ' +
+        'and note whether it delegates or transcribes.',
+    ).toEqual([])
+  })
+
+  it('every audit entry still exists in parseStrudel.ts', () => {
+    const have = tally(actual)
+    const stale: string[] = []
+    for (const [source, count] of tally(declared)) {
+      const real = have.get(source) ?? 0
+      if (real < count) stale.push(`${source} — ${count} in audit, ${real} in source`)
+    }
+    expect(
+      stale,
+      'The audit claims predicates the source no longer has. If one was deleted or ' +
+        'delegated, remove its entry (and say so in the totals) — a census that ' +
+        'overstates reads the same as one that is current.',
+    ).toEqual([])
+  })
+
+  it('the audit states the total it actually lists', () => {
+    const text = readFileSync(AUDIT, 'utf8')
+    const stated = text.match(/\*\*total anchored regexes\*\*\s*\|\s*\|\s*\*\*(\d+)\*\*/)
+    expect(stated, 'the totals table lost its **total anchored regexes** row').toBeTruthy()
+    expect(Number((stated as RegExpMatchArray)[1])).toBe(actual.length)
+  })
+
+  /**
+   * The claim the audit rests on, re-measured rather than quoted. It is a
+   * negative result about five modules, so it carries a control arm: the same
+   * scan must find anchored regexes in parseStrudel.ts itself. A zero from a
+   * broken query would otherwise read as a delegating module.
+   */
+  it('modules that delegate to an authority still have no anchored regexes', () => {
+    const delegating = [
+      'parseMini.ts',
+      'collect.ts',
+      'parseStrudelStages.ts',
+      '../visualEdit/chunkDetect.ts',
+      '../visualEdit/arrange/parse.ts',
+    ]
+    const scan = (rel: string): number => {
+      const path = join(IR_DIR, rel)
+      const text = readFileSync(path, 'utf8')
+      const sf = ts.createSourceFile(path, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+      let n = 0
+      const walk = (node: ts.Node): void => {
+        if (
+          node.kind === ts.SyntaxKind.RegularExpressionLiteral &&
+          isAnchored((node as ts.RegularExpressionLiteral).getText(sf))
+        )
+          n += 1
+        ts.forEachChild(node, walk)
+      }
+      walk(sf)
+      return n
+    }
+    expect(scan('parseStrudel.ts'), 'control arm: the scan must find the known 42').toBe(
+      actual.length,
+    )
+    for (const rel of delegating) expect(`${rel}: ${scan(rel)}`).toBe(`${rel}: 0`)
+  })
+})

--- a/packages/editor/src/ir/__tests__/predicateAudit.test.ts
+++ b/packages/editor/src/ir/__tests__/predicateAudit.test.ts
@@ -5,7 +5,8 @@
  * `parseStrudel.ts` decides things about JavaScript syntax and about Strudel's
  * vocabulary by hand, in anchored regular expressions. Every other module in
  * the parse path asks an authority instead and has zero. The audit document
- * lists all 42, what each one decides, and who owns the right answer — so that
+ * lists all 49 regex literals in the file — the 42 anchored predicates grouped by
+ * the question each decides and who owns the answer, plus the 7 unanchored — so that
  * "find the next parser bug" is a finite list rather than a search.
  *
  * A document like that decays the moment someone adds a regex, and a decayed
@@ -31,30 +32,33 @@ const IR_DIR = join(__dirname, '..')
 const SOURCE = join(IR_DIR, 'parseStrudel.ts')
 const AUDIT = join(IR_DIR, 'PREDICATE-AUDIT.md')
 
-/** A regex is "anchored" when it decides the shape of a WHOLE token — `^` at
- *  the start or `$` at the end. Unanchored expressions (a `/\s/` scan, a
- *  `.replace` over free text) locate a boundary rather than decide what
- *  something means, which is the distinction the audit turns on. */
-function isAnchored(source: string): boolean {
-  const body = source.replace(/^\//, '').replace(/\/[gimsuy]*$/, '')
-  return body.startsWith('^') || body.endsWith('$')
-}
-
-/** Every anchored regex literal in the source, in file order, duplicates kept. */
-function censusFromSource(): string[] {
-  const text = readFileSync(SOURCE, 'utf8')
-  const sf = ts.createSourceFile(SOURCE, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+/**
+ * Every regex literal in a file, in order, duplicates kept.
+ *
+ * The census is deliberately NOT filtered to anchored expressions. An anchored
+ * regex decides what a whole token means and an unanchored one usually only
+ * locates a boundary — a real distinction, and the one the audit is organised
+ * around — but it is a judgement, and a gate that applied it would be deciding
+ * for itself what counts as a predicate. It missed `ARITH_SPLIT` (which
+ * transcribes JavaScript's operator set without an anchor) on the first pass
+ * here, which is the argument. So the gate counts everything and the document
+ * does the classifying, in the open, where it can be disagreed with.
+ */
+function regexLiteralsIn(path: string): string[] {
+  const text = readFileSync(path, 'utf8')
+  const sf = ts.createSourceFile(path, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
   const found: string[] = []
   const walk = (node: ts.Node): void => {
     if (node.kind === ts.SyntaxKind.RegularExpressionLiteral) {
-      const src = (node as ts.RegularExpressionLiteral).getText(sf)
-      if (isAnchored(src)) found.push(src)
+      found.push((node as ts.RegularExpressionLiteral).getText(sf))
     }
     ts.forEachChild(node, walk)
   }
   walk(sf)
   return found
 }
+
+const censusFromSource = (): string[] => regexLiteralsIn(SOURCE)
 
 /** Every `<count>x  <regex>` line inside a ```regex fence in the audit. */
 function censusFromAudit(): string[] {
@@ -84,7 +88,7 @@ describe('predicate audit (#959)', () => {
   const actual = censusFromSource()
   const declared = censusFromAudit()
 
-  it('every anchored regex in parseStrudel.ts has an audit entry', () => {
+  it('every regex literal in parseStrudel.ts has an audit entry', () => {
     const have = tally(declared)
     const missing: string[] = []
     for (const [source, count] of tally(actual)) {
@@ -116,8 +120,8 @@ describe('predicate audit (#959)', () => {
 
   it('the audit states the total it actually lists', () => {
     const text = readFileSync(AUDIT, 'utf8')
-    const stated = text.match(/\*\*total anchored regexes\*\*\s*\|\s*\|\s*\*\*(\d+)\*\*/)
-    expect(stated, 'the totals table lost its **total anchored regexes** row').toBeTruthy()
+    const stated = text.match(/\*\*total regex literals\*\*\s*\|\s*\|\s*\*\*(\d+)\*\*/)
+    expect(stated, 'the totals table lost its **total regex literals** row').toBeTruthy()
     expect(Number((stated as RegExpMatchArray)[1])).toBe(actual.length)
   })
 
@@ -135,25 +139,16 @@ describe('predicate audit (#959)', () => {
       '../visualEdit/chunkDetect.ts',
       '../visualEdit/arrange/parse.ts',
     ]
-    const scan = (rel: string): number => {
-      const path = join(IR_DIR, rel)
-      const text = readFileSync(path, 'utf8')
-      const sf = ts.createSourceFile(path, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
-      let n = 0
-      const walk = (node: ts.Node): void => {
-        if (
-          node.kind === ts.SyntaxKind.RegularExpressionLiteral &&
-          isAnchored((node as ts.RegularExpressionLiteral).getText(sf))
-        )
-          n += 1
-        ts.forEachChild(node, walk)
-      }
-      walk(sf)
-      return n
+    /** ANCHORED only here: the claim is about predicates, and `parseMini.ts`
+     *  legitimately keeps two unanchored character scans after its rebuild. */
+    const isAnchored = (source: string): boolean => {
+      const body = source.replace(/^\//, '').replace(/\/[gimsuy]*$/, '')
+      return body.startsWith('^') || body.endsWith('$')
     }
-    expect(scan('parseStrudel.ts'), 'control arm: the scan must find the known 42').toBe(
-      actual.length,
-    )
+    const scan = (rel: string): number =>
+      regexLiteralsIn(join(IR_DIR, rel)).filter(isAnchored).length
+
+    expect(scan('parseStrudel.ts'), 'control arm: the scan must find the known 42').toBe(42)
     for (const rel of delegating) expect(`${rel}: ${scan(rel)}`).toBe(`${rel}: 0`)
   })
 })


### PR DESCRIPTION
Part of #929 / #925. Implements the deliverable in #959 — a table, not a refactor.

## The problem

`parseStrudel.ts` decides questions about JavaScript syntax and about Strudel's vocabulary in **42 hand-written anchored regular expressions**. Every other module in the parse path asks somebody who already knows, and has none:

| module | asks | anchored regexes | lines |
|---|---|---|---|
| `ir/parseMini.ts` | krill | **0** | 397 |
| `ir/collect.ts` | — | **0** | 1419 |
| `ir/parseStrudelStages.ts` | — | **0** | 377 |
| `visualEdit/chunkDetect.ts` | acorn | **0** | 496 |
| `visualEdit/arrange/parse.ts` | acorn | **0** | 223 |
| **`ir/parseStrudel.ts`** | **nobody** | **42** | **3335** |

A regular expression cannot express an infinite grammar, so each of the 42 is incomplete by construction — and none of them throw. That is why these are only ever found by being hit, one incident at a time.

## What the audit found

The 42 answer only ten distinct questions. Six of them are JavaScript's, and one — "is this a string literal, and what is inside it?" — is transcribed **fifteen times in six different spellings**. The `note`/`s`/`mini` cluster is ten regexes because three name-groups were each spelled once per quote style: a product of two independent transcriptions.

The failure modes are graded, and the worst one is invisible:

1. **The node opaques** — keeps its bytes, loses its structure. Honest, and visible in the parity counts.
2. **The node changes meaning** — `.s("drum/kit")` stops being a sample name and is re-read as mini-notation.
3. **The node silently disappears** — `.every(2, fast(2*2))` yields an `Every` wrapping the *untransformed* pattern. No `Code` marker, no count movement, no error. The IR asserts a transform the source does not contain, and the view draws it.

Class 3 is the argument for counting these rather than fixing them one at a time.

## Observed, not argued

Eleven incompleteness claims were run through `parseStrudel` against a control arm differing only in the property under test, and the IR tag-paths compared. A sample:

| input | control | result |
|---|---|---|
| `const café = …` | `cafe` | whole program opaques |
| `pp => pp.fast(2)` | `x => x.fast(2)` | **`Fast` node vanishes** |
| `fast(2*2)`, `slow(-2)` | `fast(2)`, `slow(2)` | **transform vanishes** |
| `.mask('1 0')` | `.mask("1 0")` | opaques |
| `.s("b\"d")` | `.s("bd")` | opaques |
| `setGain(0.5)` | `setcps(0.5)` | whole program opaques |
| `/*x*/stack(…)` | `stack(…)` | whole program opaques |
| `.s("drum/kit")` | `.s("bd")` | re-read as mini-notation |

Claims that were only reasoned from the expression are marked as such, and not mixed in with these.

Two probes came back SAME and are reported that way: the numeric arm of `classifyLiteralRhs` is confirmed still closed after the leading-decimal fix, and one early probe never reached `parseTransform` at all — it was the probe that was wrong, not the predicate.

## The gate

`predicateAudit.test.ts` re-derives the census from the source on every run and fails in **both** directions: a new predicate with no entry, and an entry the source no longer has. A census that overstates reads exactly like one that is current.

Two details worth the review:

- It asks **TypeScript's own tokenizer** which slashes are regexes rather than scanning for them. Deciding that means knowing which slashes are division, which are in strings and which are in comments — the same class of question the audit is about, so hand-rolling it here would reproduce the defect inside the instrument that measures it. It also makes the exclusion of the four regexes quoted in prose structural rather than heuristic.
- The five-module zero is a negative result, so both the document and the gate carry a **control arm** — the same scan must find the known 42 in `parseStrudel.ts`. A zero from a broken query would otherwise read as a delegating module.

Verified red by injecting a new anchored regex (fails), and by deleting an entry that is still in the source (fails). Green after restore.

## Scope

No behaviour change: one document, one test. `parseStrudel.ts` is untouched, so no `dist` rebuild.

The sequencing stays in #959 — category B is the same shape as the chain-root work and needs no new dependency; category A goes behind a spike, because the honest opening question is whether the IR needs its own JavaScript parse at all when `visualEdit/` already has one.

## Test plan

- `pnpm gate:editing:editor` — 3183/3183 (203 files)
- `pnpm gate:editing:app` — 161/161 (11 files)
- `tsc --noEmit` — 73 pre-existing, **0** in the new file
- fault injection — gate red on a new regex, red on a deleted entry, green on restore

Browser arm not run: this change touches no runtime code, no `dist`, and no rendered surface.