### PR TITLE
✨ Timeline: drive song analysis from eval haps (queryArc), not collect

### DIFF
--- a/packages/app/src/components/MusicalTimeline.tsx
+++ b/packages/app/src/components/MusicalTimeline.tsx
@@ -252,16 +252,19 @@ export function MusicalTimeline(
     // duplicates every row (PV175). Anchors are built once per analysis run
     // (cheap; dollarPos is a source offset, so the cycle count is irrelevant).
     const getEvents = getTimelineEventsRef.current
-    const anchors = buildLaneAnchors(ir, 1)
-    const collectFn = getEvents
-      ? (startCycle: number, endCycle: number): IREvent[] =>
-          getEvents(endCycle)
-            .filter((ev) => {
-              const c = Math.floor(ev.begin)
-              return c >= startCycle && c < endCycle
-            })
-            .map((ev) => ({ ...ev, trackId: laneKeyForHap(ev, anchors) }))
-      : undefined
+    let collectFn:
+      | ((startCycle: number, endCycle: number) => IREvent[])
+      | undefined
+    if (getEvents) {
+      const anchors = buildLaneAnchors(ir, 1)
+      collectFn = (startCycle, endCycle) =>
+        getEvents(endCycle)
+          .filter((ev) => {
+            const c = Math.floor(ev.begin)
+            return c >= startCycle && c < endCycle
+          })
+          .map((ev) => ({ ...ev, trackId: laneKeyForHap(ev, anchors) }))
+    }
     const signal = { aborted: false }
     analyzeSong(ir, { signal, collectFn })
       .then((result) => {

--- a/packages/app/src/components/MusicalTimeline.tsx
+++ b/packages/app/src/components/MusicalTimeline.tsx
@@ -68,6 +68,7 @@ import {
   type SongAnalysis,
 } from '@stave/editor'
 import { FullSongTimeline } from './FullSongTimeline'
+import { buildLaneAnchors, laneKeyForHap } from './musicalTimeline/timelineMarks'
 
 export interface MusicalTimelineProps {
   /** Current cycle (post-collect coords) from the active runtime, or
@@ -215,6 +216,17 @@ export function MusicalTimeline(
   // renderer were retired in U5.
   const [analysis, setAnalysis] = useState<SongAnalysis | null>(null)
 
+  // #980 — latest-value ref for the runtime's queryArc event accessor. The
+  // analyze effect sources onsets from EVAL haps (getTimelineEvents → queryArc)
+  // instead of the `collect` interpreter, so analysis + the eval-backed marks
+  // (#978) share one oracle. Held in a ref because props.getTimelineEvents is a
+  // fresh closure every render (StaveApp binds it inline) — reading it through a
+  // ref keeps the analyze effect keyed on `snapshot` alone, not re-running each
+  // render. The snapshot is republished AFTER eval-on-load populates
+  // songPatterns, so the accessor returns real haps by the time we query.
+  const getTimelineEventsRef = React.useRef(props.getTimelineEvents)
+  getTimelineEventsRef.current = props.getTimelineEvents
+
   // Analyze the whole song from the IR snapshot on every new snapshot
   // (re-eval). The previous run is aborted via a per-run signal so a fast edit
   // cadence can't pile up overlapping budgeted collections.
@@ -226,8 +238,32 @@ export function MusicalTimeline(
       setAnalysis(null)
       return
     }
+    // #980 — queryArc-backed collector: eval haps for the whole song, sliced to
+    // each requested [startCycle, endCycle) band. `analyzeSong` reads only
+    // {trackId, s, begin, note}, all present on hap events. When no runtime
+    // accessor is threaded (tests / non-Strudel), fall through to analyzeSong's
+    // default `collectCycles(ir)` — the collect path stays as the safety net.
+    //
+    // Eval haps carry the engine's POSITIONAL trackId (`$N`); analyzeSong groups
+    // lanes by laneKeyOf(=trackId ?? s), while the timeline scene keys rows by the
+    // IR/structural lane (`d{N}` / name). Remap each hap to its containment lane
+    // via the SAME join the marks use (buildLaneAnchors + laneKeyForHap) so
+    // analysis lanes and mark lanes share keys — else the scene renders BOTH and
+    // duplicates every row (PV175). Anchors are built once per analysis run
+    // (cheap; dollarPos is a source offset, so the cycle count is irrelevant).
+    const getEvents = getTimelineEventsRef.current
+    const anchors = buildLaneAnchors(ir, 1)
+    const collectFn = getEvents
+      ? (startCycle: number, endCycle: number): IREvent[] =>
+          getEvents(endCycle)
+            .filter((ev) => {
+              const c = Math.floor(ev.begin)
+              return c >= startCycle && c < endCycle
+            })
+            .map((ev) => ({ ...ev, trackId: laneKeyForHap(ev, anchors) }))
+      : undefined
     const signal = { aborted: false }
-    analyzeSong(ir, { signal })
+    analyzeSong(ir, { signal, collectFn })
       .then((result) => {
         if (!signal.aborted) setAnalysis(result)
       })
@@ -238,6 +274,32 @@ export function MusicalTimeline(
       signal.aborted = true
     }
   }, [snapshot])
+
+  // #980 — test-only observation of the eval-backed analysis (consumer 4).
+  // Gated on the same debug flag as the marks probe (FullSongTimeline), so
+  // production pays nothing. Lets a browser e2e adjudicate the verdict move at
+  // true fidelity: a signal-only track — which `collect` CANNOT onset — gains an
+  // analysis lane once analyzeSong reads eval haps instead of collect.
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    let on = false
+    try {
+      on = !!window.localStorage.getItem('stave:debug.timelineMarks')
+    } catch {
+      on = false
+    }
+    if (!on) return
+    ;(
+      window as unknown as { __staveTimelineAnalysis?: unknown }
+    ).__staveTimelineAnalysis = {
+      periodCycles: analysis?.periodCycles ?? null,
+      horizonCycles: analysis?.horizonCycles ?? 0,
+      lanes: (analysis?.lanes ?? []).map((l) => ({
+        laneKey: l.laneKey,
+        onsets: l.onsetsByCycle.reduce((a, b) => a + b, 0),
+      })),
+    }
+  }, [analysis])
 
   // #394 — on mount the timeline may render before its IR snapshot has been
   // published (a cold eval lags ~2.5s behind the keypress); proactively ask the

--- a/packages/app/src/components/musicalTimeline/timelineMarks.ts
+++ b/packages/app/src/components/musicalTimeline/timelineMarks.ts
@@ -262,6 +262,58 @@ function evalTrackIdToLaneKey(trackId: string | undefined): string {
 }
 
 /**
+ * The lane-anchor containment index eval haps are attributed to: `(laneKey,
+ * dollarPos)` pairs ascending by `dollarPos`, from the resilient structural walk
+ * plus the #927 declared-track seeding (zero-event tracks — signals / bare-refs —
+ * the static IR emits nothing for). This is the SINGLE source of the hap→lane
+ * join: `collectHapMarks` (marks) and the song-analysis remap (`analyzeSong`
+ * onsets, #980) both attribute through `laneKeyForHap` over this index, so their
+ * lane keyings can never drift (PV175 — a hap's `$N` trackId ≠ its `d{N}` IR lane
+ * key; containment reconciles them via source offsets both sides carry).
+ * `displayCycles` only bounds the walk — `dollarPos` is a source offset, so any
+ * `≥ 1` yields the same anchors.
+ */
+export function buildLaneAnchors(
+  ir: PatternIR | null,
+  displayCycles: number,
+): Array<[string, number]> {
+  if (!ir) return []
+  const labelOffsetByLane = new Map<string, number>()
+  const nCycles = Math.max(1, Math.ceil(displayCycles))
+  for (const lane of structuralWalk(ir, nCycles)) {
+    if (lane.dollarPos !== undefined) labelOffsetByLane.set(lane.laneKey, lane.dollarPos)
+  }
+  if (ir.tag === 'Stack') {
+    for (const [key, start] of declaredTrackAnchors(ir)) {
+      if (!labelOffsetByLane.has(key)) labelOffsetByLane.set(key, start)
+    }
+  }
+  return [...labelOffsetByLane].sort((a, b) => a[1] - b[1])
+}
+
+/**
+ * Attribute one eval hap to its display lane key: source containment into the
+ * anchor index (the IR lane whose `dollarPos` is the LARGEST ≤ the hap's
+ * `loc[0].start`), else the hap's own positional producer id
+ * (`evalTrackIdToLaneKey`). NOT `laneKeyOf` string equality — that splits an
+ * anon `$:`'s `$N` hap from its `d{N}` IR lane (PV175).
+ */
+export function laneKeyForHap(
+  ev: IREvent,
+  anchors: ReadonlyArray<readonly [string, number]>,
+): string {
+  const start = ev.loc?.[0]?.start
+  let hit: string | undefined
+  if (typeof start === 'number' && Number.isFinite(start)) {
+    for (const [key, pos] of anchors) {
+      if (pos <= start) hit = key
+      else break // ascending → no later anchor can be ≤ start
+    }
+  }
+  return hit ?? evalTrackIdToLaneKey(ev.trackId)
+}
+
+/**
  * Derive note marks from EVALUATED haps (#861), attributed to a lane by SOURCE
  * CONTAINMENT when possible, else to an EVAL-BACKED lane (#864 / P1b).
  *
@@ -290,23 +342,13 @@ function collectHapMarks(
   const out = new Map<string, SceneNote[]>()
   // (laneKey, dollarPos) pairs ascending by dollarPos — the containment index.
   const anchors = [...labelOffsetByLane].sort((a, b) => a[1] - b[1])
-  // Containment hit (an IR lane), or undefined when the hap's source start lands
-  // before every lane's statement (or it has no `loc`).
-  const irLaneFor = (start: number | undefined): string | undefined => {
-    if (typeof start !== 'number' || !Number.isFinite(start)) return undefined
-    let hit: string | undefined
-    for (const [key, pos] of anchors) {
-      if (pos <= start) hit = key
-      else break // ascending → no later anchor can be ≤ start
-    }
-    return hit
-  }
   for (const ev of events) {
     const cycle = ev.begin
     if (!Number.isFinite(cycle) || cycle < 0 || cycle >= displayCycles) continue
-    // Containment first (keeps a hap on its named/positional IR lane); else an
-    // eval-backed lane keyed by the hap's own producer id (#864 / P1b).
-    const key = irLaneFor(ev.loc?.[0]?.start) ?? evalTrackIdToLaneKey(ev.trackId)
+    // The ONE join (`laneKeyForHap`): containment first (keeps a hap on its
+    // named/positional IR lane), else an eval-backed lane keyed by the hap's own
+    // producer id (#864 / P1b). Shared with the song-analysis remap (#980).
+    const key = laneKeyForHap(ev, anchors)
     let arr = out.get(key)
     if (!arr) {
       arr = []

--- a/packages/app/tests/full-song-analysis-eval.spec.ts
+++ b/packages/app/tests/full-song-analysis-eval.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Consumer 4 (#980) — the collect→queryArc split applied to `analyzeSong`.
+ *
+ * The Song timeline's lane/period/section analysis must read onsets from EVAL
+ * haps (queryArc), not the `collect` interpreter. The verdict move, adjudicated
+ * at browser fidelity:
+ *
+ *  A signal-only track — `note(sine.range(48,72).segment(8))` — produces ZERO
+ *  onsets under `collect` (it can't evaluate `sine`), so collect-backed analysis
+ *  has NO lane for it. Eval resolves 8 discrete onsets, so eval-backed analysis
+ *  gains a second lane. Observed via the `__staveTimelineAnalysis` debug probe
+ *  (analysis feeds coarse density/period, not per-mark DOM).
+ *
+ * REACH: an invalid mid-edit tune must not wipe the analysis (last-valid eval +
+ * resilient structure), same property the marks gate proves.
+ */
+import { test, expect, type Page } from '@playwright/test'
+
+type AnalysisProbe = {
+  periodCycles: number | null
+  horizonCycles: number
+  lanes: Array<{ laneKey: string; onsets: number }>
+}
+
+function readAnalysis(page: Page): Promise<AnalysisProbe | null> {
+  return page.evaluate(
+    () => (window as unknown as { __staveTimelineAnalysis?: AnalysisProbe }).__staveTimelineAnalysis ?? null,
+  )
+}
+
+async function boot(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    try {
+      localStorage.setItem('stave:bottomPanel.height', '320')
+      localStorage.setItem('stave:bottomPanel.open', 'true')
+      localStorage.setItem('stave:bottomPanel.activeTabId', 'musical-timeline')
+      localStorage.setItem('stave:debug.timelineMarks', '1')
+    } catch { /* ignore */ }
+  })
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
+  await page.locator('[data-bottom-panel="root"]').waitFor({ timeout: 20_000 })
+  await page.waitForFunction(
+    () => {
+      const m = (window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getValue?: () => string } | null }> } } }).monaco
+      const eds = m?.editor?.getEditors?.() ?? []
+      return eds.some((e) => (e.getModel()?.getValue?.()?.length ?? 0) > 0)
+    },
+    { timeout: 20_000 },
+  )
+  await page.locator('[data-full-song="root"]').waitFor({ timeout: 15_000 })
+}
+
+async function editCode(page: Page, code: string): Promise<void> {
+  await page.evaluate((c) => {
+    const monaco = (window as unknown as { monaco?: { editor?: { getEditors?: () => Array<{ getModel: () => { getLanguageId?: () => string; setValue: (s: string) => void } | null; focus: () => void }> } } }).monaco
+    const editors = monaco?.editor?.getEditors?.() ?? []
+    const target = editors.find((e) => e.getModel()?.getLanguageId?.() === 'strudel') ?? editors[0]
+    target?.getModel()?.setValue(c)
+    target?.focus()
+  }, code)
+}
+
+test('a signal-only track gains an analysis lane (collect cannot onset it)', async ({ page }) => {
+  const errors: string[] = []
+  page.on('pageerror', (e) => errors.push(`pageerror: ${e.message}`))
+  await boot(page)
+
+  // Drum + a signal track. Under `collect` the signal produces ZERO onsets → one
+  // analysis lane. Under eval it resolves 8 onsets → a SECOND analysis lane.
+  await editCode(page, '$: s("bd sd hh")\n$: note(sine.range(48,72).segment(8))')
+
+  await expect
+    .poll(async () => (await readAnalysis(page))?.lanes.length ?? 0, { timeout: 20_000 })
+    .toBeGreaterThanOrEqual(2)
+
+  const a = await readAnalysis(page)
+  // Both lanes carry onsets (the signal lane could ONLY come from eval).
+  expect(a!.lanes.every((l) => l.onsets > 0)).toBe(true)
+  expect(errors).toEqual([])
+})
+
+test('REACH — invalid mid-edit code does not wipe the analysis', async ({ page }) => {
+  await boot(page)
+  await editCode(page, '$: s("bd sd")\n$: s("hh*4")')
+  await expect
+    .poll(async () => (await readAnalysis(page))?.lanes.length ?? 0, { timeout: 20_000 })
+    .toBeGreaterThanOrEqual(2)
+
+  // Break it mid-edit (unclosed string). evaluate returns an error without
+  // throwing and songPatterns keeps the last valid haps, so the analysis stays.
+  await editCode(page, '$: s("bd sd")\n$: s("hh*4"')
+  // Analysis must NOT collapse to empty.
+  await page.waitForTimeout(1500)
+  const a = await readAnalysis(page)
+  expect(a!.lanes.length).toBeGreaterThanOrEqual(1)
+})


