### PR TITLE
Timeline/IR-Inspector: route the IR-snapshot events through eval (queryArc), retiring collect from consumer 3

### DIFF
--- a/packages/app/src/components/StrudelEditorClient.tsx
+++ b/packages/app/src/components/StrudelEditorClient.tsx
@@ -48,7 +48,6 @@ import {
   parseMessageLocation,
   statementOffsetForSource,
   resolveAlias,
-  collectCycles,
   runPasses,
   publishIRSnapshot,
   IR,
@@ -139,20 +138,29 @@ const SNAPSHOT_REFRESH_DEBOUNCE_MS = 300;
 
 /**
  * Parse the file's current source into IR and publish an IRSnapshot for the
- * Inspector + full-song timeline. parseStrudel + collect are pure and cheap on
- * the source string, so this is safe to call outside the eval lifecycle — both
- * the eval-success path AND on-demand (#394: the full-song view needs a
- * snapshot the instant it opens, but a cold eval's `onEvaluateSuccess` lags
- * ~2.5s behind the keypress, leaving the view empty in the meantime).
+ * Inspector + full-song timeline. parseStrudel is pure and cheap on the source
+ * string, so this is safe to call outside the eval lifecycle — both the
+ * eval-success path AND on-demand (#394: the full-song view needs a snapshot
+ * the instant it opens, but a cold eval's `onEvaluateSuccess` lags ~2.5s behind
+ * the keypress, leaving the view empty in the meantime).
+ *
+ * The snapshot's `events` come from the runtime's EVALUATED haps
+ * (`getTimelineEvents`, queryArc) — eval-truth, the same source the Song
+ * timeline's display marks read — NOT the collect interpreter (#982). They are
+ * `[]` until an evaluate populates the runtime's song patterns (PK57: empty
+ * pre-eval, matching the timeline baseline); the IR tree (`ir`/`passes`) stays
+ * source-fresh regardless. A null runtime (non-Strudel / not yet created)
+ * yields empty events.
  *
  * Strudel-only, total: no-op for non-Strudel runtimes / missing files, and
  * swallows parse errors (parseStrudel guarantees a graceful Code-node
- * fallback; collect is total). `source` is the workspace fileId — NOT the
- * human-visible path — because the Inspector's click-to-source keys by id.
+ * fallback). `source` is the workspace fileId — NOT the human-visible path —
+ * because the Inspector's click-to-source keys by id.
  */
 function captureAndPublishSnapshot(
   fileId: string,
   cycleCount: number | null,
+  runtime: LiveCodingRuntime | null,
 ): void {
   const fileNow = getFile(fileId);
   if (!fileNow) return;
@@ -161,12 +169,16 @@ function captureAndPublishSnapshot(
   if (runtimeId !== "strudel") return;
   try {
     // Phase 19-07 (#79) — pre-pass-0 seed: wrap raw source as a Code node so
-    // pass 0 (RAW) reads input.code and runs extractTracks. finalIR drives both
-    // `collect` and the `ir` alias — single source of truth (PV27).
+    // pass 0 (RAW) reads input.code and runs extractTracks. finalIR is the `ir`
+    // alias — the Inspector's IR tree, source-fresh (PV27).
     const seed: PatternIR = IR.code(fileNow.content);
     const passes = runPasses(seed, STRUDEL_PASSES);
     const finalIR = passes[passes.length - 1].ir;
-    const events = collectCycles(finalIR, 0, TIMELINE_WINDOW_CYCLES);
+    // #982 — events = the runtime's evaluated haps (queryArc), not collect, so
+    // the Inspector's event table shows eval-truth. `[]` until eval populates
+    // song patterns; trackId stays the raw engine key ($N / d{N}) — the table
+    // is a flat raw view, not lane-grouped, so no lane-key remap is needed.
+    const events = runtime?.getTimelineEvents(TIMELINE_WINDOW_CYCLES) ?? [];
     publishIRSnapshot(
       {
         ts: Date.now(),
@@ -875,6 +887,7 @@ export default function StrudelEditorClient({
     captureAndPublishSnapshot(
       fid,
       runtimesRef.current.get(fid)?.getCurrentCycle?.() ?? null,
+      rt ?? null,
     );
   }, []);
 
@@ -1093,7 +1106,7 @@ export default function StrudelEditorClient({
         // song-view path (#394) publishes the identical shape — no drift.
         // Phase 19-08: cycleCount lands on the timeline capture entry (not on
         // IRSnapshot) so PV27's per-snapshot alias contract stays untouched.
-        captureAndPublishSnapshot(fileId, runtime.getCurrentCycle());
+        captureAndPublishSnapshot(fileId, runtime.getCurrentCycle(), runtime);
 
         // Prune orphaned per-track colour overrides (#583): drop TrackMeta
         // records whose track no longer exists in the evaluated code, so a


### PR DESCRIPTION
## Problem
`captureAndPublishSnapshot` still built the IR snapshot's `events[]` from the `collect` interpreter (`collectCycles`), which hand-mirrors Strudel's RNG/euclid/weighting semantics. It was the last snapshot consumer reading behaviour off `collect` rather than the runtime's evaluated haps — the timeline's own display marks already moved to eval haps.

## Fix
The snapshot's `events` now come from the runtime's `getTimelineEvents` (queryArc) — the same evaluated-hap source the Song timeline's display marks read. `parseStrudel`/`runPasses` still supply the snapshot's `ir` + `passes`, so the Inspector's IR tree stays source-fresh. `captureAndPublishSnapshot` takes the runtime; both call sites already hold it. `trackId` stays the raw engine key (`$N`/`d{N}`) — the Inspector's event table is a flat raw view, not lane-grouped, so no lane-key remap is needed.

Events are `[]` until an evaluate populates the runtime's song patterns, matching the timeline's own pre-eval baseline; the IR tree stays fresh regardless.

## Isolation
`snapshot.events` has exactly one reader — the IR Inspector event table (currently gated off pending its tab re-enable). `analyzeSong` reads `snapshot.ir` (untouched); the visible timeline marks read via the `getTimelineEvents` accessor directly, not `snapshot.events`. So this change is provably isolated — no visible surface changes. Anchor-safe: no `events[]` consumer reads dollarPos/leafIndex/armIndex/irNodeId. Removes the last app-side `collectCycles` caller outside the pre-eval marks fallback.

## Test plan
- app unit: **892 passed** · parity-corpus: **286 passed** · targeted inspector+timeline: **139 passed**
- tsc: **0 new errors** (one pre-existing `edit-locality.test.ts` error, control-armed against clean base)
- e2e (drove the real app — the shared publish path): eval-on-load ARM A + ARM B + signal-only + cold-eval — **4 passed** (confirms `captureAndPublishSnapshot` still publishes the snapshot `analyzeSong`/timeline depend on)

Refs #982. Base is `studio_v0.2.0`, so `Refs`/`Closes` won't auto-fire — close #982 by hand at merge, verify by content.