### PR TITLE
🔬 Spike: placing a hit subdivides only the element under it (#1058)

### DIFF
--- a/packages/app/tests/parity-corpus/1058-LOCALITY-SPIKE.md
+++ b/packages/app/tests/parity-corpus/1058-LOCALITY-SPIKE.md
@@ -261,6 +261,32 @@ with a control set — the cause is the accumulated `_` sustains, not the width:
 A writer emitting notation its own reader will not re-open is a round-trip hole. Filed
 separately; the mechanism is **not** diagnosed here and this doc does not guess at it.
 
+### What this spike did NOT measure — stated so no one reads it as covered
+
+- **Only `k = 2`.** #1059's presets are absolute counts (4/8/16/32/64), which are `perBar × k`
+  for larger `k`. A larger `k` produces longer runs of `_`, which is exactly what #1066's
+  refusal is sensitive to, so acceptance and re-openability at `k > 2` are **unknown**.
+- **`MAX_STEPS = 64` is bypassed here.** The refine rescales the model directly rather than
+  re-reading, so a unit at 40 columns refines to 80 and is measured — while the reader would
+  refuse to re-open it. That interaction is #1055's question and is **not** answered here.
+- **The two population restrictions cost nothing, which is checked rather than assumed.**
+  819 + 569 + 82 + 57 = 1527 exactly: zero units were dropped for a non-identity base, zero
+  for a span-walk mismatch, zero for a null refine. The span walk reproduced the original
+  mini byte-for-byte on all 819, which is what makes the element offsets sound.
+- **The hypothesis arm is judged against a rule written for the shipped op.** Its 1,293
+  "play-differs" asks are the cross-lane clamp firing as designed, not defects — the
+  pre-registered allowance only covers a same-lane clamp. So "90.5% plays" reads that arm
+  conservatively.
+
+### One note on the instrument, because it nearly produced the opposite verdict
+
+The probe's first version compared **refined** columns against **unrefined** region ranges,
+so every click was attributed to the next element along. It reported `L = 21.2%` — a clean
+INVALIDATE — and nothing in it failed. It was caught by printing the non-local samples and
+reading them: `C D`, click on element 0, reported as element `D`. The fix moved `L` from
+21.2% to 95.7% with no change to any product code. A locality measure that indexes its own
+reference frame wrongly fails in the direction that looks like a finding.
+
 ---
 
 ## VERDICT

--- a/packages/app/tests/parity-corpus/1058-LOCALITY-SPIKE.md
+++ b/packages/app/tests/parity-corpus/1058-LOCALITY-SPIKE.md
@@ -131,3 +131,158 @@ Every figure below states its population and its denominator.
 ## FINDINGS
 
 *(appended after the run — nothing above this line was written with a result in hand)*
+
+Probe: `_1058-locality.spec.ts` (a `.spec.ts`, so vitest's `include` never collects it —
+a probe, not a gate). Corpus `mini-corpus.json`, 1527 deduped minis, tree `fc73cd24`.
+
+### Population — stated, because every figure below is restricted to it
+
+| | units |
+|---|---|
+| **IN-POPULATION** (region-splice path, identity base) | **819** |
+| no grid view | 569 |
+| excluded: leaf path (own write-back) | 82 |
+| excluded: alt path (own write-back) | 57 |
+| total | 1527 |
+
+### P0 — PASSES. The issue's load-bearing claim is true.
+
+```
+"bd [~ hh] sn ~"        opens=true  steps=8   path=source  roundTrip=true
+"bd ~ sn ~"             opens=true  steps=4   path=source  roundTrip=true
+"bd [~ [hh ~]] sn ~"    opens=true  steps=8   path=leaf    roundTrip=true
+```
+
+`bd [~ hh] sn ~` already opens at 8 columns on the element-splice path and round-trips
+byte-identical, asked of the real writer. The depth-2 form also round-trips but arrives on
+the **leaf** path, which is a different write-back.
+
+### P3 — LOCALITY HOLDS, and more cleanly than the threshold required
+
+**Zero non-local writes. 0 asks, 0 distinct units, out of 15,212 asks.**
+
+`L` as pre-registered (local / accepted) is **95.7%** at full enumeration, and the entire
+4.3% shortfall is asks where locality was never *measured*, not asks that failed it:
+
+```
+accepted 6216  =  LOCAL 5946  +  CORRUPT 86 (skipped before the locality check)
+                              +  no-element-for-column 184 (factor>1: the clicked
+                                 column does not exist in that part's own space)
+```
+
+Among asks where locality is measurable it is **5946/5946 = 100%**.
+
+**Why it holds is worth recording: no new writer was needed.** `spliceGrid` already re-emits
+a changed region as `reemitRegion(cols, div)` → `reemitStep`, which spells a multi-column
+step as `[a b]`. Refining the model *and the source regions that index it* keeps the splice
+path alive, and `bd [~ hh] sn ~` falls out of machinery that has been shipped since #913.
+The only new code in this spike is a pure rescale ([[P362]]: a change of units across a set
+of fields — index and length both).
+
+### P2 — 86 corrupt asks, over 3 distinct units of 819, and **86/86 are pre-existing**
+
+The pre-registered HALT clause fired. Diagnosis, which the clause required before any
+verdict is quoted: a base arm asks the same units at the **shipped resolution with no
+subdivision anywhere**, trying every empty column of the lane. **All 86 corrupt asks belong
+to units that corrupt there too.** Subdivision-on-placement introduces zero corruption.
+
+The mechanism is a chord carrying a **duplicate member** — `[d4,f4,d4]`. The reader dedupes
+a region's content on `gridCellKey`, so the re-emit writes `[d4,f4]` and the third voice is
+gone. Filed separately; it is not this spike's to fix and not this spike's to carry.
+
+### P1 — `A = 40.9%`, and it does not measure subdivision
+
+This is the number that trips the rule, so it gets the most attribution.
+
+**98.6% of declines are ONE mechanism.**
+
+| decline cause | asks |
+|---|---|
+| **a note in ANOTHER lane sustaining through the clicked column** | **8870** |
+| column not in this part (factor>1) | 94 |
+| covered by the clicked lane's own sustain (clamp missed) | 30 |
+| multi-part | 2 |
+
+`toggleCell` clamps the lane it edits, and only that lane — "a new onset takes the room an
+earlier note was sounding through". The grid's notation constraint is per **column**: one
+token per column, `_` for a sustain, and `[_,bd]` is a chord containing a token that means
+nothing there. So a sustain in *any* lane blocks the column, the model reaching the writer
+says two things at once, and the writer rightly declines ([[PV241]] — the decline is correct).
+
+Two arms show this is not subdivision's bound:
+
+- **BASE ARM** — the shipped resolution, no refine, same 819 units: 11,633 asks,
+  **A_base = 85.0%**, and **1717 of its 1748 declines (98.2%) are the same mechanism.** The
+  gap is pre-existing. Refining merely makes it universal: preserving musical length means
+  every note doubles in columns, so every newly-created odd column sits under a sustain.
+- **ALT ARM** (hypothesis, not shipped code — clamp spans the column instead of the lane):
+  **accepted 15,056/15,212 = 99.0%**, local **14,778/15,056 = 98.2%**, and 13,763 (90.5% of
+  *all* asks) also pass the strict P2 rule. The remaining **1293 shorten a note in another
+  lane** — audible, forbidden by the P2 allowance as pre-registered, and a genuine product
+  question rather than a free win.
+
+**`A` is depth-sensitive; `L` is not** — reported at four depths, the last complete:
+
+| asks/unit cap | asks | A | L | corrupt asks / units |
+|---|---|---|---|---|
+| 2 | 1,326 | 79.1% | 98.0% | 3 / 2 |
+| 4 | 2,236 | 68.8% | 97.6% | 5 / 2 |
+| 8 | 3,775 | 62.1% | 97.0% | 9 / 2 |
+| **ALL** | **15,212** | **40.9%** | **95.7%** | 86 / 3 |
+
+### Nesting depth — the issue's worry does not occur; a different one does
+
+**Depth stays at 1 and never goes deeper.** Repeated subdivision of the same element WIDENS
+the group rather than nesting inside it:
+
+```
+bd ~ sn ~
+ -> bd [~ bd] sn ~                        depth 1,  8 cols
+ -> bd [~ bd bd _] sn ~                   depth 1, 16 cols
+ -> bd [~ bd bd _ bd _ _ _] sn ~          depth 1, 32 cols
+ -> REFUSED BY THE READER
+```
+
+So `bd [~ [hh ~]] sn ~` is not what repeated editing produces. What it produces is a group
+that **doubles in width** each time (2 → 4 → 8 tokens) — a real readability cost, and a
+different one from the one the issue predicted.
+
+**And it terminates.** After 3 gestures (4 on `bd sn`) the reader refuses the document its
+own writer just emitted: `reason = "an onset does not land on any step column"`. Isolated
+with a control set — the cause is the accumulated `_` sustains, not the width:
+
+```
+"bd [~ bd bd _ bd _ _ _] sn ~"   REFUSED
+"bd [~ bd bd ~ bd ~ ~ ~] sn ~"   opens, 32 cols   <- same onsets, rests instead of sustains
+"[~ bd bd _ bd _ _ _]"           opens,  8 cols   <- the same group, standing alone
+"bd [~ bd bd _] sn ~"            opens, 16 cols   <- one sustain fewer
+```
+
+A writer emitting notation its own reader will not re-open is a round-trip hole. Filed
+separately; the mechanism is **not** diagnosed here and this doc does not guess at it.
+
+---
+
+## VERDICT
+
+**By the letter of the rule: INVALIDATE** — `A = 40.9% < 0.50` at full enumeration.
+
+**By the evidence, the trigger is a different thing than the rule was aimed at**, and this is
+stated rather than resolved, because substituting a kinder metric after seeing the result is
+exactly what pre-registration exists to prevent:
+
+- The rule's own stated purpose is *"if placing a hit frequently needs more than the element
+  under the cursor"*. That is **P3**, and P3 passes at every depth with **zero** non-local
+  writes.
+- `A` turned out to measure the shipped placement op's per-lane clamp, not subdivision —
+  proven two ways: 85.0% acceptance with no subdivision at all and the same mechanism at
+  98.2% of its declines, and 99.0% acceptance when the clamp spans the column.
+
+**Recommendation: GO, gated on the clamp.** #1058's locality property is confirmed and needs
+no new writer. Its acceptance rate is gated by a pre-existing, separately-fixable gap in
+`toggleCell`, which now lives in `place.ts` beside where #1058's write would land. That fix
+should land before or with #1058, and it carries a product question of its own (may placing a
+hit shorten a *different* sound's note?) that #1053 is the natural home for.
+
+The call is the user's; both readings are on the table above with their numbers.
+

--- a/packages/app/tests/parity-corpus/1058-LOCALITY-SPIKE.md
+++ b/packages/app/tests/parity-corpus/1058-LOCALITY-SPIKE.md
@@ -1,0 +1,133 @@
+# #1058 — the locality spike
+
+**Pre-registered before the run.** This file's decision rule was committed before any
+measurement existed, so the result cannot be read to taste. Findings are appended below the
+rule, never folded into it.
+
+Spike for #1058 (Phase 5 of #1052, under #925). It runs **before** Phase 1 (#1054) because it
+can invalidate the rest of the sprint: if placing a hit frequently needs more than the element
+under the cursor, the headline benefit collapses from *"refining is free AND edits stay local"*
+to just *"refining does not write"* — still real, much smaller, and #1054–#1057 get re-scoped.
+
+---
+
+## What is being measured
+
+A user wants a hit at a position the grid's current resolution cannot express. Today the only
+route is a resolution change, which rewrites the whole document (`bd ~ sn ~` → 16 slots →
+`bd ~ ~ ~ ~ ~ ~ ~ sn ~ ~ ~ ~ ~ ~ ~`, the canonical defect, reproduced through the real ops in
+cont.158). #1058 proposes instead to subdivide **the element under the cursor and nothing
+else**:
+
+```
+bd ~ sn ~   + a hi-hat on the second eighth of element 1
+  ->  bd [~ hh] sn ~          one element changed
+  NOT bd ~ hh ~ sn ~ ~ ~      every element re-spelled
+```
+
+**The gesture, as measured:** refine the view ×2 (each column splits, the new odd columns are
+empty), then place a hit at one of the newly-created odd columns. The target column did not
+exist before the refine, which is precisely the case #1058 names.
+
+**Everything is asked of shipped code.** The reader is `parseStepGrid`, the placement op is
+`place.ts`'s `toggleCell` (the one definition, #1048), the writer is `serializeStepGrid`, and
+the engine is `@strudel/mini`'s `mini().queryArc` through the committed `enginePlayed` oracle.
+The only new code is a pure rescale of the model and its source regions — no re-implemented
+reader, no re-implemented writer, no hand-built expected-output table ([[PV192]]).
+
+**Population.** Every unit of the 1535-mini parity corpus that `parseStepGrid` opens onto the
+region-splice write path (`model.source` present). Units on the `altSource` / `leafSource`
+paths have their own write-backs and are reported as their own bucket, not folded into either
+side of the verdict.
+
+---
+
+## The three properties, gated SEPARATELY
+
+Property 3 is the one the sprint's case rests on, so it gets its own assertion rather than
+being folded into "the edit worked".
+
+### P0 — the precondition (the issue's own load-bearing claim)
+
+The issue asserts that `bd [~ hh] sn ~` is *not new notation*: that the current reader already
+opens it at 8 columns and it round-trips byte-identical today. Everything rests on it, so it is
+checked first and asked of the real writer rather than predicted from the model ([[PV241]]).
+
+- `parseStepGrid('bd [~ hh] sn ~')` opens, and `model.steps === 8`
+- `serializeStepGrid(model) === 'bd [~ hh] sn ~'`, byte for byte
+
+**If P0 fails the spike stops and reports** — the premise is refuted, as #1051's was.
+
+### P1 — it serializes
+
+`serializeStepGrid(toggleCell(refine(model, 2), lane, col, true))` returns a string, not `null`.
+
+A `null` is a **decline**, which is an honest answer at this boundary and not a corruption — the
+writer refuses rather than mis-spells ([[PV241]]). Declines are counted and bucketed, never
+treated as failures of correctness.
+
+### P2 — it plays
+
+`enginePlayed(edited)` against `enginePlayed(original)`, as (onset, duration, atom) rows.
+
+Required: the edited document plays **the original plus exactly one new row**, at onset
+`col / refinedSteps`, with the target lane's sound.
+
+**One pre-existing row is allowed to change, and only in one way**: a note in the *target lane*
+that was sounding through the new onset may have its duration shortened to end exactly at that
+onset. That is `toggleCell`'s clamp doing what it promises — a promise about lengths is a
+promise about room — and it is stated here *before* the run so that a correct clamp cannot be
+read as corruption.
+
+Anything else — a moved onset, a changed atom, a changed length anywhere else, a lost row — is
+**CORRUPT**.
+
+### P3 — it is LOCAL
+
+Let `[a, b)` be the source span of the top-level element containing the target column, taken
+from the region the reader built for it. Then:
+
+- `edited.slice(0, a) === original.slice(0, a)` — every byte before the element, untouched
+- the tail of `edited` of length `original.length - b` equals `original.slice(b)` — every byte
+  after the element, untouched
+
+i.e. the whole diff is confined to `[a, b)`. For a non-local result, the count of *other*
+regions whose bytes changed is reported, because "one extra region" and "the whole line" are
+different findings.
+
+### Also measured — nesting depth (the issue says explicitly: do not leave it unmeasured)
+
+Repeat the gesture on the *same* element: refine ×2, place; refine the result ×2, place; …
+Report the bracket nesting depth of the emitted element after N = 1…6 gestures, and whether
+each step stays local. `bd [~ [hh ~]] sn ~` is depth 2.
+
+This is a **decision owed by #1058** (cap the depth, or accept it and say so), not a GO/NO-GO
+input — but it must come out as a number.
+
+---
+
+## THE DECISION RULE — pre-committed
+
+Over the corpus sweep, with `A` = fraction of all asks the writer **accepted** (P1), and
+`L` = fraction of accepted-and-playing asks that are **local** (P3):
+
+| Verdict | Condition | Consequence |
+|---|---|---|
+| **GO** | `A ≥ 0.80` **and** `L ≥ 0.95` **and** corrupt = 0 | The sprint proceeds as scoped. #1054–#1057 keep their shape; #1058 ships the subdivision write. |
+| **RE-SCOPE** | corrupt = 0, and (`0.50 ≤ A < 0.80` or `0.80 ≤ L < 0.95`) | #1058 ships with a **stated bound** — the shapes it serves are named, the rest keep the resolution route. #1054–#1057 keep their shape; the sprint's headline claim is narrowed in writing. |
+| **INVALIDATE** | `A < 0.50` **or** `L < 0.80` | The benefit collapses to *"refining does not write"*. #1058 is closed or deferred and #1054–#1057 are re-scoped against the smaller claim. |
+| **HALT** | any CORRUPT ask | Stops the spike regardless of every other number. Corruption is not traded against reach; the mechanism is diagnosed before any verdict is quoted. |
+
+`P0` must pass for any of the above to be reached.
+
+**Note on what the numbers may NOT be quoted as.** `A` and `L` are properties of *this gesture*
+(refine ×2, place on a new odd column) over *this population* (corpus units on the region-splice
+path). They are not editability percentages, not writer-reach, and not comparable to the 141/85
+floors — those measure different questions over different populations ([[P343]], [[P345]]).
+Every figure below states its population and its denominator.
+
+---
+
+## FINDINGS
+
+*(appended after the run — nothing above this line was written with a result in hand)*

--- a/packages/app/tests/parity-corpus/_1058-locality.spec.ts
+++ b/packages/app/tests/parity-corpus/_1058-locality.spec.ts
@@ -1,0 +1,643 @@
+/**
+ * _1058-locality.spec.ts — THE SPIKE PROBE for #1058.
+ *
+ * A `.spec.ts`, so vitest's `include` (`*.test.ts`) never collects it: this is a
+ * probe, not a gate. Run explicitly with the spike config.
+ *
+ * The decision rule this answers was committed BEFORE this file existed —
+ * `1058-LOCALITY-SPIKE.md`, commit `6901bb8d`. Nothing here may restate it.
+ *
+ * EVERYTHING IS SHIPPED CODE. Reader `parseStepGrid`, placement op `toggleCell`
+ * (the one definition, #1048), writer `serializeStepGrid`, engine `enginePlayed`
+ * from the committed oracle. The only new code is `refine()` — a pure rescale of
+ * the model AND of the source regions that index it, which is the machinery
+ * #1058 would ship. No re-implemented reader, no re-implemented writer, no
+ * hand-built expected-output table ([[PV192]]).
+ */
+import { describe, it } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { parseStepGrid } from '../../../editor/src/visualEdit/notation/parse'
+import { serializeStepGrid } from '../../../editor/src/visualEdit/notation/serialize'
+import { toggleCell } from '../../../editor/src/visualEdit/notation/place'
+import { scaleCell, isCellOn } from '../../../editor/src/visualEdit/notation/model'
+import type {
+  GridCells,
+  StepGridModel,
+} from '../../../editor/src/visualEdit/notation/model'
+import { enginePlayedCycle, HRES, type Note } from './engineEditOracle'
+
+const dir = path.dirname(fileURLToPath(import.meta.url))
+const corpus: { minis: { mini: string }[] } = JSON.parse(
+  fs.readFileSync(path.join(dir, 'mini-corpus.json'), 'utf8'),
+)
+const MINIS = [...new Set(corpus.minis.map((o) => o.mini.trim()).filter((m) => m !== ''))]
+
+/* ── the new machinery: refine the view, and the regions that index it ── */
+
+/**
+ * Rescale a region's content by `k`. A rescale is a change of UNITS across a SET
+ * of fields ([[P362]]): the column index scales, and so does every length
+ * expressed in columns. Each own-column becomes `k` own-columns, the first
+ * carrying the notes at `k`x their length and the rest empty.
+ */
+const refineContent = (c: GridCells, k: number): GridCells =>
+  c.flatMap((col) => [
+    col.map((n) => ({ token: n.token, duration: n.duration * k })),
+    ...Array.from({ length: k - 1 }, () => [] as GridCells[number]),
+  ])
+
+/**
+ * Show the same pattern at `k`x the resolution WITHOUT rewriting it: the model
+ * widens, and the source regions widen with it so the writer's splice path stays
+ * alive. `factor` is shared-columns-per-own-column and both sides scale, so it is
+ * the one field that does NOT move.
+ */
+function refine(model: StepGridModel, k: number): StepGridModel | null {
+  const src = model.source
+  if (!src) return null
+  return {
+    ...model,
+    steps: model.steps * k,
+    lanes: model.lanes.map((l) => ({
+      ...l,
+      cells: Array.from({ length: model.steps * k }, (_, i) =>
+        i % k === 0 ? scaleCell(l.cells[i / k] ?? false, k) : false,
+      ),
+    })),
+    ...(model.gains
+      ? {
+          gains: Array.from({ length: model.steps * k }, (_, i) =>
+            i % k === 0 ? (model.gains![i / k] ?? 1) : 1,
+          ),
+        }
+      : {}),
+    source: {
+      ...src,
+      parts: src.parts.map((p) => ({
+        ...p,
+        div: p.div * k,
+        regions: p.regions.map((r) => ({
+          ...r,
+          from: r.from * k,
+          to: r.to * k,
+          content: refineContent(r.content, k),
+        })),
+      })),
+    },
+  }
+}
+
+/* ── absolute source offsets, reconstructed from the regions and CHECKED ── */
+
+interface ElemSpan {
+  part: number
+  factor: number
+  /** own-column range this element covers */
+  from: number
+  to: number
+  /** absolute byte span in the mini */
+  a: number
+  b: number
+}
+
+/**
+ * Where each element's bytes sit in the original mini.
+ *
+ * Rebuilt by walking the same pieces the writer concatenates, then CHECKED
+ * against the mini itself — if the walk reproduces the source exactly, the
+ * offsets are right by construction rather than by assertion.
+ */
+function elemSpans(model: StepGridModel, mini: string): ElemSpan[] | null {
+  const src = model.source
+  if (!src) return null
+  const out: ElemSpan[] = []
+  let at = src.prefix.length
+  let rebuilt = src.prefix
+  for (const p of src.parts) {
+    at += p.before.length
+    rebuilt += p.before
+    for (const r of p.regions) {
+      out.push({
+        part: p.part,
+        factor: p.factor,
+        from: r.from,
+        to: r.to,
+        a: at,
+        b: at + r.raw.length,
+      })
+      at += r.raw.length
+      rebuilt += r.raw
+    }
+    at += p.after.length
+    rebuilt += p.after
+  }
+  rebuilt += src.suffix
+  return rebuilt === mini ? out : null
+}
+
+/* ── the engine comparison ────────────────────────────────────────── */
+
+const key = (n: Note) =>
+  `${Math.round(n.pos * HRES)}|${Math.round(n.dur * HRES)}|${n.atom}`
+
+function multisetDiff(want: Note[], got: Note[]) {
+  const counts = new Map<string, number>()
+  for (const n of want) counts.set(key(n), (counts.get(key(n)) ?? 0) + 1)
+  const added: Note[] = []
+  for (const n of got) {
+    const k = key(n)
+    const c = counts.get(k) ?? 0
+    if (c > 0) counts.set(k, c - 1)
+    else added.push(n)
+  }
+  const removed: Note[] = []
+  for (const n of want) {
+    const k = key(n)
+    const c = counts.get(k) ?? 0
+    if (c > 0) {
+      counts.set(k, c - 1)
+      removed.push(n)
+    }
+  }
+  return { added, removed }
+}
+
+type PlayVerdict =
+  | { ok: true; clamped: boolean }
+  | { ok: false; why: string; added: Note[]; removed: Note[] }
+
+/**
+ * The edited document must play the original PLUS exactly one row, at the onset
+ * the click asked for. The single change allowed to a pre-existing row is the
+ * placement clamp — a note that was sounding through the new onset ending exactly
+ * at it — and that allowance was written down before the run.
+ */
+function playsCorrectly(
+  original: string,
+  edited: string,
+  bars: number,
+  newPos: number,
+): PlayVerdict | null {
+  let added: Note[] = []
+  let removed: Note[] = []
+  for (let b = 0; b < bars; b++) {
+    const want = enginePlayedCycle(original, b)
+    const got = enginePlayedCycle(edited, b)
+    if (want === null || got === null) return null
+    const d = multisetDiff(want, got)
+    added = added.concat(d.added)
+    removed = removed.concat(d.removed)
+  }
+  const hit = added.filter((n) => Math.abs(n.pos - Math.floor(n.pos) - newPos) < 1e-9)
+  if (hit.length !== 1) return { ok: false, why: 'no-single-new-hit-at-target', added, removed }
+  if (removed.length === 0 && added.length === 1) return { ok: true, clamped: false }
+  // the one allowance: a note of the same atom, starting earlier, shortened to
+  // end exactly at the new onset
+  if (removed.length === 1 && added.length === 2) {
+    const x = removed[0]
+    const xs = added.find((n) => n !== hit[0])
+    const localStart = x.pos - Math.floor(x.pos)
+    if (
+      xs &&
+      xs.atom === x.atom &&
+      Math.abs(xs.pos - x.pos) < 1e-9 &&
+      Math.abs(xs.dur - (newPos - localStart)) < 1e-9 &&
+      localStart < newPos &&
+      localStart + x.dur > newPos
+    )
+      return { ok: true, clamped: true }
+  }
+  return { ok: false, why: 'other-rows-moved', added, removed }
+}
+
+/**
+ * Why did the writer say no? A CLASSIFICATION of the model, not a second oracle:
+ * the writer has already given its verdict (`null`) and nothing here overrides it.
+ * This only sorts the refusals into shapes so the residual has a mechanism rather
+ * than a count.
+ */
+function declineCause(
+  refined: StepGridModel,
+  spans: ElemSpan[],
+  lane: number,
+  col: number,
+): string {
+  const bars = refined.bars ?? 1
+  const l = refined.lanes[lane]
+  const part = l.part ?? 0
+  const sp = spans.filter((s) => s.part === part)
+  const own = col / (sp[0]?.factor ?? 1)
+  const el = Number.isInteger(own) ? sp.find((s) => own >= s.from && own < s.to) : undefined
+  if (!el) return 'column-not-in-this-part (factor>1)'
+
+  // A note in ANOTHER lane sounding THROUGH the clicked column. The grid has no
+  // notation for "cp stops halfway and bd starts" as two lanes of one column —
+  // `[_,bd]` is a chord containing a token that means nothing there. `toggleCell`
+  // clamps the lane it edits, and only that lane, so the model reaching the writer
+  // says two things at once and the writer rightly declines.
+  for (const ln of refined.lanes) {
+    if ((ln.part ?? 0) !== part) continue
+    if (ln === l) continue
+    for (let i = 0; i < ln.cells.length; i++) {
+      const c = ln.cells[i]
+      if (!isCellOn(c)) continue
+      if (i < col && i + c.duration > col) return 'covered-by-ANOTHER-lane-sustain'
+    }
+  }
+  // the same thing within the clicked lane, which `clampLane` should already have
+  // resolved — here to prove it does
+  for (let i = 0; i < l.cells.length; i++) {
+    const c = l.cells[i]
+    if (!isCellOn(c)) continue
+    if (i < col && i + c.duration > col) return 'covered-by-OWN-lane-sustain (clamp missed)'
+  }
+
+  // a note whose sound reaches past the element that wrote it: its `_` would have
+  // to land in bytes this element does not own
+  let crosses = false
+  let fractional = false
+  for (const ln of refined.lanes) {
+    if ((ln.part ?? 0) !== part) continue
+    for (let i = 0; i < ln.cells.length; i++) {
+      const c = ln.cells[i]
+      if (!isCellOn(c)) continue
+      const o = i / (sp[0]?.factor ?? 1)
+      if (!Number.isInteger(o)) continue
+      const d = c.duration / (sp[0]?.factor ?? 1)
+      if (Math.abs(d - Math.round(d)) > 1e-6) fractional = true
+      const owner = sp.find((s) => o >= s.from && o < s.to)
+      if (owner && o + d > owner.to + 1e-6) {
+        crosses = true
+        if (owner === el) return 'sustain-crosses-THIS-element'
+      }
+    }
+  }
+  if (fractional) return 'fractional-length'
+  if (crosses) return 'sustain-crosses-another-element'
+  if (bars > 1) return `multi-bar (bars=${bars})`
+  if (refined.source!.parts.length > 1) return 'multi-part'
+  if (refined.gains) return 'has-gains'
+  return 'unclassified'
+}
+
+/**
+ * HYPOTHESIS ARM — not shipped code, and labelled so it can never be quoted as if
+ * it were. `toggleCell` clamps the lane it edits, and only that lane: "a new onset
+ * takes the room an earlier note was sounding through". The grid's notation
+ * constraint is per COLUMN, though — one token per column, `_` for a sustain — so a
+ * note sustaining in ANY lane blocks the column, not just one in the clicked lane.
+ *
+ * This arm asks what the acceptance rate would be if the clamp spanned the column
+ * instead of the lane. It measures the size of a possible fix; it does not make one.
+ */
+function clampAcrossLanes(model: StepGridModel, col: number, part: number): StepGridModel {
+  return {
+    ...model,
+    lanes: model.lanes.map((ln) =>
+      (ln.part ?? 0) !== part
+        ? ln
+        : {
+            ...ln,
+            cells: ln.cells.map((c, i) =>
+              isCellOn(c) && i < col && i + c.duration > col
+                ? { ...c, duration: col - i }
+                : c,
+            ),
+          },
+    ),
+  }
+}
+
+/* ── the sweep ────────────────────────────────────────────────────── */
+
+interface Tally {
+  [k: string]: number
+}
+const bump = (t: Tally, k: string, n = 1) => (t[k] = (t[k] ?? 0) + n)
+
+function sweep(asksPerUnit: number) {
+  const pop: Tally = {}
+  const ask: Tally = {}
+  const declineShapes = new Map<string, number>()
+  const corrupt: string[] = []
+  const declineSamples: string[] = []
+  const nonLocal: string[] = []
+  const corruptUnits = new Set<string>()
+  const nonLocalUnits = new Set<string>()
+
+  for (const mini of MINIS) {
+    let res
+    try {
+      res = parseStepGrid(mini)
+    } catch {
+      bump(pop, 'reader-threw')
+      continue
+    }
+    const m = res?.model
+    if (!m) {
+      bump(pop, 'no-grid-view')
+      continue
+    }
+    if (m.leafSource) {
+      bump(pop, 'excluded:leaf-path')
+      continue
+    }
+    if (m.altSource) {
+      bump(pop, 'excluded:alt-path')
+      continue
+    }
+    if (!m.source) {
+      bump(pop, 'excluded:no-source')
+      continue
+    }
+    if (serializeStepGrid(m) !== mini) {
+      bump(pop, 'excluded:no-identity-base')
+      continue
+    }
+    const refined = refine(m, 2)
+    if (!refined) {
+      bump(pop, 'excluded:refine-null')
+      continue
+    }
+    // Spans come from the REFINED model, not the parsed one. `refine` leaves every
+    // byte (`prefix`/`before`/`raw`/`after`/`suffix`) alone and scales only the
+    // column ranges, so the walk still reproduces the original mini — while the
+    // `from`/`to` it reports are in the SAME column space as the click. Taking them
+    // from the unrefined model compares a refined column against an unrefined range
+    // and mis-attributes every click to the next element along.
+    const spans = elemSpans(refined, mini)
+    if (!spans) {
+      bump(pop, 'excluded:span-walk-mismatch')
+      continue
+    }
+    bump(pop, 'IN-POPULATION')
+
+    const bars = m.bars ?? 1
+    // every newly-created column, every lane — sampled deterministically so the
+    // cap is a stated depth rather than a silent truncation
+    const cand: Array<{ lane: number; col: number }> = []
+    for (let lane = 0; lane < refined.lanes.length; lane++)
+      for (let col = 1; col < refined.steps; col += 2) cand.push({ lane, col })
+    const step = Math.max(1, Math.floor(cand.length / asksPerUnit))
+    const picked = cand.filter((_, i) => i % step === 0).slice(0, asksPerUnit)
+    if (picked.length < cand.length) bump(pop, 'units-sampled')
+
+    for (const { lane, col } of picked) {
+      bump(ask, 'asks')
+      const next = toggleCell(refined, lane, col, true)
+      const edited = serializeStepGrid(next)
+      // HYPOTHESIS ARM, measured on every ask so the two are directly comparable
+      {
+        const alt = serializeStepGrid(
+          clampAcrossLanes(toggleCell(refined, lane, col, true), col, refined.lanes[lane].part ?? 0),
+        )
+        if (alt === null) bump(ask, 'ALT:declined')
+        else {
+          bump(ask, 'ALT:accepted')
+          const ap = playsCorrectly(mini, alt, bars, (col % (refined.steps / bars)) / (refined.steps / bars))
+          if (ap === null) bump(ask, 'ALT:no-engine-probe')
+          else if (!ap.ok) bump(ask, 'ALT:play-differs')
+          else bump(ask, 'ALT:plays')
+          const l3 = refined.lanes[lane]
+          const sp3 = spans.filter((s) => s.part === (l3.part ?? 0))
+          const own3 = col / (sp3[0]?.factor ?? 1)
+          const el3 = Number.isInteger(own3)
+            ? sp3.find((s) => own3 >= s.from && own3 < s.to)
+            : undefined
+          if (el3) {
+            const t3 = mini.length - el3.b
+            if (
+              alt.slice(0, el3.a) === mini.slice(0, el3.a) &&
+              (t3 === 0 || alt.slice(alt.length - t3) === mini.slice(el3.b))
+            )
+              bump(ask, 'ALT:LOCAL')
+            else bump(ask, 'ALT:NON-LOCAL')
+          }
+        }
+      }
+
+      if (edited === null) {
+        bump(ask, 'declined')
+        const cause = declineCause(refined, spans, lane, col)
+        declineShapes.set(cause, (declineShapes.get(cause) ?? 0) + 1)
+        if (cause === 'unclassified' && declineSamples.length < 15) {
+          const l2 = refined.lanes[lane]
+          const sp2 = spans.filter((s) => s.part === (l2.part ?? 0))
+          const el2 = sp2.find((s) => col >= s.from && col < s.to)
+          declineSamples.push(
+            `${JSON.stringify(mini)}  lane ${lane} (${l2.sound}) col ${col}/${refined.steps}  element=${JSON.stringify(el2 ? mini.slice(el2.a, el2.b) : '?')} [${el2?.from},${el2?.to})  div=${refined.source!.parts[0].div}  cellsOn=${l2.cells.map((c, i) => (isCellOn(c) ? `${i}:${c.duration}` : null)).filter(Boolean).join(',')}`,
+          )
+        }
+        continue
+      }
+      bump(ask, 'accepted')
+
+      // P2 — it plays
+      const newPos = (col % (refined.steps / bars)) / (refined.steps / bars)
+      const play = playsCorrectly(mini, edited, bars, newPos)
+      if (play === null) {
+        bump(ask, 'no-engine-probe')
+      } else if (!play.ok) {
+        bump(ask, 'CORRUPT')
+        // BASE ARM: does the SAME unit corrupt under a plain toggle with no refine
+        // at all? If it does, the corruption belongs to the shipped write path and
+        // subdivision-on-placement did not introduce it ([[PK64]]).
+        // Ask the SHIPPED resolution, no refine at all: does a plain placement
+        // anywhere in this lane corrupt too? Every empty column is tried, so a
+        // "no probe" verdict means the unit offers no plain placement at all
+        // rather than that one particular column was awkward.
+        let baseVerdict = 'no-base-probe'
+        for (let bc = 0; bc < m.steps; bc++) {
+          if (isCellOn(m.lanes[lane]?.cells[bc])) continue
+          const b0 = serializeStepGrid(toggleCell(m, lane, bc, true))
+          if (b0 === null) {
+            if (baseVerdict === 'no-base-probe') baseVerdict = 'base-declines'
+            continue
+          }
+          const bp = playsCorrectly(mini, b0, bars, (bc % (m.steps / bars)) / (m.steps / bars))
+          if (bp === null) continue
+          if (!bp.ok) {
+            baseVerdict = 'base-CORRUPT'
+            break
+          }
+          baseVerdict = 'base-CLEAN'
+        }
+        bump(ask, `CORRUPT:${baseVerdict}`)
+        corruptUnits.add(mini)
+        if (corrupt.length < 12)
+          corrupt.push(
+            `--- ${play.why} / ${baseVerdict}\n    IN : ${JSON.stringify(mini)}\n    OUT: ${JSON.stringify(edited)}\n    lane ${lane} col ${col}  +${JSON.stringify(play.added)} -${JSON.stringify(play.removed)}`,
+          )
+        continue
+      } else {
+        bump(ask, 'plays')
+        if (play.clamped) bump(ask, 'plays:via-clamp')
+      }
+
+      // P3 — it is local. Denominator = accepted (and, where the engine could
+      // speak, playing) asks; reported both ways below.
+      const l = refined.lanes[lane]
+      const partIdx = l.part ?? 0
+      const sp = spans.filter((s) => s.part === partIdx)
+      const own = col / (sp[0]?.factor ?? 1)
+      const el = Number.isInteger(own) ? sp.find((s) => own >= s.from && own < s.to) : undefined
+      if (!el) {
+        bump(ask, 'no-element-for-column')
+        continue
+      }
+      const tail = mini.length - el.b
+      const prefixOk = edited.slice(0, el.a) === mini.slice(0, el.a)
+      const suffixOk = tail === 0 || edited.slice(edited.length - tail) === mini.slice(el.b)
+      if (prefixOk && suffixOk) {
+        bump(ask, 'LOCAL')
+        if (play?.ok) bump(ask, 'LOCAL:and-plays')
+      } else {
+        bump(ask, 'NON-LOCAL')
+        nonLocalUnits.add(mini)
+        if (nonLocal.length < 12)
+          nonLocal.push(
+            `${mini}  [lane ${lane} col ${col}] -> ${edited}   (element bytes [${el.a},${el.b}) = "${mini.slice(el.a, el.b)}"; prefixOk=${prefixOk} suffixOk=${suffixOk})`,
+          )
+      }
+    }
+  }
+  return { pop, ask, declineShapes, corrupt, nonLocal, declineSamples, corruptUnits, nonLocalUnits }
+}
+
+/* ── P0: the issue's own load-bearing claim ──────────────────────── */
+
+describe('#1058 spike', () => {
+  it('P0 — the precondition', () => {
+    for (const s of [
+      'bd [~ bd bd _ bd _ _ _] sn ~',
+      '[~ bd bd _ bd _ _ _]',
+      'bd [~ bd bd _ bd ~ ~ ~] sn ~',
+      'bd [~ bd bd ~ bd _ _ _] sn ~',
+      'bd [~ bd bd ~ bd ~ ~ ~] sn ~',
+      'bd [~ bd bd _] sn ~',
+      'bd [~ hh] sn ~',
+      'bd ~ sn ~',
+      'bd [~ [hh ~]] sn ~',
+      'bd sd, hh*4',
+    ]) {
+      const r = parseStepGrid(s)
+      const m = r?.model
+      const back = m ? serializeStepGrid(m) : null
+      console.log(
+        `P0  ${JSON.stringify(s).padEnd(34)} reason=${(r as {reason?: string})?.reason ?? '-'} opens=${!!m} steps=${m?.steps ?? '-'} bars=${m?.bars ?? 1} path=${m?.leafSource ? 'leaf' : m?.altSource ? 'alt' : m?.source ? 'source' : 'none'} roundTrip=${back === s} back=${JSON.stringify(back)}`,
+      )
+    }
+  })
+
+  it('the sweep', () => {
+    // Sampling DEPTH is stated, not chosen: the same sweep at four depths, the
+    // last of them the complete enumeration ([[P359]] — two shallow samples agree
+    // with each other). `A` is depth-sensitive and says so.
+    for (const cap of [2, 4, 8, Number.MAX_SAFE_INTEGER]) {
+      const { pop, ask, declineShapes, corrupt, nonLocal, declineSamples, corruptUnits, nonLocalUnits } = sweep(cap)
+      const acc = ask['accepted'] ?? 0
+      const A = (ask['asks'] ?? 0) ? acc / ask['asks'] : 0
+      const L = acc ? (ask['LOCAL'] ?? 0) / acc : 0
+      console.log(`\n===== #1058 SWEEP  (asks/unit cap = ${cap === Number.MAX_SAFE_INTEGER ? "ALL" : cap}) =====`)
+      console.log(`corpus minis (deduped): ${MINIS.length}`)
+      console.log('population:', JSON.stringify(pop, null, 0))
+      console.log('asks:', JSON.stringify(ask, null, 0))
+      console.log(`A (accepted / asks)          = ${(A * 100).toFixed(1)}%`)
+      console.log(`L (local / accepted)         = ${(L * 100).toFixed(1)}%`)
+      console.log(`CORRUPT                      = ${ask['CORRUPT'] ?? 0} asks over ${corruptUnits.size} DISTINCT units`)
+      console.log(`NON-LOCAL                    = ${ask['NON-LOCAL'] ?? 0} asks over ${nonLocalUnits.size} DISTINCT units`)
+      if (cap === Number.MAX_SAFE_INTEGER) {
+        console.log(
+          '\ndecline shapes:',
+          [...declineShapes.entries()].sort((a, b) => b[1] - a[1]).slice(0, 12),
+        )
+        if (declineSamples.length) console.log('\nUNCLASSIFIED DECLINE samples:\n  ' + declineSamples.join('\n  '))
+        if (corrupt.length) console.log('\nCORRUPT samples:\n' + corrupt.join('\n'))
+        if (nonLocal.length) console.log('\nNON-LOCAL samples:\n' + nonLocal.join('\n'))
+      }
+    }
+  })
+
+  it('BASE ARM — the shipped resolution, no refine anywhere', () => {
+    // The same population and the same op, asked WITHOUT subdivision: every empty
+    // cell of every lane, placed at the resolution the document already has. This
+    // is what attributes the acceptance rate — a decline rate that is already this
+    // high here belongs to the shipped placement path, not to subdivision.
+    const t: Tally = {}
+    for (const mini of MINIS) {
+      let m
+      try {
+        m = parseStepGrid(mini)?.model
+      } catch {
+        continue
+      }
+      if (!m || m.leafSource || m.altSource || !m.source) continue
+      if (serializeStepGrid(m) !== mini) continue
+      bump(t, 'units')
+      for (let lane = 0; lane < m.lanes.length; lane++)
+        for (let col = 0; col < m.steps; col++) {
+          if (isCellOn(m.lanes[lane].cells[col])) continue
+          bump(t, 'asks')
+          const out = serializeStepGrid(toggleCell(m, lane, col, true))
+          if (out === null) {
+            bump(t, 'declined')
+            const covered = m.lanes.some(
+              (ln, i) =>
+                i !== lane &&
+                (ln.part ?? 0) === (m!.lanes[lane].part ?? 0) &&
+                ln.cells.some((c, j) => isCellOn(c) && j < col && j + c.duration > col),
+            )
+            bump(t, covered ? 'declined:covered-by-ANOTHER-lane' : 'declined:other')
+          } else bump(t, 'accepted')
+        }
+    }
+    console.log('\n===== BASE ARM (shipped resolution, no refine) =====')
+    console.log(JSON.stringify(t))
+    console.log(
+      `A_base (accepted / asks) = ${(((t['accepted'] ?? 0) / (t['asks'] ?? 1)) * 100).toFixed(1)}%`,
+    )
+  })
+
+  it('nesting depth under repeated clicks', () => {
+    const depth = (s: string) => {
+      let d = 0
+      let max = 0
+      for (const ch of s) {
+        if (ch === '[') max = Math.max(max, ++d)
+        else if (ch === ']') d--
+      }
+      return max
+    }
+    for (const start of ['bd ~ sn ~', 'bd sn', 'bd ~ ~ ~ sn ~ ~ ~']) {
+      let cur = start
+      const line: string[] = []
+      for (let n = 1; n <= 6; n++) {
+        const m = parseStepGrid(cur)?.model
+        if (!m || !m.source) {
+          line.push(
+            `n=${n}: LEFT THE SPLICE PATH — opens=${!!m} steps=${m?.steps ?? '-'} path=${m?.leafSource ? 'leaf' : m?.altSource ? 'alt' : m ? 'model-without-source' : 'refused'}`,
+          )
+          break
+        }
+        const r = refine(m, 2)
+        if (!r) break
+        // click on the LAST new column of element 1 — the same element every time,
+        // which is the worst case the issue names
+        const perBar = r.steps / (m.bars ?? 1)
+        const col = Math.min(r.steps - 1, Math.floor(perBar / 4) | 1)
+        const next = toggleCell(r, 0, col, true)
+        const out = serializeStepGrid(next)
+        if (out === null) {
+          line.push(`n=${n}: DECLINED`)
+          break
+        }
+        line.push(`n=${n}: depth=${depth(out)} steps=${r.steps} "${out}"`)
+        cur = out
+      }
+      console.log(`\nNESTING "${start}"\n  ` + line.join('\n  '))
+    }
+  })
+})

--- a/packages/app/tests/parity-corpus/_1058-locality.spec.ts
+++ b/packages/app/tests/parity-corpus/_1058-locality.spec.ts
@@ -27,7 +27,17 @@ import type {
   GridCells,
   StepGridModel,
 } from '../../../editor/src/visualEdit/notation/model'
+import type { ParseResult } from '../../../editor/src/visualEdit/notation/model'
 import { enginePlayedCycle, HRES, type Note } from './engineEditOracle'
+
+/**
+ * `parseStepGrid` returns a discriminated union, so the model is reached through
+ * the `ok` discriminant rather than by reading `.model` off either arm — the
+ * refusal arm has no `model`, and reading it there is only invisible because
+ * JavaScript hands back `undefined`.
+ */
+const opened = (r: ParseResult<StepGridModel>): StepGridModel | null => (r.ok ? r.model : null)
+const refusalOf = (r: ParseResult<StepGridModel>): string => (r.ok ? '-' : r.reason)
 
 const dir = path.dirname(fileURLToPath(import.meta.url))
 const corpus: { minis: { mini: string }[] } = JSON.parse(
@@ -336,7 +346,7 @@ function sweep(asksPerUnit: number) {
       bump(pop, 'reader-threw')
       continue
     }
-    const m = res?.model
+    const m = opened(res)
     if (!m) {
       bump(pop, 'no-grid-view')
       continue
@@ -524,10 +534,10 @@ describe('#1058 spike', () => {
       'bd sd, hh*4',
     ]) {
       const r = parseStepGrid(s)
-      const m = r?.model
+      const m = opened(r)
       const back = m ? serializeStepGrid(m) : null
       console.log(
-        `P0  ${JSON.stringify(s).padEnd(34)} reason=${(r as {reason?: string})?.reason ?? '-'} opens=${!!m} steps=${m?.steps ?? '-'} bars=${m?.bars ?? 1} path=${m?.leafSource ? 'leaf' : m?.altSource ? 'alt' : m?.source ? 'source' : 'none'} roundTrip=${back === s} back=${JSON.stringify(back)}`,
+        `P0  ${JSON.stringify(s).padEnd(34)} reason=${refusalOf(r)} opens=${!!m} steps=${m?.steps ?? '-'} bars=${m?.bars ?? 1} path=${m?.leafSource ? 'leaf' : m?.altSource ? 'alt' : m?.source ? 'source' : 'none'} roundTrip=${back === s} back=${JSON.stringify(back)}`,
       )
     }
   })
@@ -568,26 +578,27 @@ describe('#1058 spike', () => {
     // high here belongs to the shipped placement path, not to subdivision.
     const t: Tally = {}
     for (const mini of MINIS) {
-      let m
+      let m: StepGridModel | null
       try {
-        m = parseStepGrid(mini)?.model
+        m = opened(parseStepGrid(mini))
       } catch {
         continue
       }
       if (!m || m.leafSource || m.altSource || !m.source) continue
       if (serializeStepGrid(m) !== mini) continue
+      const mm: StepGridModel = m
       bump(t, 'units')
-      for (let lane = 0; lane < m.lanes.length; lane++)
-        for (let col = 0; col < m.steps; col++) {
-          if (isCellOn(m.lanes[lane].cells[col])) continue
+      for (let lane = 0; lane < mm.lanes.length; lane++)
+        for (let col = 0; col < mm.steps; col++) {
+          if (isCellOn(mm.lanes[lane].cells[col])) continue
           bump(t, 'asks')
-          const out = serializeStepGrid(toggleCell(m, lane, col, true))
+          const out = serializeStepGrid(toggleCell(mm, lane, col, true))
           if (out === null) {
             bump(t, 'declined')
-            const covered = m.lanes.some(
+            const covered = mm.lanes.some(
               (ln, i) =>
                 i !== lane &&
-                (ln.part ?? 0) === (m!.lanes[lane].part ?? 0) &&
+                (ln.part ?? 0) === (mm.lanes[lane].part ?? 0) &&
                 ln.cells.some((c, j) => isCellOn(c) && j < col && j + c.duration > col),
             )
             bump(t, covered ? 'declined:covered-by-ANOTHER-lane' : 'declined:other')
@@ -615,7 +626,7 @@ describe('#1058 spike', () => {
       let cur = start
       const line: string[] = []
       for (let n = 1; n <= 6; n++) {
-        const m = parseStepGrid(cur)?.model
+        const m = opened(parseStepGrid(cur))
         if (!m || !m.source) {
           line.push(
             `n=${n}: LEFT THE SPLICE PATH — opens=${!!m} steps=${m?.steps ?? '-'} path=${m?.leafSource ? 'leaf' : m?.altSource ? 'alt' : m ? 'model-without-source' : 'refused'}`,


### PR DESCRIPTION
The locality spike for **#1058**, run before Phase 1 (#1054) because it could invalidate the rest of the resolution sprint (#1052). Additive only — **no product code changes**, two new files under `tests/parity-corpus/`.

## Problem

#1058's case for the sprint rests on one property: placing a hit at a position the grid cannot yet express must subdivide **the element under the cursor and nothing else**. If placement frequently needs more than that element, the benefit collapses from *"refining is free AND edits stay local"* to just *"refining does not write"* — still real, much smaller, and #1054–#1057 need re-scoping.

Asserting the property from the model would prove nothing. It had to be asked of the shipped reader, the shipped writer and the real engine, with each property gated separately — and the result had to be un-readable-to-taste.

## Fix

**The decision rule is committed first, in its own commit (`6901bb8d`), before the probe existed.** Population, gesture, the three properties, the GO / RE-SCOPE / INVALIDATE / HALT thresholds, and the one pre-existing change the play-check is allowed to see (the placement clamp shortening a note that was sounding through the new onset, so a correct clamp cannot be mistaken for corruption).

The probe uses shipped code throughout — `parseStepGrid`, `place.ts`'s `toggleCell`, `serializeStepGrid`, and the committed `engineEditOracle`. The only new code is a pure rescale of the model and the source regions that index it, which is the machinery the phase would ship. It is a `.spec.ts`, so vitest's `include` never collects it: a probe, not a gate.

## What it found

819 corpus units on the element-splice path, 15,212 placements.

- **The precondition holds** — `bd [~ hh] sn ~` opens at 8 columns and round-trips byte-identical today.
- **It is local: zero non-local writes.** And it needs no new writer — the region splice already spells a multi-column step as a group, so the subdivision falls out of machinery shipped since #913.
- **It plays** — 86 corrupt asks over 3 units, and all 86 also corrupt at the shipped resolution with no subdivision. This mechanism introduces none.
- **Acceptance is 40.9%, and it measures something else.** 98.6% of declines are one mechanism; a base arm with no subdivision reads 85.0% with that same mechanism at 98.2% of its declines, and 99.0% when the clamp spans the column instead of the lane.
- **Nesting depth stays at 1 and never deepens.** The group widens instead, and the sequence terminates when the reader refuses a document the writer just emitted.

**Verdict, both readings recorded rather than reconciled:** by the letter of the rule, INVALIDATE (acceptance < 50%). By the evidence, the trigger is a pre-existing and separately-fixable gap, while the property the rule was aimed at passes at every depth. Recommendation is GO gated on #1064; the call is the reviewer's.

Filed from the run: **#1064** (the per-lane clamp, with the product question it carries), **#1065** (a chord's duplicate member lost on edit), **#1066** (the writer emits notation its own reader refuses).

## Test plan

- `pnpm --filter @stave/app exec vitest run tests/parity-corpus` — **356 passed / 26 files**, the committed baseline, unmoved. The probe is a `.spec.ts` and is correctly not collected.
- The probe itself runs explicitly against a local config; its output is transcribed in `1058-LOCALITY-SPIKE.md` under FINDINGS.
- Attribution: every corrupt ask and the whole decline population are measured against a base arm on the same units with no subdivision, so nothing here is credited or blamed on the mechanism without that control.

Refs #1058 · #1052 · #925. Does **not** close #1058 — the phase itself is unimplemented and now gated on #1064.