### PR DESCRIPTION
**Part of the collect→queryArc split (#945 / EPIC #925) — consumer 4.**

## Problem
`analyzeSong` (the Song timeline's lane/period/section analysis) read onsets from the hand-written `collect` interpreter — a second engine that re-implements Strudel's RNG/euclid/weighting. Where it diverges from eval (binding resolution, tokenizer whitespace, recursive args) the analysis disagreed with what actually plays AND with the eval-backed marks (#978). A signal-only track (`note(sine…)`) produces zero collect onsets, so it got no analysis lane at all.

## Fix
Inject a queryArc-backed collector at the `MusicalTimeline` call site, sourced from the runtime's `getTimelineEvents`. `analyzeSong` reads only `{trackId, s, begin, note}`, all present on hap events.

The subtlety (caught by the browser gate, not inference): eval haps carry a **positional** trackId (`$N`) while the timeline scene keys rows by the IR/structural lane (`d{N}`/name). Grouping by raw `laneKeyOf` splits a `$N` hap from its `d{N}` lane and the scene renders BOTH → every row duplicated. So each hap is remapped to its containment lane via the **same join the marks use** — extracted as `buildLaneAnchors` + `laneKeyForHap` and **shared with `collectHapMarks`** so the two lane keyings can never drift. Falls back to the default collect collector when no runtime accessor is threaded (tests / non-Strudel).

**Behaviour moves, not byte-identical:** where queryArc disagrees with collect, eval is ground truth — analysis and marks now share one oracle.

## Latency (the gating question)
Measured in the real browser: timeline structure **already** waited for eval on cold-open (the snapshot that triggers `analyzeSong` publishes only after eval-on-load), so analysis lanes now land with the marks at the same instant — **no cold-open regression**; per-edit adds ~80ms.

## Verified
- New browser gate `full-song-analysis-eval.spec` — a signal track gains an analysis lane collect cannot onset, + REACH (invalid mid-edit doesn't wipe analysis): **2/2**
- `full-song-eval-on-load.spec` **3/3** — the lane-key alignment restored ARM B's exact 2-lane count (a regression this PR's own gate caught mid-development)
- app suite **892/892** (`collectHapMarks` refactor is behaviour-preserving) · parity-corpus **286/286** · app tsc **0 new**
- app-only change; no editor dist rebuild

Closes #980. (`Closes` won't fire from a studio base — close by hand at merge, verify by content.)