### PR TITLE
🔬 The placement spike asks the op whether it applied, not the writer (#1073)

### DIFF
--- a/packages/app/tests/parity-corpus/1058-LOCALITY-SPIKE.md
+++ b/packages/app/tests/parity-corpus/1058-LOCALITY-SPIKE.md
@@ -66,6 +66,22 @@ A `null` is a **decline**, which is an honest answer at this boundary and not a 
 writer refuses rather than mis-spells ([[PV241]]). Declines are counted and bucketed, never
 treated as failures of correctness.
 
+> **How this is asked changed under the probe, 2026-07-29 (#1073).** The rule above is
+> pre-registered and unchanged; only its operationalisation moved. Since #1071 the decline
+> happens one layer earlier — `toggleCell` asks the writer itself and signals "could not
+> apply" by returning its INPUT, which serializes perfectly well. Reading acceptance off a
+> non-null serialize therefore stopped distinguishing anything: re-run unmodified, every
+> cell of the table below read `A = 100.0%`, and the refused clicks reached the playback
+> oracle as edits and failed it (9,082 corrupt asks against the 86 recorded here). The probe
+> now asks the op for its own verdict (`op(x) !== x`), and the hypothesis arm — which exists
+> to rescue exactly the placements the shipped op refuses — is built on the ungated toggle.
+>
+> **Every figure below was reproduced by that re-run**, which is why they stand rather than
+> being restated: A at all four depths (79.1 / 68.8 / 62.1 / 40.9), L (98.0 / 97.6 / 97.0 /
+> 95.7), corrupt (3/2, 5/2, 9/2, 86/3), the base arm (11,633 asks, 85.0%, 1717 of 1748
+> declines), and the ALT arm (15,056 accepted, 14,778 local, 13,763 plays, 1,293
+> play-differs). The verdict was taken on numbers that still hold.
+
 ### P2 — it plays
 
 `enginePlayed(edited)` against `enginePlayed(original)`, as (onset, duration, atom) rows.

--- a/packages/app/tests/parity-corpus/_1058-locality.spec.ts
+++ b/packages/app/tests/parity-corpus/_1058-locality.spec.ts
@@ -22,6 +22,7 @@ import { fileURLToPath } from 'node:url'
 import { parseStepGrid } from '../../../editor/src/visualEdit/notation/parse'
 import { serializeStepGrid } from '../../../editor/src/visualEdit/notation/serialize'
 import { toggleCell } from '../../../editor/src/visualEdit/notation/place'
+import { ungatedToggle } from './ungatedOps'
 import { scaleCell, isCellOn } from '../../../editor/src/visualEdit/notation/model'
 import type {
   GridCells,
@@ -397,12 +398,35 @@ function sweep(asksPerUnit: number) {
 
     for (const { lane, col } of picked) {
       bump(ask, 'asks')
+      // ASK THE OP FOR ITS OWN VERDICT, never the writer for one (#1073). Since
+      // #1071 `toggleCell` answers "could not apply" by returning its INPUT by
+      // reference — and the input is the user's current model, which serializes
+      // perfectly well. Inferring acceptance from a non-null serialize therefore
+      // counts every refusal as an acceptance, which is not a skew but the loss of
+      // the distinction: measured unmodified on this tree, every cell of this sweep
+      // read 100.0% regardless of what the code did, and the refused clicks went on
+      // to reach the playback oracle as edits and fail it — 9,082 CORRUPT asks at
+      // ALL depth against the 86 the committed artifact reports.
+      //
+      // `op(x) !== x` is the signal the `notation/` family defines and the one every
+      // `can*` is derived from, so this cannot drift away from the op again.
       const next = toggleCell(refined, lane, col, true)
-      const edited = serializeStepGrid(next)
-      // HYPOTHESIS ARM, measured on every ask so the two are directly comparable
+      const edited = next === refined ? null : serializeStepGrid(next)
+      // HYPOTHESIS ARM, measured on every ask so the two are directly comparable.
+      // It asks what a clamp ACROSS the part would have made spellable, so it is
+      // built on the UNGATED toggle rather than the shipped one: the shipped op
+      // refuses exactly the placements this arm exists to rescue, and
+      // `clampAcrossLanes` cannot decline, so composing on the gated op would clamp
+      // an UNMODIFIED model, serialize it fine and score the rescue it never
+      // performed ([[P379]] — composing a decline-capable op with one that cannot
+      // moves the verdict onto the caller).
       {
         const alt = serializeStepGrid(
-          clampAcrossLanes(toggleCell(refined, lane, col, true), col, refined.lanes[lane].part ?? 0),
+          clampAcrossLanes(
+            ungatedToggle(refined, lane, col, true),
+            col,
+            refined.lanes[lane].part ?? 0,
+          ),
         )
         if (alt === null) bump(ask, 'ALT:declined')
         else {
@@ -462,7 +486,8 @@ function sweep(asksPerUnit: number) {
         let baseVerdict = 'no-base-probe'
         for (let bc = 0; bc < m.steps; bc++) {
           if (isCellOn(m.lanes[lane]?.cells[bc])) continue
-          const b0 = serializeStepGrid(toggleCell(m, lane, bc, true))
+          const bn = toggleCell(m, lane, bc, true)
+          const b0 = bn === m ? null : serializeStepGrid(bn)
           if (b0 === null) {
             if (baseVerdict === 'no-base-probe') baseVerdict = 'base-declines'
             continue
@@ -592,7 +617,8 @@ describe('#1058 spike', () => {
         for (let col = 0; col < mm.steps; col++) {
           if (isCellOn(mm.lanes[lane].cells[col])) continue
           bump(t, 'asks')
-          const out = serializeStepGrid(toggleCell(mm, lane, col, true))
+          const nx = toggleCell(mm, lane, col, true)
+          const out = nx === mm ? null : serializeStepGrid(nx)
           if (out === null) {
             bump(t, 'declined')
             const covered = mm.lanes.some(
@@ -640,7 +666,7 @@ describe('#1058 spike', () => {
         const perBar = r.steps / (m.bars ?? 1)
         const col = Math.min(r.steps - 1, Math.floor(perBar / 4) | 1)
         const next = toggleCell(r, 0, col, true)
-        const out = serializeStepGrid(next)
+        const out = next === r ? null : serializeStepGrid(next)
         if (out === null) {
           line.push(`n=${n}: DECLINED`)
           break

--- a/packages/app/tests/parity-corpus/placement-admissibility.test.ts
+++ b/packages/app/tests/parity-corpus/placement-admissibility.test.ts
@@ -354,6 +354,41 @@ describe('#1064/#1070 — a placement is offered exactly when the writer will ta
     expect(joinedAChord, 'roll placements that joined an existing chord').toBeGreaterThan(0)
   })
 
+  /**
+   * THE CONTROL ARM'S OWN GUARD (#1073). The arms above are only a comparison if
+   * `ungatedToggle` still builds what `toggleCell` builds — it is a hand-kept copy
+   * of the production op minus its spellability wrapper, and nothing made the two
+   * move together. If the production construction changed and the copy did not,
+   * "would the writer have taken it?" would quietly start answering about a model
+   * the op never produces, and every assertion here would keep passing while
+   * measuring nothing.
+   *
+   * The invariant is exact and derivable: wherever `toggleCell` does NOT refuse,
+   * it returns precisely what the ungated copy built. So compare the two directly
+   * on every accepted placement, rather than trusting them to be edited in step.
+   * Now that a second sweep depends on the copy (#1058's hypothesis arm), the
+   * copy is load-bearing in two places and worth pinning in one.
+   */
+  it('the ungated control arm still builds what the production op builds', () => {
+    let compared = 0
+    for (const mini of minis) {
+      const r = parseStepGrid(mini)
+      if (!r.ok) continue
+      for (let lane = 0; lane < r.model.lanes.length; lane++)
+        for (let col = 0; col < r.model.steps; col++) {
+          if (isCellOn(r.model.lanes[lane].cells[col])) continue
+          const gated = toggleCell(r.model, lane, col, true)
+          if (gated === r.model) continue // refused — the wrapper's answer, not the build
+          compared++
+          expect(
+            gated,
+            `${JSON.stringify(mini)} [${lane},${col}]: the control arm has drifted from the op`,
+          ).toEqual(ungatedToggle(r.model, lane, col, true))
+        }
+    }
+    // the population must be non-empty, or the comparison above reports on nothing
+    expect(compared, 'accepted placements compared').toBeGreaterThan(1000)  })
+
   it('viewPlacesNotes answers the PATH question, and no non-leaf view lost placement', () => {
     let leafViews = 0
     let nonLeafWithAnAsk = 0

--- a/packages/app/tests/parity-corpus/placement-admissibility.test.ts
+++ b/packages/app/tests/parity-corpus/placement-admissibility.test.ts
@@ -30,17 +30,8 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { parsePianoRoll, parseStepGrid } from '../../../editor/src/visualEdit/notation/parse'
-import {
-  cellOn,
-  clampLane,
-  clampPartAtOnset,
-  isCellOn,
-} from '../../../editor/src/visualEdit/notation/model'
-import type {
-  PianoRollModel,
-  StepCell,
-  StepGridModel,
-} from '../../../editor/src/visualEdit/notation/model'
+import { isCellOn } from '../../../editor/src/visualEdit/notation/model'
+import { ungatedPlace, ungatedToggle } from './ungatedOps'
 import {
   canPlaceNote,
   canToggleCell,
@@ -61,61 +52,10 @@ type Path = 'leaf' | 'alt' | 'element'
 const pathOf = (m: { leafSource?: unknown; altSource?: unknown }): Path =>
   m.leafSource ? 'leaf' : m.altSource ? 'alt' : 'element'
 
-/**
- * THE CONTROL ARM — the same EDIT, with no admissibility question asked. Kept
- * byte-for-byte in shape with the production op minus the `ifGridSpellable`
- * wrapper, so the only variable between the arms is the gate itself.
- *
- * It tracks the edit and is independent of the GATE — that is the whole and only
- * axis it controls for. When the edit changes (phase 2 widened the clamp from the
- * lane to the `,`-part), this changes with it; if it did not, it would stop being
- * an ungated copy of the current op and become a frozen model of an older one,
- * which answers a question nobody is asking.
- */
-function ungatedToggle(
-  model: StepGridModel,
-  laneIndex: number,
-  stepIndex: number,
-  value: boolean,
-): StepGridModel {
-  const paint = (v: boolean): StepCell => (v ? cellOn() : false)
-  const painted = model.lanes.map((lane, i) =>
-    i === laneIndex
-      ? {
-          ...lane,
-          cells: clampLane(
-            lane.cells.map((c, j) => (j === stepIndex ? paint(value) : c)),
-            model.steps,
-          ),
-        }
-      : lane,
-  )
-  const lanes = value
-    ? clampPartAtOnset(painted, model.lanes[laneIndex]?.part ?? 0, stepIndex)
-    : painted
-  return { ...model, lanes }
-}
-
-function ungatedPlace(
-  model: PianoRollModel,
-  pitch: string,
-  start: number,
-  duration: number,
-): PianoRollModel {
-  const groupAt = model.notes.find((n) => n.start === start)
-  if (groupAt) {
-    return { ...model, notes: [...model.notes, { pitch, start, duration: groupAt.duration }] }
-  }
-  const nextStart = Math.min(
-    ...model.notes.filter((n) => n.start > start).map((n) => n.start),
-    model.steps,
-  )
-  const notes = model.notes.map((n) =>
-    n.start < start && n.start + n.duration > start ? { ...n, duration: start - n.start } : n,
-  )
-  notes.push({ pitch, start, duration: Math.max(1, Math.min(duration, nextStart - start)) })
-  return { ...model, notes }
-}
+// THE CONTROL ARM — the ops as they stood before #1064: build the model and hand
+// it to the writer, no admissibility question asked. Moved to `ungatedOps.ts` when
+// the #1058 probe needed the same arm (#1073); the justification for keeping a
+// second oracle at all lives with the definitions.
 
 interface Tally {
   units: number

--- a/packages/app/tests/parity-corpus/ungatedOps.ts
+++ b/packages/app/tests/parity-corpus/ungatedOps.ts
@@ -1,0 +1,90 @@
+/**
+ * ungatedOps.ts — THE PLACEMENT OPS MINUS THEIR SPELLABILITY GATE, kept in one place.
+ *
+ * ⚠ THESE TRACK THE CURRENT EDIT, THEY DO NOT FREEZE AN OLD ONE. The one axis they
+ * control for is the GATE; everything else must move with production. So when #1064
+ * phase 2 widened the grid clamp from the lane to the `,`-part, `ungatedToggle` widened
+ * with it. Left lane-scoped, it would have gone on answering "would the writer have
+ * taken it?" about a model the op no longer builds — every assertion still passing,
+ * all of them measuring nothing.
+ *
+ * Since #1071 the production ops answer "could not apply" by returning their INPUT
+ * by reference (`ifGridSpellable` / `ifRollSpellable`). That is the right shape for
+ * production and the wrong shape for two kinds of measurement:
+ *
+ *  - a CONTROL ARM that needs to ask the writer itself, so that the gate is not
+ *    comparing a derived predicate against the thing it is derived from
+ *    ([[P370]] — a gate that cannot fail);
+ *  - a HYPOTHESIS ARM that asks what a DIFFERENT rule would have made spellable.
+ *    The gate refuses exactly the placements such an arm exists to rescue, so
+ *    composing on top of the gated op measures nothing ([[P379]]).
+ *
+ * These are a deliberate second oracle used as a control, which is the one use
+ * [[PV192]] permits: they exist to be compared against, never to decide anything.
+ * Kept byte-for-byte in shape with the production ops minus the spellability
+ * wrapper, so the only variable between arms is the gate itself.
+ *
+ * THEY LIVE HERE RATHER THAN IN EACH SWEEP because a second copy is how this
+ * boundary keeps growing duplicated rules ([[PV247]]): `toggleCell` itself was
+ * defined three times before #1048. Two callers is the point at which the copy
+ * becomes a module.
+ */
+import {
+  cellOn,
+  clampLane,
+  clampPartAtOnset,
+} from '../../../editor/src/visualEdit/notation/model'
+import type {
+  PianoRollModel,
+  StepCell,
+  StepGridModel,
+} from '../../../editor/src/visualEdit/notation/model'
+
+/** `toggleCell` without `ifGridSpellable` — builds the model and never refuses. */
+export function ungatedToggle(
+  model: StepGridModel,
+  laneIndex: number,
+  stepIndex: number,
+  value: boolean,
+): StepGridModel {
+  const paint = (v: boolean): StepCell => (v ? cellOn() : false)
+  const painted = model.lanes.map((lane, i) =>
+    i === laneIndex
+      ? {
+          ...lane,
+          cells: clampLane(
+            lane.cells.map((c, j) => (j === stepIndex ? paint(value) : c)),
+            model.steps,
+          ),
+        }
+      : lane,
+  )
+  // The part-wide clamp is #1064 phase 2's edit, not its gate, so the control arm
+  // carries it too — see the warning at the top of this file.
+  const lanes = value
+    ? clampPartAtOnset(painted, model.lanes[laneIndex]?.part ?? 0, stepIndex)
+    : painted
+  return { ...model, lanes }
+}
+
+/** `placeNote` without `ifRollSpellable` — resolves overlaps and never refuses. */
+export function ungatedPlace(
+  model: PianoRollModel,
+  pitch: string,
+  start: number,
+  duration: number,
+): PianoRollModel {
+  const groupAt = model.notes.find((n) => n.start === start)
+  if (groupAt) {
+    return { ...model, notes: [...model.notes, { pitch, start, duration: groupAt.duration }] }
+  }
+  const nextStart = Math.min(
+    ...model.notes.filter((n) => n.start > start).map((n) => n.start),
+    model.steps,
+  )
+  const notes = model.notes.map((n) =>
+    n.start < start && n.start + n.duration > start ? { ...n, duration: start - n.start } : n,
+  )
+  notes.push({ pitch, start, duration: Math.max(1, Math.min(duration, nextStart - start)) })
+  return { ...model, notes }
+}


### PR DESCRIPTION
Closes #1073.

## Problem

Since the placement gate moved into `toggleCell`, a refused placement comes back as the **input model** — and the input is the user's current model, which serializes perfectly well.

`_1058-locality.spec.ts` inferred acceptance from a non-null serialize:

```js
const next = toggleCell(refined, lane, col, true)
const edited = serializeStepGrid(next)   // "accepted" when this is non-null
```

So every refusal counted as an acceptance, and the metric stopped distinguishing the two at all. Re-run unmodified on `studio_v0.2.0` it reported `A = 100.0%` in **every cell** of its table, and the refused clicks went on to reach the playback oracle as edits and fail it — **9,082** corrupt asks against the **86** the committed artifact records. Nothing failed, because the probe is a `.spec.ts` that no gate collects.

The hypothesis arm had the same hole in a worse form. It composes a cross-lane clamp on top of the toggle, and that clamp cannot decline — so it clamped an **unmodified** model, serialized it fine and scored a rescue it never performed, while the op it was built on refuses exactly the placements the arm exists to test.

## Fix

Ask the op for its own verdict — `op(x) !== x`. That is the signal the notation op family already defines and the one every `can*` predicate is derived from, so it cannot drift away from the op again. Applied at all five sites in the probe.

The hypothesis arm is rebuilt on the **ungated** toggle instead — the pre-change shape the admissibility gate already kept as its control arm. Moved into a shared `ungatedOps.ts` now that a second caller needs it, rather than copied; that extraction is a pure refactor and the admissibility gate's pinned figures are unchanged.

Two call sites in `edit-locality.test.ts` use the same inlined shape and were deliberately left alone: they assert an exact output string, so a refusal returns the input and the assertion **fails loudly** rather than passing. The defect is inferring *acceptance in a tally*, not the inlined call.

## Test plan

Verified by reproduction — every figure in the committed artifact comes back, and none of them was fed to the fix:

| | before | after | committed artifact |
|---|---|---|---|
| A @ ALL | 100.0% | **40.9%** | 40.9% |
| A_base | 100.0% | **85.0%** | 85.0% |
| corrupt @ ALL | 9,082 | **86** | 86 |

- A at all four depths: 79.1 / 68.8 / 62.1 / 40.9
- L at all four depths: 98.0 / 97.6 / 97.0 / 95.7
- corrupt asks/units: 3/2, 5/2, 9/2, 86/3
- base arm: 11,633 asks, 85.0%, 1,717 of 1,748 declines by the same mechanism
- hypothesis arm: 15,056 accepted, 14,778 local, 13,763 plays, 1,293 play-differs

The base arm's **1,748 declines of 11,633 asks** independently match the figure recorded for the element path in `place.ts`, from a different measurement. The decision the artifact was taken on still holds — which is why the artifact's numbers stand rather than being restated, and its pre-registered rule is annotated rather than rewritten.

Gates: parity-corpus **369**/28 · app **975**/73 · tsc **1** (pre-existing, in a file this PR does not touch).

Part of #925.