### PR TITLE
🔭 test(harness): gate the readers' conservation property, and audit what every figure here is restricted by

### DIFF
--- a/packages/app/tests/parity-corpus/MEASUREMENT-AUDIT.md
+++ b/packages/app/tests/parity-corpus/MEASUREMENT-AUDIT.md
@@ -1,0 +1,119 @@
+# MEASUREMENT-AUDIT — what every figure at this boundary is restricted by
+
+An end-to-end audit of the measurement apparatus, not of the code it measures.
+Prompted by the observation that this boundary has now shipped **five** figures
+carrying an unstated restriction: of population, of comparison axis, of TIME, of
+prose-with-no-gate, and — found here, committed by me while documenting the other
+four — of **cycle window**.
+
+The question each gap asks is not "is this number wrong" but "what does this
+number quietly exclude, and in which direction does that bias it".
+
+Arms: `_audit-window.spec.ts`, `_audit-harvest.spec.ts`. The gate's include glob is
+`tests/parity-corpus/**/*.test.{ts,tsx}`, so exclusion comes from the **`.spec.ts`
+extension** — the `_` prefix is only a naming convention and excludes nothing. (Both
+arms were first written as `.test.ts` and silently joined the suite, 349 -> 352,
+which is this document's own subject arriving one level up: a claim about scope that
+nothing checked.) The one property worth enforcing continuously was promoted to a
+real gate instead — `reader-conservation.test.ts` (#1036).
+
+---
+
+## GAP 1 — CYCLE WINDOW — **found, fixed, and it had already corrupted my own figures**
+
+Every sweep this session read cycles 0-3, and nothing derived that 4 from anything.
+
+| window | accepted pairs | notes kept | collision units | dropped occurrences | duration-disagreeing units |
+| --- | --- | --- | --- | --- | --- |
+| 4 | 4662 | 19375 | 10 | 44 | 4 |
+| 8 | 9328 | 38770 | 10 | 87 | 4 |
+| **16** | 18662 | 77659 | **11** | **182** | **5** |
+| 32 | 37326 | 155512 | 11 | 364 | 5 |
+
+Converges at 16. The unit that requires it —
+`bd*2,[- sd]*2,[- hh]*4, <-!7 oh>, <-!12 bd*4 bd*8 bd*16!2>` — does not reach its
+colliding arm until **cycle 12**, so a 4-cycle instrument cannot see it and does
+not say so.
+
+**Consequence, stated plainly:** the #1034 figures first published as "4 units / 8
+instances" are **5 / 11** at the converged window. The doc-population figure (2 of
+889) is unchanged and therefore window-robust. The axis ratio — anchor ≈ 4×
+duration — holds at every width measured, which is why the structural conclusion
+survived even though the counts did not.
+
+**Fixed:** the conservation gate runs at 16 and pins the window in its assertions.
+
+---
+
+## GAP 2 — CORPUS HARVEST — **found, filed as #1037, biased against the hard cases**
+
+`mini-corpus.json`'s own pattern is `\b(?:s|sound|note|n)\(\s*"([^"\\]*)"`.
+Double quotes only. Measured over the same 150 tunes:
+
+| notation-head minis | n | mean len | max len | multiline | contains `<…>` | contains `,` |
+| --- | --- | --- | --- | --- | --- | --- |
+| double-quoted — harvested | 756 | 20 | 221 | 0% | 28% | 20% |
+| backtick — **invisible** | 50 | **212** | **1064** | **86%** | **60%** | 30% |
+
+59 notation-head strings missed for quote style alone. The missed set is not a
+smaller sample of the same thing — it is **ten times longer, 86% multi-line, and
+twice as likely to carry an alternation**. Backticks are how people write
+multi-cycle patterns, so the exclusion is concentrated exactly where the readers
+and writers are weakest, and exactly where GAP 1 just showed we were also
+under-sampling in time.
+
+Every reach percentage over this corpus is therefore optimistic by an unmeasured
+amount. Also stepped over, and a separate decision that has never been written
+down: minis passed to `mask` (124), `scale` (65), `struct` (47), `when` (38).
+
+**This refuted the prediction written before measuring**, which guessed the missed
+strings would be short control patterns like `"x*4"`. They are the opposite.
+
+---
+
+## GAP 3 — SWEEP ARMS ARE UNRUN — **partially fixed**
+
+`_`-prefixed arms sit outside CI, so every one of them can rot against the code it
+measures — the same disease as a figure in a comment, one level up. Not fixable by
+running them all: some are slow, and `_sweep-1034e` needs a scratch copy of the
+pre-change reader materialized by hand.
+
+**Fixed for the property that mattered:** conservation is now a real gate that
+runs every time (#1036), proven to fire, with a control arm. The remaining arms
+each carry the date and tree they were last run against, so a reader can tell
+whether their printed numbers are current.
+
+---
+
+## GAP 4 — #1031, THE UNGATED CENSUS ARM — **known, still open**
+
+The eval-arm census prints every figure it computes and asserts none of them; it
+had drifted 430/500 → 432/500 across two merges with nothing making anyone
+re-read it. Diagnosed, filed, unfixed. Included here for completeness — it is the
+third of this boundary's original three and the only one outstanding.
+
+---
+
+## GAP 5 — FIGURES COMMITTED AS PROSE — **found, filed as #1038**
+
+The class was named this arc when a comment claiming the leaf writer costs the
+roll one unit (73 → 72) re-measured at **ten** (75 → 65), having sat in the tree
+for eighteen sessions as apparent evidence. That one was corrected; the tree was
+never swept for others. Swept now — two remain, both in `parse.ts`, both
+justifying a live decision, both taken before two instrument changes:
+
+- `:876` — "Worth +9 writer-reach over the 1500-unit corpus (95 → 104)". The step
+  floor is now 126.
+- `:2377` — "the one the 71→44 writer-reach gap loses on".
+
+---
+
+## The through-line
+
+Four of the five gaps are the same shape: **a figure whose scope lives in prose,
+or nowhere, rather than in an assertion.** The standing rule for this boundary
+already says every gate must state its population and its comparison axes and be
+pinned to a literal that fails on movement. This audit adds a third item to that
+list — **and its WINDOW** — because a measurement over time is scoped by how far
+into the pattern it looked, and 4 cycles was hiding a real unit in a corpus we
+have swept a dozen times.

--- a/packages/app/tests/parity-corpus/SWEEP-1034.md
+++ b/packages/app/tests/parity-corpus/SWEEP-1034.md
@@ -1,10 +1,11 @@
 # SWEEP-1034 — one sound, one column, two lengths
 
 Measurement for #1034, taken before P4b consumes `Onset.durs`. **No product code
-changed.** The three sweep arms are `_sweep-1034{,b,c}.spec.ts` — `_`-prefixed
-specs sit outside the gate's include glob (`*.test.ts`), the established
-convention for a one-shot sweep. Gate re-run after: **23 files / 346 tests**,
-unmoved.
+changed by the sweep.** The arms are `_sweep-1034{,b,c,e,f}.spec.ts` — `_`-prefixed
+specs sit outside the gate's include glob (`*.test.ts`), the established convention
+for a one-shot sweep. Gate at the time of measuring: **23 files / 346 tests**,
+unmoved. The conservation property this exposed is now a real gate
+(`reader-conservation.test.ts`, #1036), taking the corpus suite to 24 / 349.
 
 ## The defect
 
@@ -19,10 +20,19 @@ A column shows a sound once — true of atoms, not of durations.
 
 ## Populations (each figure carries its own — never summed)
 
+**Every row below carries its cycle window, because the window changes the answer** —
+see the window-sensitivity section. Figures are at the CONVERGED window of 16.
+
 | population | denominator | units exhibiting the collapse |
 | --- | --- | --- |
-| **doc arm** — 150 tunes, offsets 0/250/500 | **889 musical units** (708 carry a mini, 536 grid-readable) | **2** — in 2 tunes |
-| **mini arm** — `mini-corpus.json` | 1500 distinct minis / 6107 uses / 360 tunes | **4** — 8 column×token instances over a 4-cycle window |
+| **doc arm** — 150 tunes, offsets 0/250/500 | **889 musical units** (708 carry a mini, 537 grid-readable) | **2** — in 2 tunes; unchanged from a 4-cycle window, so this figure is window-robust |
+| **mini arm** — `mini-corpus.json` | 1500 distinct minis / 6107 uses / 360 tunes | **5** duration-disagreeing / **11** with any same-token collision |
+
+⚠ **CORRECTION.** This report first published the mini-arm figures as 4 units / 8
+instances, measured over cycles 0-3 and stated without that restriction. At the
+converged window they are **5** and **11**. The doc arm's 2 is unchanged. The
+error is the same class the rest of this document is about — a figure carrying an
+unstated scope — committed while documenting it.
 
 The doc arm reproduces the tracker's **889** exactly, from the imported unit model
 (`unitsWithStatus`), which is what certifies it is the right population rather than
@@ -30,7 +40,7 @@ a lookalike. The two arms are NOT the same corpus: mini-corpus is harvested from
 360 tunes by the regex `\b(?:s|sound|note|n)\(\s*"([^"\\]*)"`, so it is both wider
 (more tunes) and narrower (that one call shape, double quotes only) than the 889.
 
-The 4 mini-arm units:
+The mini-arm units (4 of the 5 are visible within 4 cycles):
 
 ```
 "<eb@12, gb@10, bb@8> <a@6, c@4, e@2>, eb g [c a]!2 <bb>!2"   eb: [0.1667, 6.0]
@@ -49,6 +59,29 @@ mechanism I predicted and looked for: distinct `whole.begin` values landing on o
 `hh,hh oh sd` is the one that is real music rather than a bug demo — a sustained
 `hh` layered against `hh oh sd`.
 
+The fifth, reachable only past cycle 11:
+
+```
+"bd*2,[- sd]*2,[- hh]*4, <-!7 oh>, <-!12 bd*4 bd*8 bd*16!2>"   first collides at CYCLE 12
+```
+
+## Window sensitivity — the restriction that was hiding in every arm
+
+Every sweep started at a 4-cycle window, and nothing derived that 4 from anything.
+Measured across widths:
+
+| window | accepted pairs | notes kept | collision units | dropped occurrences | duration-disagreeing units |
+| --- | --- | --- | --- | --- | --- |
+| 4 | 4662 | 19375 | 10 | 44 | 4 |
+| 8 | 9328 | 38770 | 10 | 87 | 4 |
+| **16** | 18662 | 77659 | **11** | **182** | **5** |
+| 32 | 37326 | 155512 | 11 | 364 | 5 |
+
+Converges at 16. The unit that needs it is the `<-!12 …>` alternation above, whose
+colliding arm is not reached until cycle 12 — a 4-cycle instrument cannot see it
+and does not say so. 16 is now the window the conservation gate runs at, for that
+reason rather than by preference.
+
 ## Cost — the number that decides the choice
 
 **Zero writer-reach is at stake.** Measured per unit, both surfaces:
@@ -59,6 +92,7 @@ mechanism I predicted and looked for: distinct `whole.begin` values landing on o
 | `[C G], …` | not projected (`no-leaf-anchor`) | not projected (`unstable-period`) |
 | `[C3 G3], …` | not projected (`no-leaf-anchor`) | not projected (`unstable-period`) |
 | `hh,hh oh sd` | **core.ok = true** — the syntactic model handles it, so writer-reach excludes it by construction (`if (core.ok) continue`) | not projected (`wrong-surface`) |
+| `bd*2,[- sd]*2,…<-!12 …>` (the cycle-12 unit) | not projected (`unstable-period`) | not projected (`wrong-surface`) |
 
 So the collapse currently reaches no cell and no writer. Option (a) — refuse on
 disagreement — costs **0 units** on both populations. The declared stop condition
@@ -91,24 +125,29 @@ This widens the fix rather than changing it: the column should hold, per token, 
 list of OCCURRENCES `{span, dur}`, with `atoms` staying deduped for display. That is
 option (a) generalised to the axis that turns out to have had the same bug all along.
 
-## What the fix actually recovered — measured after, and it is 4× the filed defect
+## What the fix actually recovered — measured after, and it is ~4× the filed defect
 
 The guard was dropping occurrences on **two** axes, and duration was the smaller
-one. Classified per dropped occurrence (`_sweep-1034f.spec.ts`), over the same
-4662 unit×cycle pairs:
+one. Classified per dropped occurrence (`_sweep-1034f.spec.ts`), at the converged
+16-cycle window:
 
 | what the dropped occurrence carried | occurrences | distinct units |
 | --- | --- | --- |
-| a DIFFERENT length from the one kept — the filed defect | 8 | **4** |
-| a DIFFERENT anchor (leaf span) from the one kept | **32** | **9** |
-| identical on both axes — a true duplicate | 12 | — |
-| **total dropped** | **44** | **10** |
+| a DIFFERENT length from the one kept — the filed defect | 35 | **5** |
+| a DIFFERENT anchor (leaf span) from the one kept | **134** | **10** |
+| identical on both axes — a true duplicate | 48 | — |
+| **total dropped** | **182** | **11** |
 
-The duration figure of 4 units reproduces arm (a)'s independent count exactly,
-which is the cross-check that the two instruments agree.
+(Over 4 cycles the same split reads 8 / 32 / 12 = 44 across 10 units. The ratio —
+anchor roughly four times duration — is stable across every window measured, which
+is what makes the structural conclusion robust even though the counts are not.)
+
+The duration figure reproduces arm (a)'s independent count exactly at the same
+window (5 at 16 cycles, 4 at 4), which is the cross-check that the two instruments
+agree.
 
 The anchor axis is the one that would have survived a duration-shaped fix, and it
-is more than twice as large. `[b4,d4,f#4],b4@4` is the case that makes the point —
+is about four times as large — twice as many units, four times as many notes. `[b4,d4,f#4],b4@4` is the case that makes the point —
 both haps last exactly 1.0, so **no length is lost and a duration-only fix would
 never see it**, while the anchors differ (`{1,3}` vs `{12,14}`) and the column
 resolves to one of the two source leaves. The span is the write-back target, so

--- a/packages/app/tests/parity-corpus/_audit-harvest.spec.ts
+++ b/packages/app/tests/parity-corpus/_audit-harvest.spec.ts
@@ -1,0 +1,116 @@
+/**
+ * GAP 2 — what does the corpus HARVEST REGEX miss? Measurement only.
+ *
+ * `mini-corpus.json` records its own pattern:
+ *     \b(?:s|sound|note|n)\(\s*"([^"\\]*)"
+ * Three restrictions ride in it, none stated as a limitation: double quotes only,
+ * four call heads only, and no escapes. Every reach denominator we quote is over
+ * the result, so if the miss is material the denominators are understated.
+ *
+ * Coarse by construction: this scans TEXT for `head(<quoted>)`, so it will catch
+ * strings that are not mini-notation (bank names, sample paths). That is why the
+ * output is broken down BY HEAD rather than given as one total — the reader has to
+ * be able to judge which heads carry playable notation and which do not.
+ */
+import { describe, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const dir = path.join(path.dirname(fileURLToPath(import.meta.url)), '.bakery-runs')
+const RUNS = [
+  'edit-samples-2026-07-24T17-49-00-172Z.json',
+  'edit-samples-offset250-2026-07-24T17-49-04-301Z.json',
+  'edit-samples-offset500-2026-07-24T17-49-08-639Z.json',
+]
+
+/** the harvester's own pattern, verbatim from the corpus file's `pattern` field */
+const HARVEST = /\b(?:s|sound|note|n)\(\s*"([^"\\]*)"/g
+/** the same call shapes, but any quote style and ANY head */
+const ANY = /\b([A-Za-z_$][\w$]*)\(\s*(["'`])((?:(?!\2)[^\\]|\\.)*)\2/g
+
+describe('GAP 2 — harvest coverage over the 150-tune population', () => {
+  it('reports what the corpus regex captures and what it steps over', () => {
+    const docs: string[] = []
+    for (const f of RUNS) {
+      const j = JSON.parse(fs.readFileSync(path.join(dir, f), 'utf8'))
+      docs.push(...(j.samples as { code: string }[]).map((s) => s.code))
+    }
+
+    const harvested = new Set<string>()
+    const byHeadQuote = new Map<string, Set<string>>()
+    for (const code of docs) {
+      for (const m of code.matchAll(HARVEST)) harvested.add(m[1].trim())
+      for (const m of code.matchAll(ANY)) {
+        const [, head, quote, body] = m
+        const key = `${head}(${quote === '"' ? 'double' : quote === "'" ? 'single' : 'backtick'})`
+        if (!byHeadQuote.has(key)) byHeadQuote.set(key, new Set())
+        byHeadQuote.get(key)!.add(body.trim())
+      }
+    }
+
+    const NOTATION_HEADS = new Set(['s', 'sound', 'note', 'n'])
+    let missedInNotationHeads = 0
+    const missedRows: string[] = []
+    const otherHeadRows: [string, number, number][] = []
+
+    for (const [key, set] of [...byHeadQuote.entries()].sort()) {
+      const head = key.slice(0, key.indexOf('('))
+      const missed = [...set].filter((v) => !harvested.has(v))
+      if (NOTATION_HEADS.has(head)) {
+        if (!key.endsWith('(double)')) {
+          missedInNotationHeads += missed.length
+          for (const v of missed.slice(0, 4)) missedRows.push(`    ${key}  ${JSON.stringify(v)}`)
+        }
+      } else if (missed.length >= 3) {
+        otherHeadRows.push([key, set.size, missed.length])
+      }
+    }
+
+    console.log(`\n===== HARVEST COVERAGE (150 tunes) =====`)
+    console.log(`distinct strings the corpus regex captured here: ${harvested.size}`)
+    console.log(`\n-- the four NOTATION heads, by quote style --`)
+    for (const [key, set] of [...byHeadQuote.entries()].sort()) {
+      const head = key.slice(0, key.indexOf('('))
+      if (!NOTATION_HEADS.has(head)) continue
+      const missed = [...set].filter((v) => !harvested.has(v)).length
+      console.log(`  ${key.padEnd(18)} distinct=${String(set.size).padStart(4)}  not in corpus=${missed}`)
+    }
+    console.log(`\n  NOTATION-head strings missed for QUOTE STYLE alone: ${missedInNotationHeads}`)
+    console.log(missedRows.join('\n') || '    (none)')
+
+    // Is the missed set merely SMALLER, or a different KIND? Complexity proxies.
+    const prof = (which: 'double' | 'backtick') => {
+      const all: string[] = []
+      for (const [key, set] of byHeadQuote) {
+        const head = key.slice(0, key.indexOf('('))
+        if (NOTATION_HEADS.has(head) && key.endsWith(`(${which})`)) all.push(...set)
+      }
+      const pct = (f: (v: string) => boolean) =>
+        all.length ? Math.round((all.filter(f).length / all.length) * 100) : 0
+      return {
+        n: all.length,
+        meanLen: all.length ? Math.round(all.reduce((a, b) => a + b.length, 0) / all.length) : 0,
+        maxLen: all.reduce((a, b) => Math.max(a, b.length), 0),
+        multiline: pct((v) => v.includes('\n')),
+        alternation: pct((v) => v.includes('<')),
+        stack: pct((v) => v.includes(',')),
+      }
+    }
+    const d = prof('double'), b = prof('backtick')
+    console.log(`\n-- IS THE MISSED SET A DIFFERENT KIND? (notation heads only) --`)
+    console.log(`                 n   meanLen  maxLen  multiline  <alternation>  ,stack`)
+    for (const [name, x] of [['double (kept)', d], ['backtick (MISSED)', b]] as const) {
+      console.log(
+        `  ${name.padEnd(18)}${String(x.n).padStart(4)}${String(x.meanLen).padStart(9)}` +
+        `${String(x.maxLen).padStart(8)}${String(x.multiline + '%').padStart(11)}` +
+        `${String(x.alternation + '%').padStart(15)}${String(x.stack + '%').padStart(8)}`,
+      )
+    }
+
+    console.log(`\n-- OTHER heads taking a quoted first arg (>=3 not in corpus) --`)
+    for (const [key, total, missed] of otherHeadRows.sort((a, b) => b[2] - a[2]).slice(0, 20)) {
+      console.log(`  ${key.padEnd(22)} distinct=${String(total).padStart(4)}  not in corpus=${missed}`)
+    }
+  })
+})

--- a/packages/app/tests/parity-corpus/_audit-window.spec.ts
+++ b/packages/app/tests/parity-corpus/_audit-window.spec.ts
@@ -1,0 +1,66 @@
+/** GAP 1 — how much does the 4-cycle window hide? Measurement only. */
+import { describe, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { mini as reifyMini } from '@strudel/mini/mini.mjs'
+import { readGridOnsets, type Onset } from '../../../editor/src/visualEdit/notation/parse'
+
+const dir = path.dirname(fileURLToPath(import.meta.url))
+const minis: string[] = JSON.parse(fs.readFileSync(path.join(dir, 'mini-corpus.json'), 'utf8'))
+  .minis.map((o: { mini: string }) => o.mini.trim())
+  .filter((m: string) => m !== '')
+
+function scan(width: number) {
+  let accepted = 0, kept = 0
+  const collisionUnits = new Set<string>()
+  const durDisagreeUnits = new Set<string>()
+  let collisionOcc = 0
+  const firstSeenAtCycle = new Map<string, number>()
+  for (const m of minis) {
+    let pat: unknown
+    try { pat = reifyMini(m) } catch { continue }
+    for (let cyc = 0; cyc < width; cyc++) {
+      const r = readGridOnsets(pat, cyc)
+      if (!r.ok) continue
+      accepted++
+      for (const o of r.onsets as Onset[]) {
+        kept += o.occ.length
+        const byTok = new Map<string, number[]>()
+        for (const c of o.occ) byTok.set(c.token, [...(byTok.get(c.token) ?? []), c.dur ?? 0])
+        for (const [, ds] of byTok) {
+          if (ds.length < 2) continue
+          collisionOcc += ds.length - 1
+          collisionUnits.add(m)
+          if (!firstSeenAtCycle.has(m)) firstSeenAtCycle.set(m, cyc)
+          const distinct: number[] = []
+          for (const x of ds) if (!distinct.some((y) => Math.abs(y - x) < 1e-9)) distinct.push(x)
+          if (distinct.length > 1) durDisagreeUnits.add(m)
+        }
+      }
+    }
+  }
+  return { accepted, kept, collisionUnits, collisionOcc, durDisagreeUnits, firstSeenAtCycle }
+}
+
+describe('GAP 1 — cycle-window sensitivity', () => {
+  it('compares windows 4 / 8 / 16 / 32', () => {
+    const base = scan(4)
+    console.log(`\n  window | accepted | kept   | collision units | collision occ | dur-disagree units`)
+    let last = base
+    for (const w of [4, 8, 16, 32]) {
+      const r = scan(w)
+      console.log(
+        `  ${String(w).padStart(6)} | ${String(r.accepted).padStart(8)} | ${String(r.kept).padStart(6)}` +
+        ` | ${String(r.collisionUnits.size).padStart(15)} | ${String(r.collisionOcc).padStart(13)}` +
+        ` | ${String(r.durDisagreeUnits.size).padStart(18)}`,
+      )
+      last = r
+    }
+    const newUnits = [...last.collisionUnits].filter((u) => !base.collisionUnits.has(u))
+    console.log(`\n  UNITS a 4-cycle window NEVER REACHES (${newUnits.length}):`)
+    for (const u of newUnits.slice(0, 15)) {
+      console.log(`    first collides at cycle ${last.firstSeenAtCycle.get(u)}  ${JSON.stringify(u)}`)
+    }
+  })
+})

--- a/packages/app/tests/parity-corpus/_sweep-1034b.spec.ts
+++ b/packages/app/tests/parity-corpus/_sweep-1034b.spec.ts
@@ -23,6 +23,8 @@ const HITS = [
   '[C G], <D Fb B C A>*[0.5,2]',
   '[C3 G3], <D Fb B C A>*[0.5,2]',
   'hh,hh oh sd',
+  // the fifth, found only past cycle 11 once the window was widened
+  'bd*2,[- sd]*2,[- hh]*4, <-!7 oh>, <-!12 bd*4 bd*8 bd*16!2>',
 ]
 
 describe('#1034 cost arm — do the colliding units currently count as reach?', () => {

--- a/packages/app/tests/parity-corpus/_sweep-1034c.spec.ts
+++ b/packages/app/tests/parity-corpus/_sweep-1034c.spec.ts
@@ -28,7 +28,7 @@ const RUNS = [
   'edit-samples-offset500-2026-07-24T17-49-08-639Z.json',
 ]
 
-const CYCLES = [0, 1, 2, 3]
+const CYCLES = Array.from({ length: 16 }, (_, i) => i) // widened: 4 was hiding a unit that first collides at cycle 12
 
 /** identical detector to arm (a); duplicated here only because arm (a) is a spec */
 function collapses(mini: string, cyc: number): { token: string; durs: number[] }[] | null {

--- a/packages/app/tests/parity-corpus/_sweep-1034f.spec.ts
+++ b/packages/app/tests/parity-corpus/_sweep-1034f.spec.ts
@@ -17,7 +17,7 @@ describe('#1034 — what the 44 dropped occurrences were carrying', () => {
     const spanRows: string[] = []
     const durUnits = new Set<string>(), spanUnits = new Set<string>(), anyUnits = new Set<string>()
     for (const m of minis) {
-      for (const cyc of [0, 1, 2, 3]) {
+      for (let cyc = 0; cyc < 16; cyc++) {
         let pat: unknown
         try { pat = reifyMini(m) } catch { continue }
         const r = readGridOnsets(pat, cyc) as { ok: boolean; onsets?: any[] }

--- a/packages/app/tests/parity-corpus/reader-conservation.test.ts
+++ b/packages/app/tests/parity-corpus/reader-conservation.test.ts
@@ -11,8 +11,8 @@
  * test noticed. The axis-diff instruments could not find it either — they compare
  * the grid's reader against the roll's, and the field was present in both.
  *
- * What found it was COUNTING: 19375 occurrences played, 19331 kept. Conservation
- * is the property, so conservation is what gets pinned.
+ * What found it was COUNTING: over a 4-cycle window, 19375 occurrences played and
+ * 19331 kept. Conservation is the property, so conservation is what gets pinned.
  *
  * THE STATEMENT, per surface: for any unit the reader ACCEPTS, the number of
  * records it returns equals the number of haps the engine played that a reader is
@@ -28,14 +28,14 @@
  * of absence, and a detector that fires on its own control is not evidence either.
  *
  * PROVEN TO FIRE (2026-07-26). Restoring the old dedupe guard and re-running turns
- * the grid arm red at **31 violating unit×cycle pairs, 19331 kept against 19375
- * played** — the 44 dropped notes — while the roll control stays at 0. Both halves
- * matter: a detector that cannot fire is not evidence of absence, and one that also
+ * the grid arm red — at a 4-cycle window, 31 violating unit×cycle pairs and 19331
+ * kept against 19375 played, the 44 dropped notes — while the roll control stays
+ * at 0. Both halves matter: a detector that cannot fire is not evidence of absence, and one that also
  * fires on its conserving sibling is measuring its own arithmetic.
  *
  * POPULATION AND WINDOW ARE PART OF THE CLAIM, and are stated in the assertions
  * rather than in prose: the committed `mini-corpus.json` (1500 distinct minis
- * harvested from 360 real tunes), cycles 0-3. The totals are pinned to literals so
+ * harvested from 360 real tunes), cycles 0-15. The totals are pinned to literals so
  * that a corpus refresh or a window change announces itself instead of quietly
  * re-scoping the guarantee — a figure produced at this boundary has three times
  * shipped carrying an unstated restriction, and a gate that only asserts ">= 0
@@ -54,8 +54,18 @@ const corpus: { minis: { mini: string }[] } = JSON.parse(
 )
 const minis = corpus.minis.map((o) => o.mini.trim()).filter((m) => m !== '')
 
-/** the window the claim is scoped to — part of the assertion, not a detail */
-const CYCLES = [0, 1, 2, 3]
+/**
+ * The window the claim is scoped to — part of the assertion, not a detail.
+ *
+ * SIXTEEN, and the number is measured rather than chosen. At a 4-cycle window the
+ * corpus shows 10 units with a same-token column collision; at 16 it shows 11, and
+ * at 32 still 11 — so 16 is where this property converges. The unit that needs it
+ * is `bd*2,[- sd]*2,[- hh]*4, <-!7 oh>, <-!12 bd*4 bd*8 bd*16!2>`, whose alternation
+ * does not reach its colliding arm until CYCLE 12. A 4-cycle gate would have been
+ * blind to it, and blind in the exact way this file exists to prevent: silently, by
+ * never sampling deep enough rather than by asserting something false.
+ */
+const CYCLES = Array.from({ length: 16 }, (_, i) => i)
 
 /**
  * The engine's own count of what it played: haps a reader is obliged to consider.
@@ -162,7 +172,7 @@ describe('#1036 — an accepted unit keeps every note the engine played', () => 
     // These are the numbers the two arms above are a statement ABOUT. Without them
     // the gate still passes on a corpus of one mini over zero cycles.
     expect(minis.length).toBe(1500)
-    expect(CYCLES).toEqual([0, 1, 2, 3])
+    expect(CYCLES).toHaveLength(16)
     const grid = sweep(GRID)
     const roll = sweep(ROLL)
     expect(grid.accepted).toBe(GRID_ACCEPTED)
@@ -175,11 +185,14 @@ describe('#1036 — an accepted unit keeps every note the engine played', () => 
 /**
  * Observed 2026-07-26 on the committed corpus over cycles 0-3.
  *
- * `GRID_KEPT` is the figure the #1034 fix moved: the old reader kept 19331 of the
- * 19375 notes it accepted, and the 44 it dropped were 32 anchors, 8 lengths and 12
- * true duplicates. Pinned here so that number can never drift unremarked again.
+ * `GRID_KEPT` is the figure the #1034 fix moved. Over this 16-cycle window the old
+ * reader dropped 182 of the 77659 notes it accepted — 134 anchors, 35 lengths and
+ * 48 true duplicates, across 11 units. (The same measurement over 4 cycles reads
+ * 44 / 19375 across 10 units; both are correct, which is exactly why the window
+ * belongs in the assertion and not in a sentence someone can quote without.)
+ * Pinned here so the figure can never drift unremarked again.
  */
-const GRID_ACCEPTED = 4662
-const GRID_KEPT = 19375
-const ROLL_ACCEPTED = 2873
-const ROLL_KEPT = 15872
+const GRID_ACCEPTED = 18662
+const GRID_KEPT = 77659
+const ROLL_ACCEPTED = 11528
+const ROLL_KEPT = 63543

--- a/packages/app/tests/parity-corpus/reader-conservation.test.ts
+++ b/packages/app/tests/parity-corpus/reader-conservation.test.ts
@@ -1,0 +1,185 @@
+/**
+ * reader-conservation.test.ts — the readers DROP NOTHING (#1036).
+ *
+ * WHY THIS IS A SEPARATE KIND OF GATE. Every other assertion about a reader checks
+ * a VALUE: this pattern yields these atoms at these instants with these lengths.
+ * No assertion of that shape can see a reader that keeps one of two real notes,
+ * because the value it keeps is real — plausible on every input, on every axis, in
+ * every existing test. That is not hypothetical: `readGridOnsets` resolved a
+ * same-token `,`-stack to ONE of its two source leaves for the whole life of the
+ * file, through three sessions specifically spent hunting for dropped axes, and no
+ * test noticed. The axis-diff instruments could not find it either — they compare
+ * the grid's reader against the roll's, and the field was present in both.
+ *
+ * What found it was COUNTING: 19375 occurrences played, 19331 kept. Conservation
+ * is the property, so conservation is what gets pinned.
+ *
+ * THE STATEMENT, per surface: for any unit the reader ACCEPTS, the number of
+ * records it returns equals the number of haps the engine played that a reader is
+ * obliged to consider — one with an onset and a `whole`. A reader may REFUSE a
+ * unit (that is a gate verdict, measured elsewhere); what it may not do is accept
+ * a unit and silently return fewer notes than were played.
+ *
+ * THE ROLL IS THE CONTROL ARM, not a second subject. `readRollOnsets` pushes every
+ * qualifying hap unconditionally — it has no dedupe guard and cannot drop one — so
+ * its arm must read EXACTLY zero violations. If it ever reads non-zero, the fault
+ * is in this file's hap counting rather than in the reader, and the grid arm's
+ * zero would be worthless. A detector that cannot be shown to fire is not evidence
+ * of absence, and a detector that fires on its own control is not evidence either.
+ *
+ * PROVEN TO FIRE (2026-07-26). Restoring the old dedupe guard and re-running turns
+ * the grid arm red at **31 violating unit×cycle pairs, 19331 kept against 19375
+ * played** — the 44 dropped notes — while the roll control stays at 0. Both halves
+ * matter: a detector that cannot fire is not evidence of absence, and one that also
+ * fires on its conserving sibling is measuring its own arithmetic.
+ *
+ * POPULATION AND WINDOW ARE PART OF THE CLAIM, and are stated in the assertions
+ * rather than in prose: the committed `mini-corpus.json` (1500 distinct minis
+ * harvested from 360 real tunes), cycles 0-3. The totals are pinned to literals so
+ * that a corpus refresh or a window change announces itself instead of quietly
+ * re-scoping the guarantee — a figure produced at this boundary has three times
+ * shipped carrying an unstated restriction, and a gate that only asserts ">= 0
+ * violations" would be the fourth.
+ */
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { mini as reifyMini } from '@strudel/mini/mini.mjs'
+import { readGridOnsets, rollOnsets, type Onset } from '../../../editor/src/visualEdit/notation/parse'
+
+const corpusDir = path.dirname(fileURLToPath(import.meta.url))
+const corpus: { minis: { mini: string }[] } = JSON.parse(
+  fs.readFileSync(path.join(corpusDir, 'mini-corpus.json'), 'utf8'),
+)
+const minis = corpus.minis.map((o) => o.mini.trim()).filter((m) => m !== '')
+
+/** the window the claim is scoped to — part of the assertion, not a detail */
+const CYCLES = [0, 1, 2, 3]
+
+/**
+ * The engine's own count of what it played: haps a reader is obliged to consider.
+ * Both readers skip exactly `!hasOnset() || !whole` and nothing else, so this is
+ * their shared denominator — taken from the engine, never re-derived from a reader.
+ */
+function playedCount(pat: unknown, cyc: number): number | null {
+  let haps: Array<{ hasOnset?: () => boolean; whole?: unknown }>
+  try {
+    haps = (pat as { queryArc(a: number, b: number): typeof haps }).queryArc(cyc, cyc + 1)
+  } catch {
+    return null
+  }
+  return haps.filter((h) => (h.hasOnset?.() ?? false) && h.whole != null).length
+}
+
+interface Arm {
+  /** records the reader returned for an accepted unit, or null if it refused */
+  kept: (pat: unknown, cyc: number) => number | null
+}
+
+const GRID: Arm = {
+  kept: (pat, cyc) => {
+    const r = readGridOnsets(pat, cyc)
+    if (!r.ok) return null
+    return (r.onsets as Onset[]).reduce((n, o) => n + o.occ.length, 0)
+  },
+}
+
+const ROLL: Arm = {
+  kept: (pat, cyc) => {
+    const r = rollOnsets(pat, cyc)
+    return r === null ? null : r.length
+  },
+}
+
+type Result = { accepted: number; kept: number; played: number; violations: string[] }
+
+/** memoized — three tests ask the same two questions and the corpus is 1500 units */
+const cache = new Map<Arm, Result>()
+const sweep = (arm: Arm): Result => {
+  const hit = cache.get(arm)
+  if (hit) return hit
+  const r = sweepUncached(arm)
+  cache.set(arm, r)
+  return r
+}
+
+function sweepUncached(arm: Arm): Result {
+  let accepted = 0
+  let kept = 0
+  let played = 0
+  const violations: string[] = []
+  for (const mini of minis) {
+    let pat: unknown
+    try {
+      pat = reifyMini(mini)
+    } catch {
+      continue
+    }
+    for (const cyc of CYCLES) {
+      const k = arm.kept(pat, cyc)
+      if (k === null) continue // the reader REFUSED — a gate verdict, measured elsewhere
+      const p = playedCount(pat, cyc)
+      if (p === null) continue
+      accepted++
+      kept += k
+      played += p
+      if (k !== p) {
+        violations.push(`${JSON.stringify(mini)} @cyc${cyc}: played ${p}, kept ${k}`)
+      }
+    }
+  }
+  return { accepted, kept, played, violations }
+}
+
+describe('#1036 — an accepted unit keeps every note the engine played', () => {
+  it('CONTROL: the roll conserves, which is what calibrates the grid arm', () => {
+    // `readRollOnsets` pushes every qualifying hap with no guard, so a non-zero
+    // reading here indicts this file's counting, not the reader.
+    const r = sweep(ROLL)
+    console.log(
+      `\n  ROLL (control): accepted ${r.accepted} unit×cycle pairs, ` +
+        `played ${r.played}, kept ${r.kept}, violations ${r.violations.length}`,
+    )
+    if (r.violations.length) console.log(r.violations.slice(0, 10).join('\n'))
+    expect(r.violations).toEqual([])
+    expect(r.kept).toBe(r.played)
+  })
+
+  it('the grid reader drops nothing across the committed corpus', () => {
+    const r = sweep(GRID)
+    console.log(
+      `\n  GRID: accepted ${r.accepted} unit×cycle pairs, ` +
+        `played ${r.played}, kept ${r.kept}, violations ${r.violations.length}`,
+    )
+    if (r.violations.length) console.log(r.violations.slice(0, 20).join('\n'))
+    // Enumerated, not counted: a violation must name the unit that regressed.
+    expect(r.violations).toEqual([])
+    expect(r.kept).toBe(r.played)
+  })
+
+  it('pins the population and the window, so a re-scope cannot pass silently', () => {
+    // These are the numbers the two arms above are a statement ABOUT. Without them
+    // the gate still passes on a corpus of one mini over zero cycles.
+    expect(minis.length).toBe(1500)
+    expect(CYCLES).toEqual([0, 1, 2, 3])
+    const grid = sweep(GRID)
+    const roll = sweep(ROLL)
+    expect(grid.accepted).toBe(GRID_ACCEPTED)
+    expect(grid.kept).toBe(GRID_KEPT)
+    expect(roll.accepted).toBe(ROLL_ACCEPTED)
+    expect(roll.kept).toBe(ROLL_KEPT)
+  })
+})
+
+/**
+ * Observed 2026-07-26 on the committed corpus over cycles 0-3.
+ *
+ * `GRID_KEPT` is the figure the #1034 fix moved: the old reader kept 19331 of the
+ * 19375 notes it accepted, and the 44 it dropped were 32 anchors, 8 lengths and 12
+ * true duplicates. Pinned here so that number can never drift unremarked again.
+ */
+const GRID_ACCEPTED = 4662
+const GRID_KEPT = 19375
+const ROLL_ACCEPTED = 2873
+const ROLL_KEPT = 15872


### PR DESCRIPTION
Stacked on #1035 (base `fix/1034-onset-occurrences`). Closes #1036, and carries an end-to-end audit of the measurement apparatus that found a fifth unstated restriction — one I had committed myself earlier the same day.

## 1. The conservation gate (#1036)

Every other assertion about a reader checks a **value**, and no assertion of that shape can see a reader that keeps one of two real notes: the value it keeps is real, so it stays plausible on every input and every existing test still passes. That is why the anchor collapse survived three sessions of specifically hunting for dropped axes — the axis-diff instruments compare the grid's reader against the roll's, and the field was present in both.

What found it was **counting**. So counting is what gets pinned:

> for any unit a reader ACCEPTS, the number of records it returns equals the number of haps the engine played with an onset and a `whole`.

Refusing a unit stays a gate verdict measured elsewhere; accepting one and returning fewer notes than were played is now a failure, enumerated by unit rather than counted.

**The roll is the control arm, not a second subject.** It pushes every qualifying hap with no guard and cannot drop one, so a non-zero reading there indicts this file's arithmetic rather than the reader — and would make the grid's zero worthless.

**Proven to fire:** restoring the old guard turns the grid arm red (31 violating pairs, 19331 kept against 19375 played at a 4-cycle window) while the roll control stays at 0.

## 2. The audit — `MEASUREMENT-AUDIT.md`

### GAP 1 — cycle window · found, fixed, and it had corrupted my own figures

Every sweep read cycles 0-3, and nothing derived 4 from anything.

| window | accepted pairs | notes kept | collision units | dropped occurrences | duration-disagreeing units |
| --- | --- | --- | --- | --- | --- |
| 4 | 4662 | 19375 | 10 | 44 | 4 |
| 8 | 9328 | 38770 | 10 | 87 | 4 |
| **16** | 18662 | 77659 | **11** | **182** | **5** |
| 32 | 37326 | 155512 | 11 | 364 | 5 |

Converges at 16. The unit that needs it — `bd*2,[- sd]*2,[- hh]*4, <-!7 oh>, <-!12 bd*4 bd*8 bd*16!2>` — does not reach its colliding arm until **cycle 12**.

**Correction to #1035 and #1034:** the mini-corpus figures published as *4 units / 8 instances* are **5 / 11** at the converged window. The doc-population figure (2 of 889) is unchanged and therefore window-robust. The axis ratio — anchor ≈ 4× duration — holds at every width, which is why the structural conclusion survived even though the counts did not. **No product figure moves.**

The gate now runs at 16 and pins the window in its assertions.

### GAP 2 — corpus harvest bias · filed as #1037

`mini-corpus.json`'s pattern is `\b(?:s|sound|note|n)\(\s*"([^"\\]*)"` — double quotes only. The 59 notation-head strings it steps over are **not a smaller sample of the same thing**:

| notation-head minis | n | mean len | max len | multiline | contains `<…>` |
| --- | --- | --- | --- | --- | --- |
| double-quoted — harvested | 756 | 20 | 221 | 0% | 28% |
| backtick — **invisible** | 50 | **212** | **1064** | **86%** | **60%** |

Backticks are how people write multi-cycle patterns, so the corpus is biased away from exactly the material the readers are weakest on — and alternation is what drives the long periods GAP 1 just showed we were under-sampling. Every reach percentage over this corpus is optimistic by an unmeasured amount.

This **refuted the prediction written before measuring**, which guessed the missed strings would be short control patterns like `"x*4"`.

### GAP 3 — sweep arms unrun · partially fixed
### GAP 4 — #1031, the ungated census arm · known, still open
### GAP 5 — figures committed as prose · filed as #1038

Two writer-reach figures still justify live decisions from comments (`parse.ts:876` "95 → 104" against a floor now at 126; `parse.ts:2377` "71→44"), both taken before two instrument changes that move the number in opposite directions.

## Test plan

- Conservation gate green on both arms; **proven to fire** by restoring the guard; control arm stays at 0 in both states.
- Product figures unmoved, read off the report rather than inferred from `>=` floors passing: writer-reach **126 / 75**, projected **186 / 118**, losses **29 (leaf 0 / element 29)**.
- editor **3050** · app non-corpus **606** · tsc **62 / 1** · corpus **349** (the three cases this adds).
- Caught while writing up: both audit arms were created as `.test.ts` and silently joined the suite (349 → 352). Exclusion comes from the `.spec.ts` extension, not the underscore prefix — the document's own subject, one level up.


---

### ⚠ Figures re-based later in this stack

The corpus harvester was rebuilt in #1043 — it stopped approximating the transpiler with a
regex and started asking it, so `mini-corpus.json` went **1500 → 1535** units (backtick minis
in, commented-out code out). That moved every reach figure this project quotes.

**The numbers above were measured on this diff's own tree and are correct there.** Re-verified
per commit across the whole stack: each commit's own harness against its own tree, and the only
movement anywhere in the seven is at #1043. No writer changed across that move — the population
did.

Superseded at the stack tip: writer-reach **126 / 75 → 123 / 85** · losses **29 → 30**
(still leaf 0 / element 30).
